### PR TITLE
IEP-523: Providing the idf target attribute instead of the target name

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -60,6 +60,7 @@ import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.json.simple.JSONArray;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.EspConfigParser;
 import com.espressif.idf.core.util.IDFUtil;
@@ -578,7 +579,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		String selectedTarget = ""; //$NON-NLS-1$
 		try
 		{
-			selectedTarget = launchBarManager.getActiveLaunchTarget().getId();
+			selectedTarget = launchBarManager.getActiveLaunchTarget().getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET,
+					""); //$NON-NLS-1$
 		}
 		catch (CoreException e)
 		{

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -256,8 +256,8 @@ public class CMakeMainTab2 extends GenericMainTab {
 		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 		String selectedTarget = ""; //$NON-NLS-1$
 		try {
-			selectedTarget = launchBarManager.getActiveLaunchTarget().getId();
-
+			selectedTarget = launchBarManager.getActiveLaunchTarget().getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET,
+					""); //$NON-NLS-1$
 		} catch (CoreException e) {
 			Logger.log(e);
 		}


### PR DESCRIPTION
test cases:
1. create a target with some name like "espTest" -> open launch configuration -> flash over jtag -> in the target section as the default option the correct target is selected. 
2. same test on the debug configuration