### PR TITLE
IEP 308 list installed tools show an information dialog when there is an error

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.logging.Logger;
@@ -35,12 +37,39 @@ public class ListInstalledToolsHandler extends AbstractToolsHandler
 		Logger.log("Python Path :" + pythonExecutablenPath); //$NON-NLS-1$
 		if (StringUtil.isEmpty(pythonExecutablenPath) || StringUtil.isEmpty(idfPath))
 		{
+			showMessage(Messages.ListInstalledTools_MissingIdfPathMsg);
 			throw new ExecutionException("Paths can't be empty. Please check IDF_PATH and Python"); //$NON-NLS-1$
 		}
 		activateIDFConsoleView();
 		execute();
 		
 		return null;
+	}
+
+	private void showMessage(final String message)
+	{
+		Display.getDefault().asyncExec(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				boolean isYes = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
+						Messages.ListInstalledTools_MessageTitle, message);
+				if (isYes)
+				{
+					InstallToolsHandler installToolsHandler = new InstallToolsHandler();
+					try
+					{
+						installToolsHandler.setCommandId("com.espressif.idf.ui.command.install"); //$NON-NLS-1$
+						installToolsHandler.execute(null);
+					}
+					catch (ExecutionException e)
+					{
+						Logger.log(e);
+					}
+				}
+			}
+		});
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
@@ -32,6 +32,8 @@ public class Messages extends NLS
 	public static String InstallToolsHandler_InstallingToolsMsg;
 	public static String InstallToolsHandler_ItWilltakeTimeMsg;
 	public static String InstallToolsHandler_ToolsCompleted;
+	public static String ListInstalledTools_MessageTitle;
+	public static String ListInstalledTools_MissingIdfPathMsg;
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
@@ -25,3 +25,5 @@ InstallToolsHandler_InstallingPythonMsg=Installing Python
 InstallToolsHandler_InstallingToolsMsg=Installing tools...
 InstallToolsHandler_ItWilltakeTimeMsg=This can take a while. Please be patient.
 InstallToolsHandler_ToolsCompleted=Install tools completed.
+ListInstalledTools_MessageTitle=Message
+ListInstalledTools_MissingIdfPathMsg=Some tools are not installed or IDF_PATH path is not set. To install them go to Help -> ESP-IDF tools maneger -> Install tools. Do you want to install the missing tools now?

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
@@ -26,4 +26,4 @@ InstallToolsHandler_InstallingToolsMsg=Installing tools...
 InstallToolsHandler_ItWilltakeTimeMsg=This can take a while. Please be patient.
 InstallToolsHandler_ToolsCompleted=Install tools completed.
 ListInstalledTools_MessageTitle=Message
-ListInstalledTools_MissingIdfPathMsg=Some tools are not installed or IDF_PATH path is not set. To install them go to Help -> ESP-IDF tools maneger -> Install tools. Do you want to install the missing tools now?
+ListInstalledTools_MissingIdfPathMsg=Some tools are not installed or IDF_PATH is not set. To install them go to Help -> ESP-IDF Tools Manager -> Install Tools. Do you want to install the missing tools now?


### PR DESCRIPTION
Now List Installed tools action shows information dialog to the user when it's clicked before installed the tools (when tools are not installed and IDF_PATH is not set). The information dialog looks like this:
![IEP-308](https://user-images.githubusercontent.com/24419842/104350939-0a3e8900-5505-11eb-916a-ffc4eb191040.png)
After clicking "Yes", the Install tools dialog will be open. 
Test case:
- Go to Preferences -> C/C++ -> Build -> Environment and click Restore Defaults to clean environment variables.
-  Now go to Help -> ESP-IDF Tools Manager -> List Installed Tools and in the information dialog that appears click on "Yes". 
-  After this, the Install Tools dialog will be open, where it's necessary to choose ESP-IDF, git, and python locations. 
-  After tools installation environment variables are set again, and "List Installed Tools" is providing information about installed tools. 

Tested on Windows 10 and macOS 10.15.7