### PR TITLE
IEP-486: GH #315: SDK Configuration editor do not recognize Kconfig "menuconfig ...." line and it parameters.

### DIFF
--- a/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuItem.java
+++ b/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuItem.java
@@ -120,7 +120,7 @@ public class KConfigMenuItem
 		{
 			return false;
 		}
-
+		
 		if (getType() != null && getType().equals(IJsonServerConfig.MENU_TYPE))
 		{
 			return isVisible(children, visibleJsonMap);
@@ -156,6 +156,8 @@ public class KConfigMenuItem
 						return true;
 					}
 				}
+			} else if(kConfigMenuItem.isMenuConfig) {
+				return true;
 			}
 			else if (type.equals(IJsonServerConfig.MENU_TYPE))
 			{

--- a/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuItem.java
+++ b/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuItem.java
@@ -22,6 +22,7 @@ public class KConfigMenuItem
 	private String title;
 	private String type;
 	private String id;
+	private boolean isMenuConfig;
 
 	public KConfigMenuItem(KConfigMenuItem parent)
 	{
@@ -68,6 +69,11 @@ public class KConfigMenuItem
 	{
 		return type;
 	}
+	
+	public boolean isMenuConfig() 
+	{
+		return isMenuConfig;
+	}
 
 	public boolean hasChildren()
 	{
@@ -104,6 +110,10 @@ public class KConfigMenuItem
 		this.type = type;
 	}
 
+	public void setIsMenuConfig(boolean isMenuConfig) {
+		this.isMenuConfig = isMenuConfig;
+		
+	}
 	public boolean isVisible(JSONObject visibleJsonMap)
 	{
 		if (visibleJsonMap == null || visibleJsonMap.isEmpty())
@@ -160,4 +170,6 @@ public class KConfigMenuItem
 	{
 		return visibleJsonMap.get(configKey) != null ? (boolean) visibleJsonMap.get(configKey) : false;
 	}
+
+
 }

--- a/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuProcessor.java
+++ b/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuProcessor.java
@@ -85,7 +85,7 @@ public class KConfigMenuProcessor
 			childMenu.setType((String) jsonObject.get("type")); //$NON-NLS-1$
 			childMenu.setHelp((String) jsonObject.get("help")); //$NON-NLS-1$
 			if (jsonObject.get("is_menuconfig") != null) {
-				childMenu.setIsMenuConfig((boolean) jsonObject.get("is_menuconfig")); //$NON-NLS-1$
+				childMenu.setIsMenuConfig((boolean) jsonObject.get("is_menuconfig")); //$NON-NLS-1$ //$NON-NLS-2$ 
 			}
 		
 			String title = (String) jsonObject.get("title"); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuProcessor.java
+++ b/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/KConfigMenuProcessor.java
@@ -84,7 +84,10 @@ public class KConfigMenuProcessor
 			childMenu.setId((String) jsonObject.get("id")); //$NON-NLS-1$
 			childMenu.setType((String) jsonObject.get("type")); //$NON-NLS-1$
 			childMenu.setHelp((String) jsonObject.get("help")); //$NON-NLS-1$
-
+			if (jsonObject.get("is_menuconfig") != null) {
+				childMenu.setIsMenuConfig((boolean) jsonObject.get("is_menuconfig")); //$NON-NLS-1$
+			}
+		
 			String title = (String) jsonObject.get("title"); //$NON-NLS-1$
 			childMenu.setTitle(title);
 

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/ConfigContentProvider.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/ConfigContentProvider.java
@@ -100,6 +100,10 @@ public class ConfigContentProvider extends TreeNodeContentProvider
 				Logger.logTrace(SDKConfigUIPlugin.getDefault(), "item >" + kConfigMenuItem.getTitle() + " type >"+ kConfigMenuItem.getType()); //$NON-NLS-1$ //$NON-NLS-2$
 				
 				boolean visible = kConfigMenuItem.isVisible(visibleJsonMap);
+				if (!kConfigMenuItem.isMenuConfig())
+				{
+					visible = true;
+				}
 				Logger.logTrace(SDKConfigUIPlugin.getDefault(), "visibility >" + kConfigMenuItem.isVisible(visibleJsonMap)); //$NON-NLS-1$
 				if (visible)
 				{

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -97,6 +97,8 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 
 	private static final String ICONS_INFO_OBJ_GIF = "icons/help.gif"; //$NON-NLS-1$
 
+	private static final String ICONS_SDK_TOOL_CONFIG_PNG = "icons/sdk_tool_config.png";
+
 	private TreeViewer treeViewer;
 
 	private Group updateUIComposite;
@@ -611,7 +613,10 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 					: false);
 			Object newConfigValue = modifiedJsonMap.get(configKey);
 			String helpInfo = kConfigMenuItem.getHelp();
-
+			if (type.equals(IJsonServerConfig.MENU_TYPE))
+			{
+				isVisible = true;
+			}
 			if (isVisible && type.equals(IJsonServerConfig.STRING_TYPE))
 			{
 				Label labelName = new Label(updateUIComposite, SWT.NONE);
@@ -648,7 +653,7 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 				textControl.addModifyListener(addModifyListener(configKey, textControl));
 				addTooltipImage(kConfigMenuItem);
 			}
-			else if (isVisible && (type.equals(IJsonServerConfig.BOOL_TYPE) || kConfigMenuItem.isMenuConfig()))
+			else if (kConfigMenuItem.isMenuConfig())
 			{
 				Button button = new Button(updateUIComposite, SWT.CHECK);
 				button.setText(kConfigMenuItem.getTitle());
@@ -666,16 +671,45 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 						JSONObject jsonObj = new JSONObject();
 						jsonObj.put(configKey, button.getSelection());
 						executeCommand(jsonObj);
-						if(kConfigMenuItem.isMenuConfig()) {
-							renderMenuItems(kConfigMenuItem);
-						}
+						renderMenuItems(kConfigMenuItem);
 					}
 
 				});
 				addTooltipImage(kConfigMenuItem);
