### PR TITLE
IEP-562 Fix: Avoid appending to existing PATH env variable in CDT build

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
@@ -4,18 +4,13 @@
  *******************************************************************************/
 package com.espressif.idf.ui.update;
 
-import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
@@ -120,57 +115,8 @@ public class ExportIDFTools
 					value = appendGitToPath(value, gitExecutablePath);
 				}
 
-				final IEnvironmentVariable env = idfEnvMgr.getEnv(key);
-
-				// Environment variable not found
-				if (env == null)
-				{
-					idfEnvMgr.addEnvVariable(key, value);
-				}
-				else if (key.equals(IDFEnvironmentVariables.PATH)) // Special processing in case of PATH
-				{
-					// PATH is already defined in the environment variables - so let's identify and append the missing
-					// paths
-
-					// Process the old PATH
-					String oldPath = env.getValue();
-					String[] oldPathEntries = oldPath.split(File.pathSeparator);
-
-					// Prepare a new set of entries
-					Set<String> newPathSet = new LinkedHashSet<>(); // Order is important here, check IEP-60
-
-					// Process a new PATH
-					String[] newPathEntries = value.split(File.pathSeparator);
-					newPathSet.addAll(Arrays.asList(newPathEntries));
-
-					// Add old entries
-					newPathSet.addAll(Arrays.asList(oldPathEntries));
-
-					// Prepare PATH string
-					StringBuilder pathBuilder = new StringBuilder();
-					for (String newEntry : newPathSet)
-					{
-						newEntry = replacePathVariable(newEntry);
-						if (!StringUtil.isEmpty(newEntry))
-						{
-							pathBuilder.append(newEntry);
-							pathBuilder.append(File.pathSeparator);
-						}
-					}
-
-					// remove the last pathSeparator
-					pathBuilder.deleteCharAt(pathBuilder.length() - 1);
-
-					// Replace with a new PATH entry
-					Logger.log(pathBuilder.toString());
-					idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.PATH, pathBuilder.toString());
-				}
-				else
-				{
-					// Other build variables - let's replace with new values
-					idfEnvMgr.addEnvVariable(key, value);
-				}
-
+				// add new or replace old entries
+				idfEnvMgr.addEnvVariable(key, value);
 			}
 
 		}


### PR DESCRIPTION
We are having `python dependencies are not satisfied` issue with the Bosch customer. This has happened because they are having multiple versions of python versions installed and CMake build is picking up the python version from the system instead of python from the CDT build PATH.

Let's rely only on `idf.py export` command `PATH` output for building idf projects. That is having all the required paths and also don't see a need to append to the existing path. That basically avoids configuring multiple tool chains on the path environment also.

 