### PR TITLE
Fix invalid links in readme files (IEP-488)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub release](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
 
-[中文](./readme_CN.md) 
+[中文](./README_CN.md) 
 # ESP-IDF Eclipse Plugin
 ESP-IDF Eclipse Plugin brings developers an easy-to-use Eclipse-based development environment for developing ESP32 based IoT applications.
 It provides better tooling capabilities, which simplifies and enhances standard Eclipse CDT for developing and debugging ESP32 IoT applications. It offers advanced editing, compiling, flashing and debugging features with the addition of Installing the tools, SDK configuration and CMake editors. 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 [![GitHub 发布](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
 
-[English](./readme.md) 
+[English](./README.md) 
 # ESP-IDF Eclipse 插件
 ESP-IDF Eclipse 插件可便利开发人员在 Eclipse 开发环境中开发基于 ESP32 的 IoT 应用程序。本插件集成了编辑、编译、烧录和调试等基础功能，还有安装工具、SDK 配置和 CMake 编辑器等附加功能，可简化并增强开发人员在使用标准 Eclipse CDT 开发和调试 ESP32 IoT 应用程序时的开发体验。
 
@@ -336,6 +336,7 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 
 ![](docs/images/12_flashing.png)
 
+<a name="changeLanguage"></a>
 # 更改语言
 IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤操作。
 


### PR DESCRIPTION
This PR:
1. Fixed the issue switching from EN and CN readme files;
2. Added link for switching language section.