### PR TITLE
IEP-389: Target configuration select wrong com port

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/Messages.java
@@ -21,6 +21,8 @@ public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "com.espressif.idf.launch.serial.internal.messages"; //$NON-NLS-1$
 	public static String SerialFlashLaunch_Pause;
 	public static String SerialFlashLaunch_Resume;
+	public static String SerialPortNotFoundTitle;
+	public static String SerialPortNotFoundMsg;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/messages.properties
@@ -10,3 +10,5 @@
 ################################################################################
 SerialFlashLaunch_Pause=Pausing serial port
 SerialFlashLaunch_Resume=Resuming serial port
+SerialPortNotFoundTitle=Serial port not found
+SerialPortNotFoundMsg=The serial port was not found. Please select it first and flash the project again.

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -118,10 +118,6 @@ public class NewSerialFlashTargetWizardPage extends WizardPage {
 						}
 					}
 				}
-
-				if (serialPortCombo.getSelectionIndex() < 0) {
-					serialPortCombo.select(0);
-				}
 			}
 		} catch (IOException e) {
 			Activator.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID,


### PR DESCRIPTION
Fixed selecting the wrong port after disconnecting the device.
test case:
connect the device and select the right port to it in the esp target configuration > quit the target configuration wizard > unplug the device and try to flash the project and you will see error msg: 
<img width="573" alt="Screenshot 2021-05-27 at 11 55 17" src="https://user-images.githubusercontent.com/24419842/119796901-72a16c00-bee2-11eb-9e95-60d2cd73a070.png">
if we will go to the esp target wizard again, we will see an empty device:
<img width="583" alt="Screenshot 2021-05-27 at 11 56 49" src="https://user-images.githubusercontent.com/24419842/119797195-aed4cc80-bee2-11eb-8bb0-17f5317ceccc.png">

if we connect our device again, we will be able to flash the project again without selecting a port.

