### PR TITLE
IEP-405: Build/Index after creating a new component in the project 

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizard.java
@@ -1,5 +1,8 @@
 package com.espressif.idf.ui.wizard;
 
+import java.io.FileWriter;
+import java.io.IOException;
+
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -42,6 +45,8 @@ public class NewComponentWizard extends Wizard implements INewWizard
 		{
 			IDEWorkbenchPlugin.getPluginWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
 			MessageDialog.openInformation(null, Messages.NewIdfComponentWizard_Component_Title, message);
+			triggerResourceChanges();
+			IDEWorkbenchPlugin.getPluginWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
 		catch (CoreException e)
 		{
@@ -50,6 +55,21 @@ public class NewComponentWizard extends Wizard implements INewWizard
 		return true;
 	}
 
+	private void triggerResourceChanges() 
+	{
+		try
+		{
+			FileWriter fr = new FileWriter(mainPage.getCreatedComponentPath() + "/CMakeLists.txt", true); //$NON-NLS-1$
+			fr.write("\n");
+			fr.flush();
+			fr.close();
+		}
+		catch (IOException e)
+		{
+			Logger.log(e);
+		}
+	}
+	
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection)
 	{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizard.java
@@ -60,7 +60,7 @@ public class NewComponentWizard extends Wizard implements INewWizard
 		try
 		{
 			FileWriter fr = new FileWriter(mainPage.getCreatedComponentPath() + "/CMakeLists.txt", true); //$NON-NLS-1$
-			fr.write("\n");
+			fr.write("\n"); //$NON-NLS-1$
 			fr.flush();
 			fr.close();
 		}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizardPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewComponentWizardPage.java
@@ -169,13 +169,17 @@ public class NewComponentWizardPage extends WizardPage
 
 	private boolean checkIfComponentExists()
 	{
-		IProject selectedProject = ResourcesPlugin.getWorkspace().getRoot().getProject(projectCombo.getText());
-		IPath newPath = selectedProject.getLocation().append("/components"); //$NON-NLS-1$
-		Path absPath = Paths.get(newPath.toString() + "\\" + componentName.getText()); //$NON-NLS-1$
-		if (Files.exists(absPath))
+		if (Files.exists(getCreatedComponentPath()))
 		{
 			return true;
 		}
 		return false;
+	}
+
+	public Path getCreatedComponentPath()
+	{
+		IProject selectedProject = ResourcesPlugin.getWorkspace().getRoot().getProject(projectCombo.getText());
+		IPath newPath = selectedProject.getLocation().append("components").append(componentName.getText()); //$NON-NLS-1$
+		return Paths.get(newPath.toString());
 	}
 }


### PR DESCRIPTION
Added a trigger that allows to rebuilding the project after adding a component.
Test case: 
- Create a new component in the already built project > rebuild the project > there is no "Unresolved inclusion" issue