### PR TITLE
IEP-439: replacing jfrog link with the cloudsmith artifactory link

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -31,7 +31,7 @@
 		</location>
 		
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.16.0"/>
+			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
 			<repository location="jar:https://dl.cloudsmith.io/public/15knots/p2-zip/raw/files/CMakeEd-1.17.0.zip!/"/>
 		</location>
 		

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -32,7 +32,7 @@
 		
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.16.0"/>
-			<repository location="jar:https://fifteenknots.jfrog.io/artifactory/p2-zip/CMakeEd-1.16.0.zip!/"/>
+			<repository location="jar:https://dl.cloudsmith.io/public/15knots/p2-zip/raw/files/CMakeEd-1.17.0.zip!/"/>
 		</location>
 		
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
CMake4Eclipse Jfrog link is having monthly quota download issues hence moving to cloudsmith repository as suggested. This will fix the build issues we are having.

@sigmaaa @alirana01 FYI