### PR TITLE
IEP-310 Add validation checks before allowing IDF project creation

### DIFF
--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -8,8 +8,10 @@
             name="%category.name">
       </category>
       <wizard
+            canFinishEarly="true"
             category="com.espressif.idf.ui.new.wizard.category"
-            class="com.espressif.idf.ui.wizard.NewIDFProjectWizard"
+            class="com.espressif.idf.ui.wizard.NewIdfProjectMainWizard"
+            hasPages="false"
             icon="icons/espressif_idf_project.png"
             id="com.espressif.idf.ui.new.project.wizard"
             name="%wizard.name"

--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -21,8 +21,10 @@
          </description>
       </wizard>
       <wizard
+            canFinishEarly="true"
             category="com.espressif.idf.ui.new.wizard.category"
-            class="com.espressif.idf.ui.wizard.NewComponentWizard"
+            class="com.espressif.idf.ui.wizard.NewComponentMainWizard"
+            hasPages="false"
             icon="icons/espressif_idf_project.png"
             id="com.espressif.idf.ui.component.wizard"
             name="%wizard.name.1"

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewComponentHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewComponentHandler.java
@@ -15,6 +15,10 @@ public class NewComponentHandler extends AbstractHandler
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException
 	{
+		if (!NewProjectHandlerUtil.installToolsCheck())
+		{
+			return null;
+		}
 		NewComponentWizard newComponentWizard = new NewComponentWizard();
 		newComponentWizard.init(PlatformUI.getWorkbench(), null);
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandler.java
@@ -1,17 +1,12 @@
 package com.espressif.idf.ui.handlers;
 
-import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
-import com.espressif.idf.core.IDFEnvironmentVariables;
-import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.wizard.NewIDFProjectWizard;
 
 /**
@@ -20,34 +15,21 @@ import com.espressif.idf.ui.wizard.NewIDFProjectWizard;
  */
 public class NewProjectHandler extends AbstractHandler
 {
-
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException
 	{
-		// IDF_PATH
-		String idfPath = IDFUtil.getIDFPath();
-
-		// PATH
-		IEnvironmentVariable pathEnv = new IDFEnvironmentVariables().getEnv(IDFEnvironmentVariables.PATH);
-		String path = pathEnv.getValue();
-
-		if (StringUtil.isEmpty(idfPath) || StringUtil.isEmpty(path))
+		if (!NewProjectHandlerUtil.installToolsCheck())
 		{
-
-			MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.NewProjectHandler_PathErrorTitle,
-					Messages.NewProjectHandler_CouldntFindPaths + Messages.NewProjectHandler_NavigateToHelpMenu
-							+ Messages.NewProjectHandler_MandatoryMsg);
 			return null;
 		}
-
 		NewIDFProjectWizard newIDFProjectWizard = new NewIDFProjectWizard();
 		newIDFProjectWizard.init(PlatformUI.getWorkbench(), null);
 
 		WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), newIDFProjectWizard);
+
 		dialog.create();
 		dialog.open();
 
 		return null;
 	}
-
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
@@ -1,0 +1,70 @@
+package com.espressif.idf.ui.handlers;
+
+import java.util.Optional;
+
+import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.osgi.service.prefs.Preferences;
+
+import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.ui.UIPlugin;
+import com.espressif.idf.ui.update.InstallToolsHandler;
+
+public class NewProjectHandlerUtil
+{
+	private static final String INSTALL_TOOLS_FLAG = "INSTALL_TOOLS_FLAG"; //$NON-NLS-1$
+
+	public static boolean installToolsCheck()
+	{
+		// IDF_PATH
+		String idfPath = IDFUtil.getIDFPath();
+
+		// PATH
+		IEnvironmentVariable pathEnv = new IDFEnvironmentVariables().getEnv(IDFEnvironmentVariables.PATH);
+		String path = Optional.ofNullable(pathEnv).map(o -> o.getValue()).orElse(null);
+
+		Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
+		boolean isToolsInstalled = scopedPreferenceStore.getBoolean(INSTALL_TOOLS_FLAG, false);
+
+		if (StringUtil.isEmpty(idfPath) || StringUtil.isEmpty(path) || !isToolsInstalled)
+		{
+			showMessage();
+			return false;
+		}
+		return true;
+	}
+
+	private static void showMessage()
+	{
+		Display.getDefault().asyncExec(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				boolean isYes = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
+						Messages.NewProjectHandler_PathErrorTitle,
+						Messages.NewProjectHandler_CouldntFindPaths + Messages.NewProjectHandler_NavigateToHelpMenu
+								+ Messages.NewProjectHandler_MandatoryMsg);
+				if (isYes)
+				{
+					InstallToolsHandler installToolsHandler = new InstallToolsHandler();
+					try
+					{
+						installToolsHandler.setCommandId("com.espressif.idf.ui.command.install"); //$NON-NLS-1$
+						installToolsHandler.execute(null);
+					}
+					catch (ExecutionException e)
+					{
+						Logger.log(e);
+					}
+				}
+			}
+		});
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
@@ -1,3 +1,8 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+
 package com.espressif.idf.ui.handlers;
 
 import java.util.Optional;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
