### PR TITLE
IEP-513 GH #346: Eclipse on Windows shows error markers for cpp file but not for c file when I include freertos/FreeRTOS.h but build succeeds anyway

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -397,6 +397,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 			{
 				Thread.sleep(2500);
 			}
+			reIndex(project);
 			return new IProject[] { project };
 		} catch (Exception e) {
 			throw new CoreException(IDFCorePlugin.errorStatus(
@@ -930,12 +931,12 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 				
 				includePaths = includePaths.stream().filter(s-> !localPathsToRemove.contains(s)).collect(Collectors.toList());
 				includePaths.addAll(incPaths);
-				includePaths.addAll(0, systemIncludePaths);
+				includePaths.addAll(systemIncludePaths);
 				
 				ExtendedScannerInfo info = new ExtendedScannerInfo(definedSymbols,
-						includePaths.stream().toArray(String[]::new), macroFiles.stream().toArray(String[]::new),
+						systemIncludePaths.stream().toArray(String[]::new), macroFiles.stream().toArray(String[]::new),
 						includeFiles.stream().toArray(String[]::new),
-						systemIncludePaths.stream().toArray(String[]::new));
+						includePaths.stream().toArray(String[]::new));
 				infoPerResource.put(file, info);
 				haveUpdates = true;
 			}


### PR DESCRIPTION
Hi @kolipakakondal, @alirana01.

these changes are fixing this problem https://github.com/espressif/idf-eclipse-plugin/issues/346.
Also fixing some problems with the indexer on project examples, where the indexer was confused because he couldn't get some ESP-IDF headers when they were included as local headers. 

As an example, you can use the "wave_gen" project. 
Before -> indexer couldn't resolve #include "driver/timer.h" inclusion
Now -> Problem is gone. You can navigate to the definition of it and the project has 0 errors in the text editor either. 