### PR TITLE
IEP-498 Indexer fails on changing the launch target

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -131,6 +131,11 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		// Let's generate build artifacts directly under the build folder so that CLI and eclipse IDF will be in sync
 		String name = ICBuildConfiguration.DEFAULT_NAME;
 
+		if (configManager.hasConfiguration(this, project, name)
+				&& project.getActiveBuildConfig().getName().contains(name))
+		{
+			return configManager.getBuildConfiguration(project.getActiveBuildConfig());
+		}
 		IBuildConfiguration config = configManager.createBuildConfiguration(this, project, name, monitor);
 		CBuildConfiguration cmakeConfig = new IDFBuildConfiguration(config, name, toolChain, file, launchMode);
 		configManager.addBuildConfiguration(config, cmakeConfig);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -15,34 +15,15 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial.ui.internal;
 
-import java.io.File;
-
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.IWorkspaceRunnable;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.launchbar.core.ILaunchBarManager;
-import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.launchbar.core.target.ILaunchTargetWorkingCopy;
 import org.eclipse.launchbar.ui.target.LaunchTargetWizard;
-import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.widgets.Display;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
-import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.SDKConfigJsonReader;
-import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.launch.serial.SerialFlashLaunchTargetProvider;
 
 public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
@@ -78,107 +59,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 		wc.save();
 
 		storeLastUsedSerialPort();
-		String newIdfTarget = page.getIDFTarget();
-
-		Display.getDefault().asyncExec(new Runnable() {
-			@Override
-			public void run() {
-				update(newIdfTarget);
-			}
-
-			private void update(String newTarget) {
-				//Get old IDF target for the project
-				try {
-					ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
-					ILaunchDescriptor activeLaunchDescriptor = launchBarManager.getActiveLaunchDescriptor();
-					String projectName = activeLaunchDescriptor.getName();
-					if (!StringUtil.isEmpty(projectName)) {
-
-						//Get IProject
-						IWorkspace workspace = ResourcesPlugin.getWorkspace();
-						IResource project = workspace.getRoot().findMember(projectName);
-
-						Logger.log("Project Name:: " + projectName); //$NON-NLS-1$
-						Logger.log("Project:: " + project); //$NON-NLS-1$
-
-						//build folder exist?
-						if (project != null) {
-							File buildLocation = new File(project.getLocation() + "/build"); //$NON-NLS-1$
-							if (buildLocation.exists()) {
-								//get current target
-								String currentTarget = new SDKConfigJsonReader((IProject) project)
-										.getValue("IDF_TARGET"); //$NON-NLS-1$
-
-								//If both are not same
-								if (currentTarget != null && !newTarget.equals(currentTarget)) {
-									boolean isDelete = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
-											"IDF TARGET Changed", //$NON-NLS-1$
-											"IDF_TARGET has changed for the project. Do you want to delete the `build` folder for the project?"); //$NON-NLS-1$
-									if (isDelete) {
-										IWorkspaceRunnable runnable = new IWorkspaceRunnable() {
-
-											@Override
-											public void run(IProgressMonitor monitor) throws CoreException {
-
-												monitor.beginTask("Deleting build folder...", 1); //$NON-NLS-1$
-												Logger.log("Deleting build folder " + buildLocation.getAbsolutePath()); //$NON-NLS-1$
-												deleteDirectory(buildLocation);
-												cleanSdkConfig(project);
-												project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-											}
-
-										};
-
-										//run workspace job
-										try {
-											ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
-										} catch (Exception e1) {
-											Logger.log(IDFCorePlugin.getPlugin(), "Unable to delete the build folder", //$NON-NLS-1$
-													e1);
-										}
-									}
-								}
-							}
-						}
-
-					}
-
-				} catch (CoreException e1) {
-					Logger.log(e1);
-				}
-			}
-		});
-
 		return true;
