### PR TITLE
IEP-535 Default and saved values for JTAG combo buttons

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
@@ -7,4 +7,7 @@ public final class IDFLaunchConstants
 	public static final String DEBUG_LAUNCH_CONFIG_TYPE= "com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"; //$NON-NLS-1$
 	public static final String RUN_LAUNCH_CONFIG_TYPE = "com.espressif.idf.launch.serial.launchConfigurationType"; //$NON-NLS-1$
 	public static final String FLASH_OVER_JTAG = "FLASH_OVER_JTAG"; //$NON-NLS-1$
+	public static final String JTAG_FLASH_VOLTAGE = "com.espressif.idf.debug.gdbjtag.openocd.jtagFlashVoltage";
+	public static final String TARGET_FOR_JTAG = "com.espressif.idf.debug.gdbjtag.openocd.jtagTarget";
+	public static final String JTAG_BOARD = "com.espressif.idf.debug.gdbjtag.openocd.jtagBoard";
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -266,17 +266,23 @@ public class IDFUtil
 	 */
 	public static String getXtensaToolchainExecutablePath(IProject project)
 	{
-		Pattern gdb_pattern = ESPToolChainProvider.GDB_PATTERN; // default
 		String projectEspTarget = null;
 		if (project != null)
 		{
 			projectEspTarget = new SDKConfigJsonReader(project).getValue("IDF_TARGET"); //$NON-NLS-1$
-			if (!StringUtil.isEmpty(projectEspTarget) && projectEspTarget.equals(ESP32C3ToolChain.OS))
-			{
-				gdb_pattern = ESPToolChainProvider.GDB_PATTERN_ESP32C3;
-				projectEspTarget = ESP32C3ToolChain.ARCH;
-			}
 		}
+		return getXtensaToolchainExecutablePathByTarget(projectEspTarget);
+	}
+	
+	public static String getXtensaToolchainExecutablePathByTarget(String projectEspTarget) {
+
+		Pattern gdb_pattern = ESPToolChainProvider.GDB_PATTERN; // default
+		if (!StringUtil.isEmpty(projectEspTarget) && projectEspTarget.equals(ESP32C3ToolChain.OS))
+		{
+			gdb_pattern = ESPToolChainProvider.GDB_PATTERN_ESP32C3;
+			projectEspTarget = ESP32C3ToolChain.ARCH;
+		}
+		
 
 		// Process PATH to find the toolchain path
 		IEnvironmentVariable cdtPath = new IDFEnvironmentVariables().getEnv("PATH"); //$NON-NLS-1$
@@ -304,7 +310,7 @@ public class IDFUtil
 							{
 								return path;
 							}
-							else if (tuples[1].equals(projectEspTarget))
+							else if (tuples[1].equals(projectEspTarget) || tuples[0].equals(projectEspTarget))
 							{
 								return path;
 							}
@@ -317,7 +323,7 @@ public class IDFUtil
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Get Addr2Line path based on the target configured for the project with toolchain
 	 * @return

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
@@ -27,7 +27,9 @@ Require-Bundle: ilg.gnumcueclipse.debug.gdbjtag,
  com.espressif.idf.launch.serial.core;bundle-version="1.0.0",
  com.espressif.idf.ui;bundle-version="1.0.0",
  ilg.gnumcueclipse.core,
- org.eclipse.cdt.debug.ui
+ org.eclipse.cdt.debug.ui,
+ com.espressif.idf.launch.serial.ui,
+ org.eclipse.launchbar.ui;bundle-version="2.4.200"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %bundle.vendor
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
@@ -41,6 +41,11 @@ public class Messages {
 	public static String BreakPointPage_TextHeapDumpFileName;
 	public static String BreakPointPage_BtnBrowse;
 
+	public static String IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle;
+	public static String IDFLaunchTargetNotFoundMsg1;
+	public static String IDFLaunchTargetNotFoundMsg2;
+	public static String IDFLaunchTargetNotFoundMsg3;
+
 	// ------------------------------------------------------------------------
 
 	static {
@@ -49,6 +54,8 @@ public class Messages {
 	}
 
 	private static ResourceBundle RESOURCE_BUNDLE;
+
+
 	static {
 		try {
 			RESOURCE_BUNDLE = ResourceBundle.getBundle(MESSAGES);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -381,6 +381,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 						String selectedItem = fTarget.getItem(fTarget.getSelectionIndex());
 						boardConfigsMap = parser.getBoardsConfigs(selectedItem);
 						fTargetName.setItems(parser.getBoardsConfigs(selectedItem).keySet().toArray(new String[0]));
+						fTargetName.select(0);
+						fTargetName.notifyListeners(SWT.Selection, null);
 					}
 				});
 				fTarget.setLayoutData(gd);
@@ -397,6 +399,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				fTargetName.setItems(parser.getBoardsConfigs(selectedTarget).keySet().toArray(new String[0]));
 				boardConfigsMap = parser.getBoardsConfigs(selectedTarget);
 				
+				fTargetName.select(0);
 				fTargetName.addSelectionListener(new SelectionAdapter()
 				{
 					@SuppressWarnings("unchecked")
@@ -420,6 +423,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 						}
 
 					}
+
 				});
 				fTargetName.setLayoutData(gd);
 			}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
