### PR TITLE
IEP-481: Push Nightly master builds to amazon s3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,10 +3,15 @@
 
 name: Nightly builds
 
+# on:
+#   schedule:
+#     - cron: "0 0 * * *"
 on:
-  schedule:
-    - cron: "0 0 * * *"
-
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
 jobs:
   build:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-# This workflow will build a Java project with Maven
+# This workflow will build a Java project with Maven and publish nightly builds
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Nightly builds

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -120,9 +120,5 @@ jobs:
         aws s3 rm s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly --recursive
         aws s3 cp --acl=public-read --recursive "./${FOLDER_NAME}/" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly
         aws s3 cp --acl=public-read "./releng/index.html" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly/
-        aws s3 cp --acl=public-read --recursive "./${FOLDER_NAME}/" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/${FOLDER_NAME}
-        aws s3 cp --acl=public-read --recursive --exclude "*" --include "Espressif-IDE-*" ./releng/com.espressif.idf.product/target/products/ s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
-        aws s3 cp --acl=public-read "${ARCHIVE_VERSION_NEW}" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/
-        aws s3 cp --acl=public-read "./releng/ide-dmg-builder/Espressif-IDE-${FOLDER_NAME}.dmg" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
         aws cloudfront create-invalidation --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} --paths "/dl/idf-eclipse-plugin/updates/nightly/*"
 Footer

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,19 +3,17 @@
 
 name: Nightly builds
 
-# on:
-#   schedule:
-#     - cron: "0 0 * * *"
+on:
+  schedule:
+    - cron: cron: "0 0 * * *"
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
     
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -27,15 +25,73 @@ jobs:
         distribution: 'adopt'
    
     - name: Build with Maven
-      run: mvn clean verify -Djarsigner.skip=true
-      
+      run: |
+        export JARSIGNER_KEYSTORE_B64=${{secrets.JARSIGNER_REL_KEYSTORE_B64}}
+        export JARSIGNER_STOREPASS=${{secrets.JARSIGNER_REL_STOREPASS}}
+        export JARSIGNER_ALIAS=${{secrets.JARSIGNER_REL_ALIAS}}
+        KEYSTORE_FILE="${PWD}/{{secrets.JARSIGNER_KEYSTORE}}"
+        echo "${KEYSTORE_FILE}"
+        printf "%s" "${JARSIGNER_KEYSTORE_B64}" | base64 -d - > "${KEYSTORE_FILE}"
+        mvn -e -X clean install -Djarsigner.keystore="${KEYSTORE_FILE}" -Djarsigner.alias="${JARSIGNER_ALIAS}" -Djarsigner.storepass="${JARSIGNER_STOREPASS}" -DskipTests=true
+        rm -v "${KEYSTORE_FILE}"
+    
+    - name: Codesign Espressif-IDE
+      env: 
+        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+      run: |
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+        /usr/bin/security create-keychain -p espressif build.keychain
+        /usr/bin/security default-keychain -s build.keychain
+        /usr/bin/security unlock-keychain -p espressif build.keychain
+        /usr/bin/security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+        /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
+        
+        echo "codesigning espressif-ide"
+        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app -v
+        /usr/bin/codesign -v -vvv --deep $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app
+        
+        echo "Creating dmg for Espressif-IDE.app"
+        $PWD/releng/ide-dmg-builder/ide-dmg-builder.sh
+        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg -v
+        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg
+    
+    - name: Notarize Espressif-IDE
+      env: 
+        NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+        NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+      run: |
+        echo "Notarization of Espressif-IDE.dmg"
+        xcrun altool --notarize-app -f $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg -u $NOTARIZATION_USERNAME -p $NOTARIZATION_PASSWORD --primary-bundle-id Espressif-ide.app
+    
+    - name: Upload macosx dmg
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: espressif-ide-macosx-dmg
+        path: releng/ide-dmg-builder/Espressif-IDE.dmg
+
     - name: Upload build artifacts
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v2
       with:
-        name: artifacts
+        name: com.espressif.idf.update
         path: releng/com.espressif.idf.update/target/repository
-  
+        
+    - name: Upload windows rcp
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: espressif-ide-win32
+        path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip
+
+    - name: Upload linux rcp
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: espressif-ide-linux
+        path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz
+
     - name: Upload build assets to dl.espressif.com
       id: upload-release-asset-espressif
       env:
@@ -43,7 +99,30 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       run: |
-        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-
+        ARCHIVE_DIR="/releng/com.espressif.idf.update/target/"
+        ARCHIVE_NAME="com.espressif.idf.update*.zip"
+        echo "${ARCHIVE_DIR}"
+        echo ${PWD}${ARCHIVE_DIR}
+        ARCHIVE_FILE_NAME="$(find ${PWD}${ARCHIVE_DIR}${ARCHIVE_NAME})"
+        echo "${ARCHIVE_FILE_NAME}"
+        ARCHIVE_PREFIX="com.espressif.idf.update-"
+        ARCHIVE_SUFFIX="-SNAPSHOT.zip";
+        tmp=${ARCHIVE_FILE_NAME#*${ARCHIVE_PREFIX}}   # remove prefix
+        ARCHIVE_VERSION=${tmp%${ARCHIVE_SUFFIX}*}   # remove suffix
+        echo "${ARCHIVE_VERSION}"
+        FOLDER_NAME="v${ARCHIVE_VERSION}"
+        mkdir "${FOLDER_NAME}" && cd "${FOLDER_NAME}" && unzip -q ${ARCHIVE_FILE_NAME} && cd ..
+        echo ${PWD}
+        ARCHIVE_VERSION_NEW="${ARCHIVE_PREFIX}${ARCHIVE_VERSION}.zip"
+        echo ${ARCHIVE_VERSION_NEW}
+        mv ${ARCHIVE_FILE_NAME} ${ARCHIVE_VERSION_NEW}
+        mv releng/ide-dmg-builder/Espressif-IDE.dmg "releng/ide-dmg-builder/Espressif-IDE-${FOLDER_NAME}.dmg"
+        aws s3 rm s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly --recursive
+        aws s3 cp --acl=public-read --recursive "./${FOLDER_NAME}/" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly
+        aws s3 cp --acl=public-read "./releng/index.html" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/nightly/
+        aws s3 cp --acl=public-read --recursive "./${FOLDER_NAME}/" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/${FOLDER_NAME}
+        aws s3 cp --acl=public-read --recursive --exclude "*" --include "Espressif-IDE-*" ./releng/com.espressif.idf.product/target/products/ s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
+        aws s3 cp --acl=public-read "${ARCHIVE_VERSION_NEW}" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/
+        aws s3 cp --acl=public-read "./releng/ide-dmg-builder/Espressif-IDE-${FOLDER_NAME}.dmg" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} --paths "/dl/idf-eclipse-plugin/updates/nightly/*"
+Footer

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,13 @@ jobs:
    
     - name: Build with Maven
       run: mvn clean verify -Djarsigner.skip=true
+      
+    - name: Upload build artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: releng/com.espressif.idf.update/target/repository
   
     - name: Upload build assets to dl.espressif.com
       id: upload-release-asset-espressif

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,13 +1,11 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven 
+name: Nightly builds
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,13 +24,6 @@ jobs:
     - name: Build with Maven
       run: mvn clean verify -Djarsigner.skip=true
   
-    - name: Upload build artifacts
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: artifacts
-        path: releng/com.espressif.idf.update/target/repository
-
     - name: Upload build assets to dl.espressif.com
       id: upload-release-asset-espressif
       env:
@@ -38,7 +31,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       run: |
-        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+        aws s3 cp --acl=public-read --no-progress /releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,11 +31,14 @@ jobs:
         name: artifacts
         path: releng/com.espressif.idf.update/target/repository
 
-    - name: Upload macosx Release Asset To dl.espressif.com
+    - name: Upload build assets to dl.espressif.com
       id: upload-release-asset-espressif
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-   
+      run: |
+        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+        aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,53 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven 
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+   
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+   
+    - name: Build with Maven
+      run: mvn clean verify -Djarsigner.skip=true
+  
+    - name: Upload build artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: releng/com.espressif.idf.update/target/repository
+        
+    - name: Upload win32 Release Asset To dl.espressif.com
+        id: upload-release-asset-espressif
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+    
+    - name: Upload macosx Release Asset To dl.espressif.com
+        id: upload-release-asset-espressif
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+   
+    - name: Upload linux Release Asset To dl.espressif.com
+        id: upload-release-asset-espressif
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -26,28 +26,28 @@ jobs:
       with:
         name: artifacts
         path: releng/com.espressif.idf.update/target/repository
-        
+
     - name: Upload win32 Release Asset To dl.espressif.com
-        id: upload-release-asset-espressif
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+      id: upload-release-asset-espressif
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
     
     - name: Upload macosx Release Asset To dl.espressif.com
-        id: upload-release-asset-espressif
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+      id: upload-release-asset-espressif
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
    
     - name: Upload linux Release Asset To dl.espressif.com
-        id: upload-release-asset-espressif
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
+      id: upload-release-asset-espressif
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,6 +3,12 @@
 
 name: Java CI with Maven 
 
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 jobs:
   build:
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -33,14 +33,6 @@ jobs:
         name: artifacts
         path: releng/com.espressif.idf.update/target/repository
 
-    - name: Upload win32 Release Asset To dl.espressif.com
-      id: upload-release-asset-espressif
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-    
     - name: Upload macosx Release Asset To dl.espressif.com
       id: upload-release-asset-espressif
       env:
@@ -49,11 +41,3 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-macosx.cocoa.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
    
-    - name: Upload linux Release Asset To dl.espressif.com
-      id: upload-release-asset-espressif
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      run: aws s3 cp --acl=public-read --no-progress /home/runner/work/idf-eclipse-plugin/idf-eclipse-plugin/releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz s3://${{ secrets.DL_BUCKET }}/dl/ide/nightly/
-


### PR DESCRIPTION
## Description

This will push the Espressif IDE update artifacts to the s3 bucket. 
Nightly update site https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/

Fixes # ([IEP-481](https://jira.espressif.com:8443/browse/IEP-481))

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Case 1:
- Launch Espressif-IDE
- Add nightly update site https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/
- Eclipse should be able to get the nightly changes from the master branch

**Test Configuration**:
* ESP-IDF: NA
* OS (Windows,Linux and macOS): All

## Dependent components impacted by this PR:

- Update

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