-	}
-
-	private boolean deleteDirectory(File directoryToBeDeleted) {
-		File[] allContents = directoryToBeDeleted.listFiles();
-		if (allContents != null) {
-			for (File file : allContents) {
-				deleteDirectory(file);
-			}
-		}
-		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete(); //$NON-NLS-1$
-	}
-
-	private void cleanSdkConfig(IResource project) {
-		File sdkconfig = new File(project.getLocation().toOSString(), "sdkconfig"); //$NON-NLS-1$
-		if (sdkconfig.exists()) {
-			File sdkconfigOld = new File(project.getLocation().toOSString(), "sdkconfig.old"); //$NON-NLS-1$
-			boolean isRenamed = sdkconfig.renameTo(sdkconfigOld);
-			Logger.log(NLS.bind("Renaming {0} status...{1}", sdkconfig.getAbsolutePath(), isRenamed)); //$NON-NLS-1$
-
-			if (!isRenamed) //sdkconfig.old might already exist
-			{
-				//delete sdkconfig.old file!
-				Logger.log(
-						NLS.bind("Deleting {0} status...{1}", sdkconfigOld.getAbsolutePath(), sdkconfigOld.delete())); //$NON-NLS-1$
-
-				//attempting one more time!
-				sdkconfig.renameTo(sdkconfigOld);
-			}
-		}
 	}
 
 	private void storeLastUsedSerialPort() {

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EclipseUtil.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EclipseUtil.java
@@ -10,8 +10,10 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
 /**
@@ -48,6 +50,7 @@ public class EclipseUtil
 
 	/**
 	 * Selected project from the Project explorer view
+	 * 
 	 * @return
 	 */
 	public static IProject getSelectedProjectInExplorer()
@@ -74,6 +77,24 @@ public class EclipseUtil
 					return resource.getProject();
 				}
 			}
