### PR TITLE
IEP-524: IDF launch target changed message is not showing

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -47,9 +47,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 		String typeId = IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE;
 		String id = page.getTargetName();
 		ILaunchTarget target = getLaunchTarget();
-		if (target == null) {
-			target = manager.addLaunchTarget(typeId, id);
-		}
+		target = manager.addLaunchTarget(typeId, id);
 		ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
 		wc.setId(id);
 		wc.setAttribute(ILaunchTarget.ATTR_OS, page.getOS());


### PR DESCRIPTION
We need to call `manager.addLaunchTarget(typeId, id);` every time, when we are editing esp IDF target. This allows us to trigger the launch bar listener and show the "IDF launch target changed" message when it's needed. It's also allows us to not duplicate code, that is using in launch bar listener.

By calling `manager.addLaunchTarget(typeId, id);` we are not adding target if it already exists in related hashmap, so it's safe to call it every time when we are editing esp idf target.