### PR TITLE
IEP-468: Сustomize the messages according to what is missing

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/Messages.java
@@ -5,10 +5,13 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.handlers.messages"; //$NON-NLS-1$
-	public static String NewProjectHandler_CouldntFindPaths;
+	public static String NewProjectHandler_CouldntFindPath;
+	public static String NewProjectHandler_CouldntFindIdfPath;
+	public static String NewProjectHandler_CouldntFindTools;
 	public static String NewProjectHandler_MandatoryMsg;
 	public static String NewProjectHandler_NavigateToHelpMenu;
 	public static String NewProjectHandler_PathErrorTitle;
+
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandlerUtil.java
@@ -36,15 +36,25 @@ public class NewProjectHandlerUtil
 		Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 		boolean isToolsInstalled = scopedPreferenceStore.getBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, false);
 
-		if (StringUtil.isEmpty(idfPath) || StringUtil.isEmpty(path) || !isToolsInstalled)
+		if (StringUtil.isEmpty(idfPath))
 		{
-			showMessage();
+			showMessage(Messages.NewProjectHandler_CouldntFindIdfPath);
+			return false;
+		}
+		if (StringUtil.isEmpty(path))
+		{
+			showMessage(Messages.NewProjectHandler_CouldntFindPath);
+			return false;
+		}
+		if (!isToolsInstalled)
+		{
+			showMessage(Messages.NewProjectHandler_CouldntFindTools);
 			return false;
 		}
 		return true;
 	}
 
-	private static void showMessage()
+	private static void showMessage(String missingMsg)
 	{
 		Display.getDefault().asyncExec(new Runnable()
 		{
@@ -53,7 +63,7 @@ public class NewProjectHandlerUtil
 			{
 				boolean isYes = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
 						Messages.NewProjectHandler_PathErrorTitle,
-						Messages.NewProjectHandler_CouldntFindPaths + Messages.NewProjectHandler_NavigateToHelpMenu
+						missingMsg + Messages.NewProjectHandler_NavigateToHelpMenu
 								+ Messages.NewProjectHandler_MandatoryMsg);
 				if (isYes)
 				{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
@@ -1,4 +1,6 @@
-NewProjectHandler_CouldntFindPaths=Couldn't find either IDF_PATH or PATH in the CDT build environment variables. \n \n
+NewProjectHandler_CouldntFindPath=Couldn't find PATH in the CDT build environment variables. \n \n
+NewProjectHandler_CouldntFindIdfPath=Couldn't find IDF_PATH in the CDT build environment variables. \n \n
+NewProjectHandler_CouldntFindTools=Could't find installed tools.  \n \n
 NewProjectHandler_MandatoryMsg=This is a mandatory step even if you've already installed the tools from the command line. Do you want to install the missing tools now?
 NewProjectHandler_NavigateToHelpMenu=Please navigate to menu `Help > ESP-IDF Tools Manager > Install Tools` to install and configure the required paths for creating and building the ESP-IDF projects. \n \n
 NewProjectHandler_PathErrorTitle=Path Error


### PR DESCRIPTION
different message when tools are not installed from Eclipse, example:

<img width="574" alt="Screenshot 2021-06-15 at 22 02 16" src="https://user-images.githubusercontent.com/24419842/122108946-79f2d000-ce25-11eb-9aff-5b951faf7023.png">

<img width="574" alt="Screenshot 2021-06-15 at 22 07 29" src="https://user-images.githubusercontent.com/24419842/122109513-21700280-ce26-11eb-9322-55594b9c4fc7.png">

<img width="568" alt="Screenshot 2021-06-15 at 22 09 12" src="https://user-images.githubusercontent.com/24419842/122109734-5ed49000-ce26-11eb-9750-f636bb6b05b0.png">