+		}
+		return null;
+	}
+
+	public static Shell getShell()
+	{
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (window == null)
+		{
+			IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+			if (windows.length > 0)
+			{
+				return windows[0].getShell();
+			}
+		}
+		else
+		{
+			return window.getShell();
 		}
 		return null;
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -11,11 +11,13 @@ import java.net.URL;
 import java.text.MessageFormat;
 
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
+import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.ui.IStartup;
 import org.json.simple.JSONObject;
@@ -49,11 +51,13 @@ public class InitializeToolsStartup implements IStartup
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet" ; //$NON-NLS-1$
 
+	@SuppressWarnings("restriction")
 	@Override
 	public void earlyStartup()
 	{
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener());
-		
+		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
+		launchBarManager.addListener(new LaunchBarListener());
 		if (isInstallerConfigSet())
 		{
 			Logger.log("Ignoring esp_idf.json settings as it was configured earilier.");

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -19,10 +19,7 @@ import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.internal.Activator;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Monitor;
-import org.eclipse.swt.widgets.Shell;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
@@ -83,16 +80,8 @@ public class LaunchBarListener implements ILaunchBarListener
 						// If both are not same
 						if (currentTarget != null && !newTarget.equals(currentTarget))
 						{
-							Display display = Display.getDefault();
-							Shell shell = new Shell(display);
-							Monitor primary = display.getPrimaryMonitor();
-							Rectangle bounds = primary.getBounds();
-							Rectangle rect = shell.getBounds();
-							int x = bounds.x + (bounds.width - rect.width) / 2;
-							int y = bounds.y + (bounds.height - rect.height) / 2;
-							shell.setLocation(x, y);
 
-							boolean isDelete = MessageDialog.openQuestion(shell,
+							boolean isDelete = MessageDialog.openQuestion(EclipseUtil.getShell(),
 									"IDF TARGET Changed", //$NON-NLS-1$
 									"IDF_TARGET has changed for the project. Do you want to delete the `build` folder for the project?"); //$NON-NLS-1$
 							if (isDelete)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -1,3 +1,7 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.ui;
 
 import java.io.File;
@@ -16,7 +20,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
-import org.eclipse.launchbar.core.internal.Activator;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
@@ -26,7 +29,6 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.SDKConfigJsonReader;
 import com.espressif.idf.core.util.StringUtil;
 
-@SuppressWarnings("restriction")
 public class LaunchBarListener implements ILaunchBarListener
 {
 	@Override
@@ -38,7 +40,7 @@ public class LaunchBarListener implements ILaunchBarListener
 			@Override
 			public void run()
 			{
-				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null);
+				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null); //$NON-NLS-1$
 				update(targetName);
 			}
 		});
@@ -50,9 +52,9 @@ public class LaunchBarListener implements ILaunchBarListener
 		// Get old IDF target for the project
 		try
 		{
-			ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
+			ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
 			ILaunchConfiguration activeConfig = launchBarManager.getActiveLaunchConfiguration();
-			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, "");
+			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
 			if (projectName.isEmpty())
 			{
 				ILaunchDescriptor activeLaunchDescriptor = launchBarManager.getActiveLaunchDescriptor();
@@ -82,8 +84,8 @@ public class LaunchBarListener implements ILaunchBarListener
 						{
 
 							boolean isDelete = MessageDialog.openQuestion(EclipseUtil.getShell(),
-									"IDF TARGET Changed", //$NON-NLS-1$
-									"IDF_TARGET has changed for the project. Do you want to delete the `build` folder for the project?"); //$NON-NLS-1$
+									Messages.LaunchBarListener_TargetChanged_Title,
+									Messages.LaunchBarListener_TargetChanged_Msg);
 							if (isDelete)
 							{
 								IWorkspaceRunnable runnable = new IWorkspaceRunnable()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -1,0 +1,174 @@
+package com.espressif.idf.ui;
+
+import java.io.File;
+
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.launchbar.core.ILaunchBarListener;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+import org.eclipse.launchbar.core.ILaunchDescriptor;
+import org.eclipse.launchbar.core.internal.Activator;
+import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Monitor;
+import org.eclipse.swt.widgets.Shell;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.SDKConfigJsonReader;
+import com.espressif.idf.core.util.StringUtil;
+
+@SuppressWarnings("restriction")
+public class LaunchBarListener implements ILaunchBarListener
+{
+	@Override
+	public void activeLaunchTargetChanged(ILaunchTarget target)
+	{
+		Display.getDefault().asyncExec(new Runnable()
+		{
+
+			@Override
+			public void run()
+			{
+				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null);
+				update(targetName);
+			}
+		});
+
+	}
+
+	private void update(String newTarget)
+	{
+		// Get old IDF target for the project
+		try
+		{
+			ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
+			ILaunchConfiguration activeConfig = launchBarManager.getActiveLaunchConfiguration();
+			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, "");
+			if (projectName.isEmpty())
+			{
+				ILaunchDescriptor activeLaunchDescriptor = launchBarManager.getActiveLaunchDescriptor();
+				projectName = activeLaunchDescriptor.getName();
+			}
+			if (!StringUtil.isEmpty(projectName))
+			{
+
+				// Get IProject
+				IWorkspace workspace = ResourcesPlugin.getWorkspace();
+				IResource project = workspace.getRoot().findMember(projectName);
+
+				Logger.log("Project Name:: " + projectName); //$NON-NLS-1$
+				Logger.log("Project:: " + project); //$NON-NLS-1$
+
+				// build folder exist?
+				if (project != null)
+				{
+					File buildLocation = new File(project.getLocation() + "/build"); //$NON-NLS-1$
+					if (buildLocation.exists())
+					{
+						// get current target
+						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
+
+						// If both are not same
+						if (currentTarget != null && !newTarget.equals(currentTarget))
+						{
+							Display display = Display.getDefault();
+							Shell shell = new Shell(display);
+							Monitor primary = display.getPrimaryMonitor();
+							Rectangle bounds = primary.getBounds();
+							Rectangle rect = shell.getBounds();
+							int x = bounds.x + (bounds.width - rect.width) / 2;
+							int y = bounds.y + (bounds.height - rect.height) / 2;
+							shell.setLocation(x, y);
+
+							boolean isDelete = MessageDialog.openQuestion(shell,
+									"IDF TARGET Changed", //$NON-NLS-1$
+									"IDF_TARGET has changed for the project. Do you want to delete the `build` folder for the project?"); //$NON-NLS-1$
+							if (isDelete)
+							{
+								IWorkspaceRunnable runnable = new IWorkspaceRunnable()
+								{
+
+									@Override
+									public void run(IProgressMonitor monitor) throws CoreException
+									{
+
+										monitor.beginTask("Deleting build folder...", 1); //$NON-NLS-1$
+										Logger.log("Deleting build folder " + buildLocation.getAbsolutePath()); //$NON-NLS-1$
+										deleteDirectory(buildLocation);
+										cleanSdkConfig(project);
+										project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+									}
+
+								};
+
+								// run workspace job
+								try
+								{
+									ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
+								}
+								catch (Exception e1)
+								{
+									Logger.log(IDFCorePlugin.getPlugin(), "Unable to delete the build folder", //$NON-NLS-1$
+											e1);
+								}
+							}
+						}
+					}
+				}
+
+			}
+
+		}
+		catch (CoreException e1)
+		{
+			Logger.log(e1);
+		}
+	}
+
+	private boolean deleteDirectory(File directoryToBeDeleted)
+	{
+		File[] allContents = directoryToBeDeleted.listFiles();
+		if (allContents != null)
+		{
+			for (File file : allContents)
+			{
+				deleteDirectory(file);
+			}
+		}
+		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete(); //$NON-NLS-1$
+	}
+
+	private void cleanSdkConfig(IResource project)
+	{
+		File sdkconfig = new File(project.getLocation().toOSString(), "sdkconfig"); //$NON-NLS-1$
+		if (sdkconfig.exists())
+		{
+			File sdkconfigOld = new File(project.getLocation().toOSString(), "sdkconfig.old"); //$NON-NLS-1$
+			boolean isRenamed = sdkconfig.renameTo(sdkconfigOld);
+			Logger.log(NLS.bind("Renaming {0} status...{1}", sdkconfig.getAbsolutePath(), isRenamed)); //$NON-NLS-1$
+
+			if (!isRenamed) // sdkconfig.old might already exist
+			{
+				// delete sdkconfig.old file!
+				Logger.log(
+						NLS.bind("Deleting {0} status...{1}", sdkconfigOld.getAbsolutePath(), sdkconfigOld.delete())); //$NON-NLS-1$
+
+				// attempting one more time!
+				sdkconfig.renameTo(sdkconfigOld);
+			}
+		}
+	}
+
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/Messages.java
@@ -1,0 +1,19 @@
+package com.espressif.idf.ui;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS
+{
+	private static final String BUNDLE_NAME = "com.espressif.idf.ui.messages"; //$NON-NLS-1$
+	public static String LaunchBarListener_TargetChanged_Msg;
+	public static String LaunchBarListener_TargetChanged_Title;
+	static
+	{
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages()
+	{
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
@@ -1,0 +1,2 @@
+LaunchBarListener_TargetChanged_Msg=IDF launch target has changed for the project. Do you want to delete the `build` folder for the project?
+LaunchBarListener_TargetChanged_Title=IDF Launch Target Changed


### PR DESCRIPTION
Functionality with the update method was moved to the LaunchBarListener, that's triggering immediately after we are changing the target to the target with a different IDF_TARGET value. Functionality is a little bit refactored, so it's working with debug mode also. 

Test cases:

1.  Create and build the project > change target > "IDF TARGET CHANGED" message appears > click Yes > project is cleaned and the next build is working.
2. Create and build the project > change target > "IDF TARGET CHANGED" message appears > click No > Indexer fails due to the incorrect target 
3. Select some project > create a new launch target > "IDF TARGET CHANGED" message appears if the new launch target is different from one in the build folder configuration
4. Repeat test cases 1,2 and 3 on the debug configuration. 