### PR TITLE
Update readme files to include how to switch languages (IEP-477)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![GitHub release](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
 
+[中文](./readme_CN.md) 
 # ESP-IDF Eclipse Plugin
 ESP-IDF Eclipse Plugin brings developers an easy-to-use Eclipse-based development environment for developing ESP32 based IoT applications.
 It provides better tooling capabilities, which simplifies and enhances standard Eclipse CDT for developing and debugging ESP32 IoT applications. It offers advanced editing, compiling, flashing and debugging features with the addition of Installing the tools, SDK configuration and CMake editors. 
@@ -33,12 +34,12 @@ To get a quick understanding about ESP-IDF and Eclipse plugin features check our
 * [ Configuring Core Build Toolchain ](#ConfigureToolchains)<br>
 * [ Configuring CMake Toolchain ](#ConfigureCMakeToolchain)<br>
 * [ Configuring the flash arguments ](#customizeLaunchConfig)<br>
-* [ Changing Language ](#changeLanguage)<br>
 * [ Installing IDF Eclipse Plugin from Eclipse Market Place](#installPluginsFromMarketPlace) <br>
 * [ Installing IDF Eclipse Plugin using local archive ](#installPluginsUsingLocalFile) <br>
 * [ Upgrading IDF Eclipse Plugin ](#upgradePlugins)<br>
 * [ Importing an existing IDF Project ](#ImportProject)<br>
 * [ Importing an existing Debug launch configuration ](#importDebugLaunchConfig)<br>
+* [ Changing Language ](#changeLanguage)<br>
 * [ Troubleshooting Guide](#troubleshooting)<br>
 * [ How to raise bugs ](#howToRaiseBugs)<br>
 * <a href ="https://github.com/espressif/idf-eclipse-plugin/blob/master/FAQ.md#FAQ">FAQ</a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,6 @@
 [![GitHub 发布](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
 
+[English](./readme.md) 
 # ESP-IDF Eclipse 插件
 ESP-IDF Eclipse 插件可便利开发人员在 Eclipse 开发环境中开发基于 ESP32 的 IoT 应用程序。本插件集成了编辑、编译、烧录和调试等基础功能，还有安装工具、SDK 配置和 CMake 编辑器等附加功能，可简化并增强开发人员在使用标准 Eclipse CDT 开发和调试 ESP32 IoT 应用程序时的开发体验。
 
@@ -37,6 +38,7 @@ ESP-IDF Eclipse 插件支持 `macOS`、`Window` 和 `Linux` 操作系统。
 * [升级 IDF Eclipse 插件](#upgradePlugins)<br>
 * [导入一个现有的 IDF 项目](#ImportProject)<br>
 * [导入一个现有的 Debug 启动配置](#importDebugLaunchConfig)<br>
+* [更改语言](#changeLanguage)<br>
 * [故障排除指南](#troubleshooting)<br>
 * [如何提交 bug](#howToRaiseBugs)<br>
 * <a href ="https://github.com/espressif/idf-eclipse-plugin/blob/master/FAQ.md#FAQ">常见问题</a>
@@ -333,6 +335,18 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 ![](docs/images/11_launch_configuration.png)
 
 ![](docs/images/12_flashing.png)
+
+# 更改语言
+IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤操作。
+
+1. 前往菜单栏，点击`帮助`。
+1. 在下拉菜单中选择`更改语言`。
+1. 在子下拉菜单中选择所需的语言。
+1. 此后，Eclipse 重启后将切换至所选择的语言。
+
+![](docs/images/change_language.png)
+
+注意，上述操作仅提供针对插件界面的汉化。如需全部汉化，则请另外安装 Eclipse 汉化包。
 
 <a name="troubleshooting"></a>
 # 故障排除 


### PR DESCRIPTION
This PR:
1. Added redirection between English and Chinese readme files at the beginning of the readme files;
2. Provided Chinese translation on how to switch between Chinese and English Eclipse plugin interfaces;
3. Adjusted the position where "changing language" is added in the table of contents. 