### PR TITLE
IEP-442: Correct updating launch configuration dropdown box

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
@@ -33,6 +33,10 @@ public class IDFDebugLaunchDescriptorType implements ILaunchDescriptorType
 	@Override
 	public ILaunchDescriptor getDescriptor(Object launchObject)
 	{
+		if (!(launchObject instanceof ILaunchConfiguration))
+		{
+			return null;
+		}
 		ILaunchConfiguration config = (ILaunchConfiguration) launchObject;
 		try
 		{

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFLaunchDescriptorType.java
@@ -43,6 +43,7 @@ public class IDFLaunchDescriptorType implements ILaunchDescriptorType {
 				return null;
 			}
 			IProject project = getProject();
+			project = project != null ? project : config.getMappedResources()[0].getProject();
 			try {
 				if (IDFProjectNature.hasNature(project)) {
 					ILaunchDescriptor descriptor = descriptors.get(config);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -40,8 +40,11 @@ public class LaunchBarListener implements ILaunchBarListener
 			@Override
 			public void run()
 			{
-				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null); //$NON-NLS-1$
-				update(targetName);
+				if (target != null)
+				{
+					String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null); //$NON-NLS-1$
+					update(targetName);
+				}
 			}
 		});
 


### PR DESCRIPTION
this PR includes fixes for both problems: incorrect updating launch configuration dropdown box and losing target for duplicate configuration because of it. Also, small fixes were added to avoid NPE.
Test cases:

1. Create a new project > create a few debug and launch configurations for this project > close the project > dropdown box will remove all configuration related to this project > open the project again > all configurations are added back to the dropdown box
2. Create a new project > create a few debug and launch configurations for this project > close the project > dropdown box will remove all configuration related to this project > restart eclipse > all configuration related to the closed project are still removed > open the project again > all configurations are added back to the dropdown box