### PR TITLE
IEP-476: Add warning message if openOCD doesn't support jtag flashing

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -71,10 +71,12 @@ public class CMakeMainTab2 extends GenericMainTab {
 	}
 
 	private void createJtagFlashButton(Composite parent) {
-		if (!isJtagFlashAvailable) {
-			return;
-		}
-		flashOverJtagButton = new Button(parent, SWT.CHECK);
+		Composite c = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		c.setLayout(layout);
+
+		flashOverJtagButton = new Button(c, SWT.CHECK);
 		flashOverJtagButton.setText(Messages.CMakeMainTab2_JtagComboLbl);
 		flashOverJtagButton.addSelectionListener(new SelectionListener() {
 
@@ -93,6 +95,13 @@ public class CMakeMainTab2 extends GenericMainTab {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
+
+		if (!isJtagFlashAvailable) {
+			Label lbl = new Label(c, SWT.NONE);
+			lbl.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW));
+			lbl.setText(Messages.CMakeMainTab2_JtagFlashingNotSupportedMsg);
+			flashOverJtagButton.setEnabled(false);
+		}
 	}
 
 	private void switchUI() {

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -35,6 +35,7 @@ public class Messages extends NLS {
 	public static String configBoardLabel;
 	public static String configBoardTooTip;
 	public static String CMakeMainTab2_OpeonOcdSetupGroupTitle;
+	public static String CMakeMainTab2_JtagFlashingNotSupportedMsg;
 
 	static {
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -24,3 +24,5 @@ configTargetToolTip=Select a launch target
 configBoardLabel=Board:
 configBoardTooTip=Select a board based on ESP target
 CMakeMainTab2_OpeonOcdSetupGroupTitle=OpenOCD Setup:
+CMakeMainTab2_JtagFlashingNotSupportedMsg=(JTAG flash functionality isn't available, please update OpenOCD. The minimum required version is v0.10.0-esp32-20210401)
+


### PR DESCRIPTION
Added warning message if openOCD doesn't support jtag flashing:
<img width="982" alt="Screenshot 2021-06-25 at 10 35 32" src="https://user-images.githubusercontent.com/24419842/123427022-633a3f00-d5c4-11eb-908a-7e81da80d3b5.png">
