### PR TITLE
IEP-203 Can't delete a Launch Target

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -27,8 +27,6 @@ public class Messages extends NLS {
 	public static String NewSerialFlashTargetWizardPage_Name;
 	public static String NewSerialFlashTargetWizardPage_SerialPort;
 	public static String NewSerialFlashTargetWizardPage_Title;
-	public static String LaunchTargetDeleteMessage;
-	public static String LaunchTargetDeleteTitle;
 
 	static {
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -27,6 +27,9 @@ public class Messages extends NLS {
 	public static String NewSerialFlashTargetWizardPage_Name;
 	public static String NewSerialFlashTargetWizardPage_SerialPort;
 	public static String NewSerialFlashTargetWizardPage_Title;
+	public static String LaunchTargetDeleteMessage;
+	public static String LaunchTargetDeleteTitle;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -56,7 +56,6 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 	@Override
 	public void addPages() {
 		super.addPages();
-
 		page = new NewSerialFlashTargetWizardPage(getLaunchTarget());
 		addPage(page);
 	}
@@ -66,12 +65,10 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 		ILaunchTargetManager manager = Activator.getService(ILaunchTargetManager.class);
 		String typeId = IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE;
 		String id = page.getTargetName();
-
 		ILaunchTarget target = getLaunchTarget();
 		if (target == null) {
 			target = manager.addLaunchTarget(typeId, id);
 		}
-
 		ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
 		wc.setId(id);
 		wc.setAttribute(ILaunchTarget.ATTR_OS, page.getOS());
@@ -94,7 +91,6 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 				try {
 					ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 					ILaunchDescriptor activeLaunchDescriptor = launchBarManager.getActiveLaunchDescriptor();
-
 					String projectName = activeLaunchDescriptor.getName();
 					if (!StringUtil.isEmpty(projectName)) {
 
@@ -163,7 +159,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 				deleteDirectory(file);
 			}
 		}
-		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete();
+		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete(); //$NON-NLS-1$
 	}
 
 	private void cleanSdkConfig(IResource project) {
@@ -194,6 +190,26 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 			preferences.flush();
 		} catch (BackingStoreException e) {
 			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public boolean canDelete() {
+		return true;
+	}
+
+	@Override
+	public void performDelete() {
+
+		Preferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.launchbar.core"); //$NON-NLS-1$
+		try {
+			preferences.node("LaunchTargetManager") //$NON-NLS-1$
+					.node("com.espressif.idf.launch.serial.core.serialFlashTarget," + page.getTargetName()) //$NON-NLS-1$
+					.removeNode();
+			preferences.flush();
+			MessageDialog.openInformation(null, Messages.LaunchTargetDeleteTitle, Messages.LaunchTargetDeleteMessage);
+		} catch (BackingStoreException e) {
+			Logger.log(e);
 		}
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -200,16 +200,10 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 
 	@Override
 	public void performDelete() {
-
-		Preferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.launchbar.core"); //$NON-NLS-1$
-		try {
-			preferences.node("LaunchTargetManager") //$NON-NLS-1$
-					.node("com.espressif.idf.launch.serial.core.serialFlashTarget," + page.getTargetName()) //$NON-NLS-1$
-					.removeNode();
-			preferences.flush();
-			MessageDialog.openInformation(null, Messages.LaunchTargetDeleteTitle, Messages.LaunchTargetDeleteMessage);
-		} catch (BackingStoreException e) {
-			Logger.log(e);
+		ILaunchTargetManager targetMgr = Activator.getService(ILaunchTargetManager.class);
+		ILaunchTarget target = getLaunchTarget();
+		if (target != null) {
+			targetMgr.removeLaunchTarget(target);
 		}
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -16,5 +16,3 @@ NewSerialFlashTargetWizardPage_IDFTargetToolTipMsg=This will be configured as ID
 NewSerialFlashTargetWizardPage_Name=Name:
 NewSerialFlashTargetWizardPage_SerialPort=Serial Port:
 NewSerialFlashTargetWizardPage_Title=ESP Target
-LaunchTargetDeleteMessage=The launch target has been removed. To refresh the launch target bar, restart eclipse is needed
-LaunchTargetDeleteTitle=Launch Target

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -16,3 +16,5 @@ NewSerialFlashTargetWizardPage_IDFTargetToolTipMsg=This will be configured as ID
 NewSerialFlashTargetWizardPage_Name=Name:
 NewSerialFlashTargetWizardPage_SerialPort=Serial Port:
 NewSerialFlashTargetWizardPage_Title=ESP Target
+LaunchTargetDeleteMessage=The launch target has been removed. To refresh the launch target bar, restart eclipse is needed
+LaunchTargetDeleteTitle=Launch Target


### PR DESCRIPTION
Added option to delete a launch target:
![IEP-203](https://user-images.githubusercontent.com/24419842/113264100-de949900-92d2-11eb-8b8a-fdc8580744b7.png)

after deleting, a launch target is still in the launch bar until the eclipse is not restarted. To inform the user about it, the information dialog was added: 

![IEP-203 info dial](https://user-images.githubusercontent.com/24419842/113264115-e18f8980-92d2-11eb-9620-5c6b70874758.png)

I