### PR TITLE
IEP-479: Fixed indexer fails issue on change configuration

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
@@ -41,6 +41,7 @@ public class IDFDebugLaunchDescriptorType implements ILaunchDescriptorType
 			if (identifier.equals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 			{
 				IProject project = getProject();
+				project = project != null ? project : config.getMappedResources()[0].getProject();
 				if (IDFProjectNature.hasNature(project))
 				{
 					IDFProjectLaunchDescriptor descriptor = descriptors.get(config);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -299,6 +299,9 @@ public class CMakeMainTab2 extends GenericMainTab {
 		File workingDir;
 		if (workDirectoryField.getText().isEmpty()) {
 			try {
+				if (configuration.getMappedResources() == null) {
+					return;
+				}
 				workingDir = new File(configuration.getMappedResources()[0].getProject().getLocationURI());
 				workDirectoryField.setText(newVariableExpression("workspace_loc", workingDir.getName())); //$NON-NLS-1$
 			} catch (CoreException e) {


### PR DESCRIPTION
This PR relates to issues described here: https://github.com/espressif/idf-eclipse-plugin/issues/309

this PR fixes issue with failing indexer on change configuration. 
The second problem was that building in Debug Config fails. It happened because we were losing target after the eclipse restart. This problem was also fixed, now we are not losing target and after eclipse restart, the target bar is not missing for debug config. 

An additional fix for the NPE, when creating a new launch configuration was added. 

Tested on macOS and Windows 10. Test cases:
switching configs, creating a new launch configuration, modify the configuration, delete a configuration, switching between different projects, project close and reopen and eclipse restarting, switching workspaces. 
Expected result: Indexer not failing, building in debug/launch configuration works