### PR TITLE
IEP-317 Fixing error jdk when not releasing sdkconfig.json after switching launch target

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/SDKConfigJsonReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/SDKConfigJsonReader.java
@@ -63,16 +63,20 @@ public class SDKConfigJsonReader
 		}
 
 		JSONParser parser = new JSONParser();
+		FileReader reader = new FileReader(sdkconfigJsonPath);
 		try
 		{
-			return (JSONObject) parser.parse(new FileReader(sdkconfigJsonPath));
-
+			return (JSONObject) parser.parse(reader);
 		}
 		catch (
 				IOException
 				| ParseException e)
 		{
 			throw new Exception(e);
+		}
+		finally 
+		{
+			reader.close();
 		}
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -163,7 +163,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 				deleteDirectory(file);
 			}
 		}
-		return directoryToBeDeleted.delete();
+		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete();
 	}
 
 	private void cleanSdkConfig(IResource project) {


### PR DESCRIPTION
Now after switching the target from esp32 to esp32s2, the java process is releasing the lock on sdkconfig.json file so it can be deleted and not cause a build error. 
However, if a whole directory "build" is deleted after switching the target on Windows 10 ( I don't have the same issue on macOS),  there are other issue: "CreateProcess error=267, The directory name is invalid”, when I'm trying to build a project. 

To fix it, in deleteDirectory function was added condition statement, which leaves an empty build directory in the end. 

With both of these changes, the problem with building projects after switching targets is gone on both Windows 10 and macOS.

Test case:

- build some project on esp32 launch target, then switch target on esp32s2, click "Yes" in IDF target changed dialog. After that, click the Build button -> project is successfully built. 