### PR TITLE
IEP-349 fixing Build not configured correctly error

### DIFF
--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -26,6 +26,7 @@ Bundle-ActivationPolicy: lazy
 Export-Package: com.espressif.idf.core,
  com.espressif.idf.core.build,
  com.espressif.idf.core.logging,
+ com.espressif.idf.core.resources,
  com.espressif.idf.core.util,
  org.json.simple,
  org.json.simple.parser

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
@@ -1,0 +1,81 @@
+package com.espressif.idf.core.resources;
+
+import java.util.Iterator;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.ICBuildConfiguration;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager2;
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.build.IToolChainManager;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.osgi.service.prefs.Preferences;
+
+import com.espressif.idf.core.logging.Logger;
+
+public class ResourceChangeListener implements IResourceChangeListener 
+{
+	
+	@Override
+	public void resourceChanged(IResourceChangeEvent event)
+	{
+		if (event == null || event.getDelta() == null) {
+			return;
+		}
+		
+		try
+		{
+			event.getDelta().accept(new IResourceDeltaVisitor() {
+				@Override
+				public boolean visit(IResourceDelta delta) throws CoreException
+				{
+					recheckConfigs();
+					if (delta.getResource().getType() == IResource.PROJECT && delta.getFlags() == IResourceDelta.OPEN) 
+					{
+						IProject project = (IProject) delta.getResource();
+						if (project.isOpen()) 
+						{
+							Preferences settings = InstanceScope.INSTANCE.getNode(CCorePlugin.PLUGIN_ID).node("config")
+									.node(project.getName()).node(project.getActiveBuildConfig().getName()); //$NON-NLS-1$
+							IToolChainManager toolChainManager = CCorePlugin.getService(IToolChainManager.class);
+							IToolChain toolChain = getESPToolChain(toolChainManager);
+							settings.put(ICBuildConfiguration.TOOLCHAIN_TYPE, toolChain .getTypeId());
+							settings.put(ICBuildConfiguration.TOOLCHAIN_ID, toolChain.getId());
+							
+						}
+					}
+					return true;
+				}
+
+			});
+				
+		} catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		
+	}
+	
+	private void recheckConfigs() 
+	{
+		ICBuildConfigurationManager mgr = CCorePlugin.getService(ICBuildConfigurationManager.class);
+		ICBuildConfigurationManager2 manager = (ICBuildConfigurationManager2) mgr;
+		manager.recheckConfigs();
+	}
+	
+	private IToolChain getESPToolChain(IToolChainManager toolChainManager) throws CoreException
+	{
+		Iterator<IToolChain> iter = toolChainManager.getAllToolChains().iterator();
+		iter.next();
+		return iter.next();
+	}
+}
+
+

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -22,7 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager2;
 import org.eclipse.cdt.debug.core.CDebugCorePlugin;
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigDelegate;
@@ -170,6 +173,9 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			IProjectDescription desc = project.getDescription();
 			desc.setActiveBuildConfig(buildConfig.getBuildConfiguration().getName());
 			project.setDescription(desc, monitor);
+			ICBuildConfigurationManager mgr = CCorePlugin.getService(ICBuildConfigurationManager.class);
+			ICBuildConfigurationManager2 manager = (ICBuildConfigurationManager2) mgr;
+			manager.recheckConfigs();
 
 			((IDFBuildConfiguration) buildConfig).setLaunchTarget(target);
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -13,6 +13,8 @@ import java.text.MessageFormat;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.IToolChainManager;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.ui.IStartup;
@@ -24,6 +26,7 @@ import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.build.ESPToolChainManager;
 import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.resources.ResourceChangeListener;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.update.ExportIDFTools;
 
@@ -49,7 +52,7 @@ public class InitializeToolsStartup implements IStartup
 		Location installLocation = Platform.getInstallLocation();
 		URL url = installLocation.getURL();
 		Logger.log("Eclipse Install location::" + url);
-
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener(), IResourceChangeEvent.PRE_BUILD);
 		// Check the esp-idf.json
 		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
 		if (!idf_json_file.exists())
@@ -86,6 +89,7 @@ public class InitializeToolsStartup implements IStartup
 					configureToolChain();
 				}
 			}
+
 
 		}
 		catch (

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -13,7 +13,6 @@ import java.text.MessageFormat;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.IToolChainManager;
-import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.service.datalocation.Location;
@@ -52,7 +51,7 @@ public class InitializeToolsStartup implements IStartup
 		Location installLocation = Platform.getInstallLocation();
 		URL url = installLocation.getURL();
 		Logger.log("Eclipse Install location::" + url);
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener(), IResourceChangeEvent.PRE_BUILD);
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener());
 		// Check the esp-idf.json
 		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
 		if (!idf_json_file.exists())


### PR DESCRIPTION
These changes are fixing the "Build not configured correctly" problem after closing, renaming, and copy the project.
The user now is able to build the project after it was closed and reopened again. 

Test cases:

1. Create a new project, close and open it. Then click on the build button -> successfully built project.
2. You can close an already built project and reopen it. Then click on the build button -> since the project is already built, you will see "ninja: no work to do. Build complete " message 

  

