### PR TITLE
IEP-409: Handling port closing and opening on serial flash

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.cdt.native.serial;bundle-version="1.1.0",
  org.eclipse.core.variables,
  com.espressif.idf.core,
- com.espressif.idf.ui
+ com.espressif.idf.ui,
+ com.espressif.idf.terminal.connector.serial
 Export-Package: com.espressif.idf.launch.serial,
  com.espressif.idf.launch.serial.core
 Bundle-Activator: com.espressif.idf.launch.serial.internal.Activator

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunch.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunch.java
@@ -17,7 +17,6 @@ package com.espressif.idf.launch.serial.internal;
 
 import java.io.IOException;
 
-import org.eclipse.cdt.serial.SerialPort;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugEvent;
@@ -28,10 +27,11 @@ import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.launch.TargetedLaunch;
 
 import com.espressif.idf.launch.serial.SerialFlashLaunchTargetProvider;
+import com.espressif.idf.terminal.connector.serial.connector.SerialPortHandler;
 
 public class SerialFlashLaunch extends TargetedLaunch {
 
-	private SerialPort serialPort;
+	private SerialPortHandler serialPort;
 	private boolean wasOpen;
 
 	public SerialFlashLaunch(ILaunchConfiguration launchConfiguration, String mode, ISourceLocator locator,
@@ -39,7 +39,7 @@ public class SerialFlashLaunch extends TargetedLaunch {
 		super(launchConfiguration, mode, target, locator);
 		if (target != null) {
 			String serialPortName = target.getAttribute(SerialFlashLaunchTargetProvider.ATTR_SERIAL_PORT, ""); //$NON-NLS-1$
-			serialPort = !serialPortName.isEmpty() ? SerialPort.get(serialPortName) : null;
+			serialPort = !serialPortName.isEmpty() ? SerialPortHandler.get(serialPortName) : null;
 		}
 		DebugPlugin.getDefault().addDebugEventListener(this);
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
@@ -14,10 +14,10 @@ Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",
  org.eclipse.ui;bundle-version="3.8.0",
  org.eclipse.cdt.native.serial;bundle-version="1.0.0",
  org.eclipse.debug.core,
- com.espressif.idf.launch.serial.ui,
  com.espressif.idf.core,
  com.espressif.idf.ui,
- com.espressif.idf.serial.monitor;bundle-version="1.0.0"
+ com.espressif.idf.serial.monitor,
+ org.eclipse.cdt.core.native
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
@@ -1,0 +1,189 @@
+package com.espressif.idf.terminal.connector.serial.connector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+
+import org.eclipse.tm.internal.terminal.provisional.api.TerminalState;
+
+import com.espressif.idf.serial.monitor.handlers.SerialMonitorHandler;
+import com.espressif.idf.terminal.connector.serial.activator.Activator;
+
+public class SerialPortHandler {
+
+	private final String portName;
+	private boolean isOpen;
+	private boolean isPaused;
+	private Object pauseMutex = new Object();
+
+	private static final Map<String, LinkedList<WeakReference<SerialPortHandler>>> openPorts = new HashMap<>();
+
+	private Process process;
+	private Thread thread;
+	private SerialConnector serialConnector;
+
+	private static String adjustPortName(String portName) {
+		if (System.getProperty("os.name").startsWith("Windows") && !portName.startsWith("\\\\.\\")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			return "\\\\.\\" + portName; //$NON-NLS-1$
+		} else {
+			return portName;
+		}
+	}
+
+	/**
+	 * Return an the SerialPortHandler with the given name or null if it hasn't been allocated yet. This
+	 * would be used by components that need to pause and resume a serial port.
+	 *
+	 * @param portName
+	 * @return
+	 * @since 1.1
+	 */
+	public static SerialPortHandler get(String portName) {
+		synchronized (openPorts) {
+			LinkedList<WeakReference<SerialPortHandler>> list = openPorts.get(adjustPortName(portName));
+			if (list == null) {
+				return null;
+			}
+
+			Iterator<WeakReference<SerialPortHandler>> i = list.iterator();
+			while (i.hasNext()) {
+				WeakReference<SerialPortHandler> ref = i.next();
+				SerialPortHandler port = ref.get();
+				if (port == null) {
+					i.remove();
+				} else {
+					return port;
+				}
+			}
+
+			return null;
+		}
+	}
+
+	public SerialPortHandler(String portName, SerialConnector serialConnector) {
+		this.portName = adjustPortName(portName);
+		this.serialConnector = serialConnector;
+	}
+
+	public String getPortName() {
+		return portName;
+	}
+
+	public synchronized void open() {
+
+		//set state
+		serialConnector.control.setState(TerminalState.CONNECTING);
+
+		//Hook IDF Monitor with the CDT serial monitor
+		SerialMonitorHandler serialMonitorHandler = new SerialMonitorHandler(serialConnector.project, portName,
+				serialConnector.filterOptions);
+		process = serialMonitorHandler.invokeIDFMonitor();
+
+		thread = new Thread() {
+			@Override
+			public void run() {
+				InputStream targetIn = process.getInputStream();
+				byte[] buff = new byte[256];
+				int n;
+				try {
+					while ((n = targetIn.read(buff, 0, buff.length)) >= 0) {
+						if (n != 0) {
+							serialConnector.control.getRemoteToTerminalOutputStream().write(buff, 0, n);
+						}
+					}
+					serialConnector.disconnect();
+				} catch (IOException e) {
+					Activator.log(e);
+					serialConnector.control.setState(TerminalState.CLOSED);
+				}
+			}
+		};
+
+		thread.start();
+
+		isOpen = true;
+
+		serialConnector.control.setState(TerminalState.CONNECTED);
+
+		synchronized (openPorts) {
+			LinkedList<WeakReference<SerialPortHandler>> list = openPorts.get(portName);
+			if (list == null) {
+				list = new LinkedList<>();
+				openPorts.put(portName, list);
+			}
+			list.addFirst(new WeakReference<>(this));
+		}
+	}
+
+	public synchronized void close() throws IOException {
+		if (isOpen) {
+			isOpen = false;
+
+			//kill the port process and thread
+			if (process != null) {
+				process.destroy();
+			}
+			if (thread != null) {
+				thread.interrupt();
+			}
+
+			synchronized (openPorts) {
+				LinkedList<WeakReference<SerialPortHandler>> list = openPorts.get(portName);
+				if (list != null) {
+					Iterator<WeakReference<SerialPortHandler>> i = list.iterator();
+					while (i.hasNext()) {
+						WeakReference<SerialPortHandler> ref = i.next();
+						SerialPortHandler port = ref.get();
+						if (port == null || port.equals(this)) {
+							i.remove();
+						}
+					}
+				}
+			}
+
+			try {
+				// Sleep for a second since some serial ports take a while to actually close
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				// nothing to do
+			}
+		}
+	}
+
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void pause() throws IOException {
+		if (!isOpen) {
+			return;
+		}
+		synchronized (pauseMutex) {
+			isPaused = true;
+			close();
+			try {
+				// Sleep for a second since some serial ports take a while to actually close
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				// nothing to do
+			}
+		}
+	}
+
+	public void resume() throws IOException {
+		synchronized (pauseMutex) {
+			if (!isPaused) {
+				return;
+			}
+			isPaused = false;
+			open();
+			isOpen = true;
+			pauseMutex.notifyAll();
+		}
+	}
+
+}


### PR DESCRIPTION
https://jira.espressif.com:8443/browse/IEP-409

**Test Case:**

1. Build and flash an application
2. Open ESP-IDF serial terminal
3. The serial terminal should connect to the port and show serial output
4. Flash the application again - This should disconnect the port and stop printing the serial output, and once the flashing is over it should connect back to the serial port and start printing the serial output (This was not the case earlier, where we were unable to flash it again until we close the serial monitor window)