@@ -385,4 +385,7 @@ BreakPointPage_BtnStopHeapTrace=Stop Heap Trace
 BreakPointPage_TextHeapDumpFileName=Heap Dump File Name: 
 BreakPointPage_BtnBrowse=Browse
 
-
+IDFLaunchTargetNotFoundMsg1=IDF Launch Target with 
+IDFLaunchTargetNotFoundMsg2=\ is not found. 
+IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle=IDF Launch Target not found
+IDFLaunchTargetNotFoundMsg3=Do you want to create a new IDF launch target?

--- a/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Automatic-Module-Name: org.eclipse.cdt.launch.serial.ui
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: com.espressif.idf.ui.dialogs,
  org.eclipse.cdt.dsf.gdb
+Export-Package: com.espressif.idf.launch.serial.ui.internal

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -123,6 +123,9 @@ public class CMakeMainTab2 extends GenericMainTab {
 		}
 		try {
 			ILaunchConfigurationWorkingCopy wc = configuration.getWorkingCopy();
+			wc.setAttribute(IDFLaunchConstants.JTAG_FLASH_VOLTAGE, fFlashVoltage.getText());
+			wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, fTarget.getText());
+			wc.setAttribute(IDFLaunchConstants.JTAG_BOARD, fTargetName.getText());
 			wc.setAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, flashOverJtagButton.getSelection());
 			wc.doSave();
 		} catch (CoreException e) {
@@ -155,18 +158,34 @@ public class CMakeMainTab2 extends GenericMainTab {
 		try {
 			String undefinedArguments = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_TOOL_ARGUMENTS,
 					espFlashCommand);
+			initializeJtagComboFields(configuration);
+			updateArgumentsField();
+
 			if (undefinedArguments.contains(EMPTY_CONFIG_OPTIONS)) {
 				defaultArguments = espFlashCommand;
+
+				if (undefinedArguments.contentEquals(EMPTY_CONFIG_OPTIONS)) {
+					undefinedArguments = argumentsForJtagFlash;
+				}
 				argumentsForJtagFlash = undefinedArguments;
+
 			} else {
 				defaultArguments = undefinedArguments;
-				argumentsForJtagFlash = EMPTY_CONFIG_OPTIONS;
 			}
+
 			argumentField.setText(undefinedArguments);
 		} catch (CoreException e) {
 			Logger.log(e);
 		}
 
+	}
+
+	private void initializeJtagComboFields(ILaunchConfiguration configuration) throws CoreException {
+		fFlashVoltage
+				.setText(configuration.getAttribute(IDFLaunchConstants.JTAG_FLASH_VOLTAGE, fFlashVoltage.getText()));
+		fTarget.setText(configuration.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, fTarget.getText()));
+		fTarget.notifyListeners(SWT.Selection, null);
+		fTargetName.setText(configuration.getAttribute(IDFLaunchConstants.JTAG_BOARD, fTargetName.getText()));
 	}
 
 	@Override
@@ -189,7 +208,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 			Label label = new Label(group, SWT.NONE);
 			label.setText(Messages.flashVoltageLabel);
 			label.setToolTipText(Messages.flashVoltageToolTip);
