### PR TITLE
IEP-553 GH #385: Need option for not download the program before debugging.

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -162,7 +162,7 @@ public class Configuration {
 		return executable;
 	}
 
-	public static Boolean getDoFlashBeforeStart(ILaunchConfiguration configuration) throws CoreException
+	public static boolean getDoFlashBeforeStart(ILaunchConfiguration configuration) throws CoreException
 	{
 		return configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, false);
 	}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -106,7 +106,7 @@ public class Configuration {
 				lst.addAll(StringUtils.splitCommandLineOptions(other));
 			}
 
-			if (ESPFlashUtil.checkIfJtagIsAvailable())
+			if (ESPFlashUtil.checkIfJtagIsAvailable() && getDoFlashBeforeStart(configuration))
 			{
 				lst.add(ESPFlashUtil.getEspJtagFlashCommand(configuration));
 			}
@@ -162,6 +162,10 @@ public class Configuration {
 		return executable;
 	}
 
+	public static Boolean getDoFlashBeforeStart(ILaunchConfiguration configuration) throws CoreException
+	{
+		return configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, false);
+	}
 	public static String[] getGdbClientCommandLineArray(ILaunchConfiguration configuration) {
 
 		List<String> lst = new ArrayList<String>();

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ConfigurationAttributes.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ConfigurationAttributes.java
@@ -51,6 +51,7 @@ public interface ConfigurationAttributes {
 
 	public static final String GDB_CLIENT_OTHER_COMMANDS = PREFIX + ".gdbClientOtherCommands"; //$NON-NLS-1$
 
+	public static final String DO_FLASH_BEFORE_START = PREFIX + ".doFlashBeforeStart"; //$NON-NLS-1$
 	// ------------------------------------------------------------------------
 
 	// TabStartup

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
@@ -46,6 +46,9 @@ public class Messages {
 	public static String IDFLaunchTargetNotFoundMsg2;
 	public static String IDFLaunchTargetNotFoundMsg3;
 
+	public static String StartupTabOpenOcdGroup;
+	public static String StartupTabFlashBeforeStart;
+
 	// ------------------------------------------------------------------------
 
 	static {

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -43,6 +43,7 @@ import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -55,6 +56,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Group;
@@ -166,6 +168,24 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			System.out.println("openocd.TabDebugger.createControl() ");
 		}
 
+		if (!(parent instanceof ScrolledComposite))
+		{
+			ScrolledComposite sc = new ScrolledComposite(parent, SWT.V_SCROLL | SWT.H_SCROLL);
+			sc.setFont(parent.getFont());
+			sc.setExpandHorizontal(true);
+			sc.setExpandVertical(true);
+			sc.setShowFocusedControl(true);
+			this.createControl(sc);
+			Control control = this.getControl();
+			if (control != null)
+			{
+				sc.setContent(control);
+				sc.setMinSize(control.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+				this.setControl(control.getParent());
+			}
+			return;
+
+		}
 		Composite comp = new Composite(parent, SWT.NONE);
 		setControl(comp);
 		GridLayout layout = new GridLayout();
@@ -275,14 +295,23 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		}
 
 		{
-			fDoStartGdbServer = new Button(comp, SWT.CHECK);
+			Composite local = new Composite(comp, SWT.NONE);
+			GridLayout layout = new GridLayout();
+			layout.numColumns = 1;
+			layout.marginHeight = 0;
+			layout.marginWidth = 0;
+			layout.makeColumnsEqualWidth = true;
+			local.setLayout(layout);
+			GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns;
+			local.setLayoutData(gd);
+
+			fDoStartGdbServer = new Button(local, SWT.CHECK);
 			fDoStartGdbServer.setText(Messages.getString("DebuggerTab.doStartGdbServer_Text"));
 			fDoStartGdbServer.setToolTipText(Messages.getString("DebuggerTab.doStartGdbServer_ToolTipText"));
-			GridData gd = new GridData();
-			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns;
+			gd = new GridData(GridData.FILL_HORIZONTAL);
 			fDoStartGdbServer.setLayoutData(gd);
 		}
-
 		{
 			Label label = new Label(comp, SWT.NONE);
 			label.setText(Messages.getString("DebuggerTab.gdbServerExecutable_Label"));
@@ -513,7 +542,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				});
 				fTargetName.setLayoutData(gd);
 			}
-
 		}
 
 		{
@@ -963,6 +991,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 			// OpenOCD GDB server
 			{
+
 				// Start server locally
 
 				booleanDefault = fPersistentPreferences.getGdbServerDoStart();

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabStartup.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabStartup.java
@@ -57,13 +57,12 @@ import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 import org.eclipse.ui.views.navigator.ResourceComparator;
 
-import com.espressif.idf.core.IDFEnvironmentVariables;
-import com.espressif.idf.core.util.EspConfigParser;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.IIDFGDBJtagConstants;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.PersistentPreferences;
+import com.espressif.idf.launch.serial.util.ESPFlashUtil;
 
 import ilg.gnumcueclipse.debug.gdbjtag.DebugUtils;
 
@@ -180,9 +179,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		setControl(comp);
 		GridLayout layout = new GridLayout();
 		comp.setLayout(layout);
-		EspConfigParser parser = new EspConfigParser();
-		String openOCDPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.OPENOCD_SCRIPTS);
-		if (!openOCDPath.isEmpty() && parser.hasBoardConfigJson())
+		if (ESPFlashUtil.checkIfJtagIsAvailable())
 		{
 			createOpenOcdGroup(comp);
 		}
@@ -263,19 +260,20 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			comp.setLayout(layout);
 			GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 			comp.setLayoutData(gd);
-		}
-
-		{
-			Composite local = new Composite(comp, SWT.NONE);
-			GridLayout layout = new GridLayout();
-			layout.numColumns = 1;
-			layout.marginHeight = 0;
-			layout.marginWidth = 0;
-			local.setLayout(layout);
-			fDoFlashBeforeStart = new Button(local, SWT.CHECK);
+			fDoFlashBeforeStart = new Button(comp, SWT.CHECK);
 			fDoFlashBeforeStart.setText(Messages.StartupTabFlashBeforeStart);
-
 		}
+
+//		{
+//			Composite local = new Composite(comp, SWT.NONE);
+//			GridLayout layout = new GridLayout();
+//			layout.numColumns = 1;
+//			layout.marginHeight = 0;
+//			layout.marginWidth = 0;
+//			local.setLayout(layout);
+//
+//
+//		}
 
 	}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
@@ -389,3 +389,6 @@ IDFLaunchTargetNotFoundMsg1=IDF Launch Target with
 IDFLaunchTargetNotFoundMsg2=\ is not found. 
 IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle=IDF Launch Target not found
 IDFLaunchTargetNotFoundMsg3=Do you want to create a new IDF launch target?
+
+StartupTabOpenOcdGroup=OpenOCD Options
+StartupTabFlashBeforeStart=Flash every time with application binaries


### PR DESCRIPTION
The OpenOCD Options composite has been added to the Startup tab with the "Flash every time with application binaries option". We can add more options in the future there, for example "OpenOCD log" with the command -d3 -l oocd.log.
<img width="1073" alt="Screenshot 2021-11-01 at 16 59 12" src="https://user-images.githubusercontent.com/24419842/139693023-5baa7f29-3621-48d3-8306-b7322037ac19.png">

Also, as part of the PR, scrollbars have been added to the Debugger and Startup tabs.