-				if (button.getSelection()) {
+
+				if (kConfigMenuItem.hasChildren())
+				{
+					button.setImage(SDKConfigUIPlugin.getImage(ICONS_SDK_TOOL_CONFIG_PNG));
+				}
+
+				if (button.getSelection())
+				{
 					renderMenuItems(kConfigMenuItem);
 				}
+			}
+			else if (isVisible && type.equals(IJsonServerConfig.BOOL_TYPE))
+			{
+				Button button = new Button(updateUIComposite, SWT.CHECK);
+				button.setText(kConfigMenuItem.getTitle());
+				button.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 2, 1));
+				button.setToolTipText(helpInfo);
+				if (configValue != null)
+				{
+					button.setSelection((boolean) configValue);
+				}
+				button.addSelectionListener(new SelectionAdapter()
+				{
+					@Override
+					public void widgetSelected(SelectionEvent e)
+					{
+						JSONObject jsonObj = new JSONObject();
+						jsonObj.put(configKey, button.getSelection());
+						executeCommand(jsonObj);
+					}
+
+				});
+				addTooltipImage(kConfigMenuItem);
+
 			}
 
 			else if (isVisible && type.equals(IJsonServerConfig.INT_TYPE))

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -648,7 +648,7 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 				textControl.addModifyListener(addModifyListener(configKey, textControl));
 				addTooltipImage(kConfigMenuItem);
 			}
-			else if (isVisible && type.equals(IJsonServerConfig.BOOL_TYPE))
+			else if (isVisible && (type.equals(IJsonServerConfig.BOOL_TYPE) || kConfigMenuItem.isMenuConfig()))
 			{
 				Button button = new Button(updateUIComposite, SWT.CHECK);
 				button.setText(kConfigMenuItem.getTitle());
@@ -666,10 +666,16 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 						JSONObject jsonObj = new JSONObject();
 						jsonObj.put(configKey, button.getSelection());
 						executeCommand(jsonObj);
+						if(kConfigMenuItem.isMenuConfig()) {
+							renderMenuItems(kConfigMenuItem);
+						}
 					}
 
 				});
 				addTooltipImage(kConfigMenuItem);
+				if (button.getSelection()) {
+					renderMenuItems(kConfigMenuItem);
+				}
 			}
 
 			else if (isVisible && type.equals(IJsonServerConfig.INT_TYPE))

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -97,7 +97,7 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 
 	private static final String ICONS_INFO_OBJ_GIF = "icons/help.gif"; //$NON-NLS-1$
 
-	private static final String ICONS_SDK_TOOL_CONFIG_PNG = "icons/sdk_tool_config.png";
+	private static final String ICONS_SDK_TOOL_CONFIG_PNG = "icons/sdk_tool_config.png"; //$NON-NLS-1$
 
 	private TreeViewer treeViewer;
 

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -613,10 +613,6 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 					: false);
 			Object newConfigValue = modifiedJsonMap.get(configKey);
 			String helpInfo = kConfigMenuItem.getHelp();
