### PR TITLE
Optimized default wizard size

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/AbstractTemplatesSelectionPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/AbstractTemplatesSelectionPage.java
@@ -97,7 +97,7 @@ public abstract class AbstractTemplatesSelectionPage extends BaseWizardSelection
 		// it can be made bigger by the wizard
 		// See bug #83356
 		gd.widthHint = 400;
-		gd.heightHint = 500;
+		gd.heightHint = 350;
 		sashForm.setLayoutData(gd);
 
 		templateViewer = createTreeViewer(sashForm);


### PR DESCRIPTION
Optimized new project creation wizard size. More picture below:
Here on the left is a new size, and on the right is an old size.
![IEP-331](https://user-images.githubusercontent.com/24419842/104244814-7b2d6480-5463-11eb-9d0a-e54ebe0c9ea7.png)

Tested both on windows 10 and macOS 10.15.7. 