@@ -1,4 +1,4 @@
 NewProjectHandler_CouldntFindPaths=Couldn't find either IDF_PATH or PATH in the CDT build environment variables. \n \n
-NewProjectHandler_MandatoryMsg=This is a mandatory step even if you've already installed the tools from the command line.
+NewProjectHandler_MandatoryMsg=This is a mandatory step even if you've already installed the tools from the command line. Do you want to install the missing tools now?
 NewProjectHandler_NavigateToHelpMenu=Please navigate to menu `Help > ESP-IDF Tools Manager > Install Tools` to install and configure the required paths for creating and building the ESP-IDF projects. \n \n
 NewProjectHandler_PathErrorTitle=Path Error

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -4,37 +4,25 @@
  *******************************************************************************/
 package com.espressif.idf.ui.update;
 
-import java.io.File;
-import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.IToolChainManager;
-import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.osgi.util.NLS;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFConstants;
-import com.espressif.idf.core.IDFCorePlugin;
-import com.espressif.idf.core.IDFEnvironmentVariables;
-import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.build.ESPToolChainManager;
 import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.ui.UIPlugin;
 
 /**
  * IDF Tools install command handler
@@ -47,6 +35,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 
 	private IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
 	private ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
+	private static final String INSTALL_TOOLS_FLAG = "INSTALL_TOOLS_FLAG"; //$NON-NLS-1$
 
 	@Override
 	protected void execute()
@@ -81,6 +70,16 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			}
 
 		};
+		Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
+		scopedPreferenceStore.putBoolean(INSTALL_TOOLS_FLAG, true);
+		try
+		{
+			scopedPreferenceStore.flush();
+		}
+		catch (BackingStoreException e)
+		{
+			Logger.log(e);
+		}
 		installToolsJob.schedule();
 
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentMainWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentMainWizard.java
@@ -3,6 +3,7 @@
  * Use is subject to license terms.
  *******************************************************************************/
 
+
 package com.espressif.idf.ui.wizard;
 
 import org.eclipse.core.commands.ExecutionException;
@@ -13,13 +14,13 @@ import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.ui.handlers.NewProjectHandler;
+import com.espressif.idf.ui.handlers.NewComponentHandler;
 import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
 
