### PR TITLE
IEP-461: provide the right path to the board/interface config file and update UI

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -346,7 +346,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				label.setText(Messages.getString("DebuggerTab.flashVoltageLabel"));
 				label.setToolTipText(Messages.getString("DebuggerTab.flashVoltageToolTip"));
 				GridData gd = new GridData();
-				gd.widthHint = 60;
+				gd.widthHint = 80;
 				gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 				fFlashVoltage = new Combo(comp, SWT.SINGLE | SWT.BORDER);
 				fFlashVoltage.setItems(parser.getEspFlashVoltages().toArray(new String[0]));
@@ -367,7 +367,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				label.setText(Messages.getString("DebuggerTab.configTargetLabel"));
 				label.setToolTipText(Messages.getString("DebuggerTab.configTargetToolTip"));
 				GridData gd = new GridData();
-				gd.widthHint = 60;
+				gd.widthHint = 80;
 				gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 				fTarget = new Combo(comp, SWT.SINGLE | SWT.BORDER);
 				fTarget.setItems(parser.getTargets().toArray(new String[0]));
@@ -390,7 +390,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				label.setToolTipText(Messages.getString("DebuggerTab.configBoardTooTip"));
 
 				GridData gd = new GridData();
-				gd.widthHint = 130;
+				gd.widthHint = 250;
 				gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 				fTargetName = new Combo(comp, SWT.SINGLE | SWT.BORDER);
 				fTargetName.setItems(parser.getBoardsConfigs(selectedTarget).keySet().toArray(new String[0]));

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/utils/EspConfigParser.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/utils/EspConfigParser.java
@@ -28,7 +28,7 @@ public class EspConfigParser
 	public EspConfigParser()
 	{
 		espConfigPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.OPENOCD_SCRIPTS)
-				+ "/tcl_esp-config.json";
+				+ "/esp-config.json"; // $NON-NLS-1$
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
In the latest [openocd](https://github.com/espressif/openocd-esp32/releases/tag/v0.10.0-esp32-20210401)  "esp-config.json" file was added. We are using it to provide to the user the right interface/board in the debugger configurations tab. 
The right path to the esp-config.json was provided and combo elements for voltage, target
 and board now is bigger, so the user is able to see the option he is selecting
 
 <img width="627" alt="Screenshot 2021-06-07 at 15 23 22" src="https://user-images.githubusercontent.com/24419842/121017949-87b1b100-c7a6-11eb-819b-b157a49bdbd5.png">
 
 