-			fFlashVoltage = new Combo(group, SWT.SINGLE | SWT.BORDER);
+			fFlashVoltage = new Combo(group, SWT.SINGLE | SWT.BORDER | SWT.READ_ONLY);
 			fFlashVoltage.setItems(parser.getEspFlashVoltages().toArray(new String[0]));
 			fFlashVoltage.setText("default"); //$NON-NLS-1$
 			fFlashVoltage.addSelectionListener(new SelectionAdapter() {
@@ -203,7 +222,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 			Label label = new Label(group, SWT.NONE);
 			label.setText(Messages.configTargetLabel);
 			label.setToolTipText(Messages.configTargetToolTip);
-			fTarget = new Combo(group, SWT.SINGLE | SWT.BORDER);
+			fTarget = new Combo(group, SWT.SINGLE | SWT.BORDER | SWT.READ_ONLY);
 			fTarget.setItems(parser.getTargets().toArray(new String[0]));
 			fTarget.setText(selectedTarget);
 			fTarget.addSelectionListener(new SelectionAdapter() {
@@ -212,6 +231,8 @@ public class CMakeMainTab2 extends GenericMainTab {
 					String selectedItem = fTarget.getItem(fTarget.getSelectionIndex());
 					boardConfigsMap = parser.getBoardsConfigs(selectedItem);
 					fTargetName.setItems(parser.getBoardsConfigs(selectedItem).keySet().toArray(new String[0]));
+					fTargetName.select(0);
+					updateArgumentsField();
 				}
 			});
 		}
@@ -219,10 +240,10 @@ public class CMakeMainTab2 extends GenericMainTab {
 			Label label = new Label(group, SWT.NONE);
 			label.setText(Messages.configBoardLabel);
 			label.setToolTipText(Messages.configBoardTooTip);
-			fTargetName = new Combo(group, SWT.SINGLE | SWT.BORDER);
+			fTargetName = new Combo(group, SWT.SINGLE | SWT.BORDER | SWT.READ_ONLY);
 			fTargetName.setItems(parser.getBoardsConfigs(selectedTarget).keySet().toArray(new String[0]));
 			boardConfigsMap = parser.getBoardsConfigs(selectedTarget);
-
+			fTargetName.select(0);
 			fTargetName.addSelectionListener(new SelectionAdapter() {
 				@Override
 				public void widgetSelected(SelectionEvent e) {

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -37,6 +37,11 @@ public class Messages extends NLS {
 	public static String CMakeMainTab2_OpeonOcdSetupGroupTitle;
 	public static String CMakeMainTab2_JtagFlashingNotSupportedMsg;
 
+	public static String IDFLaunchTargetNotFoundMsg1;
+	public static String IDFLaunchTargetNotFoundMsg2;
+	public static String IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle;
+	public static String IDFLaunchTargetNotFoundMsg3;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -26,3 +26,7 @@ configBoardTooTip=Select a board based on ESP target
 CMakeMainTab2_OpeonOcdSetupGroupTitle=OpenOCD Setup:
 CMakeMainTab2_JtagFlashingNotSupportedMsg=(JTAG flash functionality isn't available, please update OpenOCD. The minimum required version is v0.10.0-esp32-20210401)
 
+IDFLaunchTargetNotFoundMsg1=IDF Launch Target with 
+IDFLaunchTargetNotFoundMsg2=\ is not found. 
+IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle=IDF Launch Target not found
+IDFLaunchTargetNotFoundMsg3=Do you want to create a new IDF launch target?


### PR DESCRIPTION
Hi @kolipakakondal, @alirana01 

PR contains:
- the default value for the board combo button (first from the list)
- saving values for jtag combo buttons. 
- changing the launch target, based on the IDF-target selected in the combo button and previously selected serial port.
-  handled the case, where the user doesn't have a launch target with according IDF-target. In this case. We are navigating him to IDF-Target creation wizard:

<img width="651" alt="Screenshot 2021-10-04 at 13 55 22" src="https://user-images.githubusercontent.com/24419842/135840159-3dbc5b47-cbbc-4b0e-97c4-67d1020972aa.png">

- for the debug configuration, we are also changing the gdb executable based on what target is selected. 
- Fixed one bug related to gdb executable, it's relates to already [closed issue](https://github.com/espressif/idf-eclipse-plugin/issues/325), but from the comments I see, that users still facing it 