-public class NewIdfProjectMainWizard extends Wizard implements INewWizard
+public class NewComponentMainWizard extends Wizard implements INewWizard
 {
 
-	public NewIdfProjectMainWizard()
+	public NewComponentMainWizard()
 	{
 		if (NewProjectHandlerUtil.installToolsCheck())
 		{
@@ -28,7 +29,7 @@ public class NewIdfProjectMainWizard extends Wizard implements INewWizard
 				@Override
 				public void run()
 				{
-					NewProjectHandler handler = new NewProjectHandler();
+					NewComponentHandler handler = new NewComponentHandler();
 					try
 					{
 						handler.execute(null);
@@ -43,14 +44,14 @@ public class NewIdfProjectMainWizard extends Wizard implements INewWizard
 	}
 
 	@Override
-	public boolean performFinish()
+	public void init(IWorkbench workbench, IStructuredSelection selection)
 	{
-		return true;
 	}
 
 	@Override
-	public void init(IWorkbench workbench, IStructuredSelection selection)
+	public boolean performFinish()
 	{
+		return true;
 	}
 
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -20,6 +20,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.ui.handlers.EclipseHandler;
+import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
 import com.espressif.idf.ui.templates.IDFProjectGenerator;
 import com.espressif.idf.ui.templates.ITemplateNode;
 import com.espressif.idf.ui.templates.TemplateListSelectionPage;
@@ -51,6 +52,10 @@ public class NewIDFProjectWizard extends TemplateWizard
 	@Override
 	public void addPages()
 	{
+		if (!NewProjectHandlerUtil.installToolsCheck())
+		{
+			return;
+		}
 		super.addPages();
 
 		mainPage = new WizardNewProjectCreationPage("basicNewProjectPage") //$NON-NLS-1$
@@ -65,15 +70,14 @@ public class NewIDFProjectWizard extends TemplateWizard
 		mainPage.setTitle(Messages.NewIDFProjectWizard_Project_Title);
 		mainPage.setDescription(Messages.NewIDFProjectWizard_ProjectDesc);
 		this.setWindowTitle(Messages.NewIDFProjectWizard_NewIDFProject);
-		
+
 		TemplatesManager templatesManager = new TemplatesManager();
 		ITemplateNode templateRoot = templatesManager.getTemplates();
 
 		boolean hasTemplates = templateRoot.getChildren().isEmpty();
 		if (!hasTemplates)
 		{
-			templatesPage = new TemplateListSelectionPage(templateRoot,
-					Messages.NewIDFProjectWizard_TemplatesHeader);
+			templatesPage = new TemplateListSelectionPage(templateRoot, Messages.NewIDFProjectWizard_TemplatesHeader);
 			ITemplateNode templateNode = templatesManager.getTemplateNode(IDFConstants.DEFAULT_TEMPLATE_ID);
 			if (templateNode != null)
 			{
@@ -88,8 +92,9 @@ public class NewIDFProjectWizard extends TemplateWizard
 		{
 			this.addPage(templatesPage);
 		}
+
 	}
-	
+
 	@Override
 	public boolean performFinish()
 	{
@@ -129,7 +134,5 @@ public class NewIDFProjectWizard extends TemplateWizard
 		}
 		return generator;
 	}
-	
-	
 
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIdfProjectMainWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIdfProjectMainWizard.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+
+package com.espressif.idf.ui.wizard;
+
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.INewWizard;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
+
+import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
+
+public class NewIdfProjectMainWizard extends Wizard implements INewWizard
+{
+
+	public NewIdfProjectMainWizard()
+	{
+		if (NewProjectHandlerUtil.installToolsCheck())
+		{
+			NewIDFProjectWizard newIDFProjectWizard = new NewIDFProjectWizard();
+			newIDFProjectWizard.init(PlatformUI.getWorkbench(), null);
+
+			WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), newIDFProjectWizard);
+
+			dialog.create();
+			dialog.open();
+		}
+	}
+
+	@Override
+	public boolean performFinish()
+	{
+		return false;
+	}
+
+	@Override
+	public void init(IWorkbench workbench, IStructuredSelection selection)
+	{
+	}
+
+}


### PR DESCRIPTION
Added validation check before allowing IDF project creation. Validation consists of checking if idf-tools install command were run from eclipse and checking the existence of environment variables (IDF_PATH and path). 

test cases: 
after reset environment variables or reset INSTALL_TOOLS_FLAG preference

- try to create new idf project from project explorer > right click > new or from File > new.

<img width="570" alt="Screenshot 2021-05-16 at 15 03 08" src="https://user-images.githubusercontent.com/24419842/118396360-ebd5cf00-b657-11eb-9c72-0078093b546b.png">

after click on "Yes" install tools dialog appears: 

<img width="601" alt="Screenshot 2021-05-16 at 15 04 56" src="https://user-images.githubusercontent.com/24419842/118396413-1d4e9a80-b658-11eb-9ea2-4243a93bf863.png">

- after the tools have been installed and the env variables have been set, project creation should be allowed.