### PR TITLE
Added Microsoft C++ Build tools to the dependency list. (IEP-365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ To get a quick understanding about ESP-IDF and Eclipse plugin features check our
 The minimum requirements for running the IDF Eclipse plug-ins are:
 * **Java 11 and above** : Download and install Java SE from <a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">here</a>
 * **Python 3.5 and above** : Download and install Python from <a href="https://www.python.org/downloads/">here</a>
-* **Eclipse 2020-06 CDT and above** : Download and install Eclipse CDT package from <a href= "https://www.eclipse.org/downloads/packages/release/2020-06/r/eclipse-ide-cc-developers">here </a>
+* **Microsoft C++ Build Tools** : Download and install from <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">here</a>
+* **Eclipse 2020-06 CDT and above** : Download and install Eclipse CDT package from <a href= "https://www.eclipse.org/downloads/packages/release/2020-06/r/eclipse-ide-cc-developers">here</a>
 *  **Git** : Get the latest git from <a href ="https://git-scm.com/downloads">here</a>
 *  **ESP-IDF 4.0 and above** : Clone the ESP-IDF repo from <a href ="https://github.com/espressif/esp-idf/releases">here</a>
 


### PR DESCRIPTION
Simple change to the readme which adds  Microsoft's c++ build tools, required by IDF to install dependencies.