-			if (type.equals(IJsonServerConfig.MENU_TYPE))
-			{
-				isVisible = true;
-			}
 			if (isVisible && type.equals(IJsonServerConfig.STRING_TYPE))
 			{
 				Label labelName = new Label(updateUIComposite, SWT.NONE);
@@ -655,28 +651,16 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 			}
 			else if (kConfigMenuItem.isMenuConfig())
 			{
-				Button button = new Button(updateUIComposite, SWT.CHECK);
-				button.setText(kConfigMenuItem.getTitle());
-				button.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 2, 1));
-				button.setToolTipText(helpInfo);
-				if (configValue != null)
-				{
-					button.setSelection((boolean) configValue);
-				}
+				Button button = createCheckBox(kConfigMenuItem, configKey, configValue, helpInfo);
 				button.addSelectionListener(new SelectionAdapter()
 				{
 					@Override
 					public void widgetSelected(SelectionEvent e)
 					{
-						JSONObject jsonObj = new JSONObject();
-						jsonObj.put(configKey, button.getSelection());
-						executeCommand(jsonObj);
 						renderMenuItems(kConfigMenuItem);
 					}
 
 				});
-				addTooltipImage(kConfigMenuItem);
-
 				if (kConfigMenuItem.hasChildren())
 				{
 					button.setImage(SDKConfigUIPlugin.getImage(ICONS_SDK_TOOL_CONFIG_PNG));
@@ -686,30 +670,13 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 				{
 					renderMenuItems(kConfigMenuItem);
 				}
+
+
+
 			}
 			else if (isVisible && type.equals(IJsonServerConfig.BOOL_TYPE))
 			{
-				Button button = new Button(updateUIComposite, SWT.CHECK);
-				button.setText(kConfigMenuItem.getTitle());
-				button.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 2, 1));
-				button.setToolTipText(helpInfo);
-				if (configValue != null)
-				{
-					button.setSelection((boolean) configValue);
-				}
-				button.addSelectionListener(new SelectionAdapter()
-				{
-					@Override
-					public void widgetSelected(SelectionEvent e)
-					{
-						JSONObject jsonObj = new JSONObject();
-						jsonObj.put(configKey, button.getSelection());
-						executeCommand(jsonObj);
-					}
-
-				});
-				addTooltipImage(kConfigMenuItem);
-
+				createCheckBox(kConfigMenuItem, configKey, configValue, helpInfo);
 			}
 
 			else if (isVisible && type.equals(IJsonServerConfig.INT_TYPE))
@@ -799,6 +766,31 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 				renderMenuItems(kConfigMenuItem);
 			}
 		}
+	}
+
+	private Button createCheckBox(KConfigMenuItem kConfigMenuItem, String configKey, Object configValue,
+			String helpInfo) {
+		Button button = new Button(updateUIComposite, SWT.CHECK);
+		button.setText(kConfigMenuItem.getTitle());
+		button.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 2, 1));
+		button.setToolTipText(helpInfo);
+		if (configValue != null)
+		{
+			button.setSelection((boolean) configValue);
+		}
+		button.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				JSONObject jsonObj = new JSONObject();
+				jsonObj.put(configKey, button.getSelection());
+				executeCommand(jsonObj);
+			}
+
+		});
+		addTooltipImage(kConfigMenuItem);
+		return button;
 	}
 
 	protected boolean isExist(JSONObject jsonMap, String key)


### PR DESCRIPTION
PR summary:
- rendering menuconfig elements as bool type, so the user is able to enable/disable them
- by enabling/disabling menuconfig elements, corresponding menus will be added/removed in the treeview. 
- highlighting menuconfig elements by adding the icon.

before:
menuconfig element is missing, no way to enable/disable it 
<img width="982" alt="Screenshot 2021-11-09 at 10 49 28" src="https://user-images.githubusercontent.com/24419842/140892358-dfff2f36-bc70-474d-b290-7ea8420cbb54.png">

after:
disabled menuconfig
<img width="889" alt="Screenshot 2021-11-09 at 10 45 43" src="https://user-images.githubusercontent.com/24419842/140892426-dba187f4-f27a-454b-b075-00619c4c9ed5.png">
enabled menuconfig
<img width="891" alt="Screenshot 2021-11-08 at 17 47 57" src="https://user-images.githubusercontent.com/24419842/140892441-5a3337c4-75e5-4638-9845-a2b21f2390c9.png">


