### PR TITLE
IEP-490: Provided right gdb executable to gdb client

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
@@ -28,9 +28,11 @@ public class ESPToolChainProvider implements IToolChainProvider
 
 	// esp32, esp32s2, esp32s3
 	public static final Pattern GCC_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gcc(\\.exe)?"); //$NON-NLS-1$ xtensa-esp32s2-elf-readelf
+	public static final Pattern GDB_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gdb(\\.exe)?"); //$NON-NLS-1$
 
 	// esp32c3
 	public static final Pattern GCC_PATTERN_ESP32C3 = Pattern.compile("riscv32-esp-elf-gcc(\\.exe)?"); //$NON-NLS-1$ //riscv32-esp-elf-gcc
+	public static final Pattern GDB_PATTERN_ESP32C3 = Pattern.compile("riscv32-esp-elf-gdb(\\.exe)?"); //$NON-NLS-1$
 
 	@Override
 	public String getId()

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -271,14 +271,14 @@ public class IDFUtil
 	 */
 	public static String getXtensaToolchainExecutablePath(IProject project)
 	{
-		Pattern gcc_pattern = ESPToolChainProvider.GCC_PATTERN; // default
+		Pattern gdb_pattern = ESPToolChainProvider.GDB_PATTERN; // default
 		String projectEspTarget = null;
 		if (project != null)
 		{
 			projectEspTarget = new SDKConfigJsonReader(project).getValue("IDF_TARGET"); //$NON-NLS-1$
 			if (!StringUtil.isEmpty(projectEspTarget) && projectEspTarget.equals(ESP32C3ToolChain.OS))
 			{
-				gcc_pattern = ESPToolChainProvider.GCC_PATTERN_ESP32C3;
+				gdb_pattern = ESPToolChainProvider.GDB_PATTERN_ESP32C3;
 				projectEspTarget = ESP32C3ToolChain.ARCH;
 			}
 		}
@@ -299,7 +299,7 @@ public class IDFUtil
 							continue;
 						}
 
-						Matcher matcher = gcc_pattern.matcher(file.getName());
+						Matcher matcher = gdb_pattern.matcher(file.getName());
 						if (matcher.matches())
 						{
 							String path = file.getAbsolutePath();

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -1003,7 +1003,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			fDoStartGdbClient.setSelection(DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);
 
 			//Set Xtensa toolchain path
-			String clientExecutablePath = getGdbClientExecutable();
+			String clientExecutablePath = getGdbClientExecutable(fConfiguration);
 			if (clientExecutablePath != null)
 			{
 				fGdbClientExecutable.setText(clientExecutablePath);
@@ -1312,7 +1312,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 		// GDB client setup
 		{
-			defaultString = getGdbClientExecutable();
+			defaultString = getGdbClientExecutable(configuration);
 			configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME, defaultString);
 
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_REMOTE_TARGET,
@@ -1331,13 +1331,13 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 	}
 	
 	//Get Xtensa toolchain path based on the target configured for the project
-	private String getGdbClientExecutable()
+	private String getGdbClientExecutable(ILaunchConfiguration configuration)
 	{
 		// Find the project and current launch target configured
 		IProject project = null;
-		if (fConfiguration != null)
+		if (configuration != null)
 		{
-			project = EclipseUtils.getProjectByLaunchConfiguration(fConfiguration);
+			project = EclipseUtils.getProjectByLaunchConfiguration(configuration);
 		}
 		String exePath = IDFUtil.getXtensaToolchainExecutablePath(project);
 		return StringUtil.isEmpty(exePath) ? StringUtil.EMPTY : exePath;


### PR DESCRIPTION
The default option for gdb executable in the GDB setup client is now based on IDF_TARGET