### PR TITLE
IEP-465 UI menu for "idf.py python-clean" command

### DIFF
--- a/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
@@ -25,3 +25,4 @@ wizard.name.1 = Espressif IDF Component
 wizard.description.0 = Create a new EspressIf IDF component
 command.label.2 = ESP-IDF: Python Clean
 command.name.5 = ESP-IDF: Python Clean
+

--- a/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
@@ -23,3 +23,5 @@ page.name = Espressif
 
 wizard.name.1 = Espressif IDF Component
 wizard.description.0 = Create a new EspressIf IDF component
+command.label.2 = Python clean
+command.name.5 = Python clean

--- a/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
@@ -23,5 +23,5 @@ page.name = Espressif
 
 wizard.name.1 = Espressif IDF Component
 wizard.description.0 = Create a new EspressIf IDF component
-command.label.2 = Python clean
-command.name.5 = Python clean
+command.label.2 = ESP-IDF: Python Clean
+command.name.5 = ESP-IDF: Python Clean

--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -233,6 +233,22 @@
                </iterate>
             </visibleWhen>
          </command>
+         <command
+               commandId="com.espressif.commands.cleanCommand"
+               icon="icons/espressif.png"
+               label="%command.label.2"
+               style="push">
+            <visibleWhen
+                  checkEnabled="false">
+               <iterate
+                     ifEmpty="false"
+                     operator="or">
+                  <instanceof
+                        value="org.eclipse.core.resources.IResource">
+                  </instanceof>
+               </iterate>
+            </visibleWhen>
+         </command>
       </menuContribution>
    </extension>
    <extension
@@ -293,4 +309,19 @@
              name="English">
        </Language>
     </extension>
+    <extension
+         point="org.eclipse.ui.commands">
+      <command
+            categoryId="com.espressif.commands.category"
+            id="com.espressif.commands.cleanCommand"
+            name="%command.name.5">
+      </command>
+   </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="com.espressif.idf.ui.handlers.PythonCleanCommandHandler"
+            commandId="com.espressif.commands.cleanCommand">
+      </handler>
+   </extension>
 </plugin>

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+
+package com.espressif.idf.ui.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.ProcessBuilderFactory;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.ui.EclipseUtil;
+import com.espressif.idf.ui.update.AbstractToolsHandler;
+
+public class PythonCleanCommandHandler extends AbstractToolsHandler
+{
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException
+	{
+		activateIDFConsoleView();
+		if (!NewProjectHandlerUtil.installToolsCheck())
+		{
+			return null;
+		}
+		IProject selectedProject = EclipseUtil.getSelectedProjectInExplorer();
+
+		Path pathToProject = new Path(selectedProject.getLocation().toString());
+		List<String> commands = new ArrayList<>();
+		commands.add(IDFUtil.getIDFPythonEnvPath());
+		commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+		commands.add("clean"); //$NON-NLS-1$
+		Map<String, String> envMap = new IDFEnvironmentVariables().getEnvMap();
+		console.print((runCommand(commands, pathToProject, envMap)));
+		return event;
+	}
+
+	private String runCommand(List<String> arguments, Path workDir, Map<String, String> env)
+	{
+		String exportCmdOp = ""; //$NON-NLS-1$
+		ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
+		try
+		{
+			IStatus status = processRunner.runInBackground(arguments,
+					workDir, env);
+			if (status == null)
+			{
+				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
+
+			}
+
+			// process export command output
+			exportCmdOp = status.getMessage();
+			Logger.log(exportCmdOp);
+		}
+		catch (Exception e1)
+		{
+			Logger.log(IDFCorePlugin.getPlugin(), e1);
+		}
+		return exportCmdOp;
+	}
+
+	@Override
+	protected void execute()
+	{
+	}
+
+
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
@@ -56,7 +56,7 @@ public class PythonCleanCommandHandler extends AbstractToolsHandler
 			if (status == null)
 			{
 				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
-
+				return IDFCorePlugin.errorStatus("Status can't be null", null).toString();
 			}
 
 			// process export command output


### PR DESCRIPTION
added python clean command:

<img width="336" alt="Screenshot 2021-06-21 at 23 25 02" src="https://user-images.githubusercontent.com/24419842/122823405-fdaa3200-d2e7-11eb-8062-dea0ca85c028.png">

to use this command go to Project explorer > right click on project.
Test cases:

1. Run command on a built project > command successfully executed
2. Run command on a new project > command successfully executed
3. Run command on a project without build directory > user will see a message in a console that build directory is missing, nothing to clean
