### PR TITLE
IEP-574: Fix for update site installation on Eclipse 4.19

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
@@ -29,7 +29,7 @@ Require-Bundle: ilg.gnumcueclipse.debug.gdbjtag,
  ilg.gnumcueclipse.core,
  org.eclipse.cdt.debug.ui,
  com.espressif.idf.launch.serial.ui,
- org.eclipse.launchbar.ui;bundle-version="2.4.200"
+ org.eclipse.launchbar.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %bundle.vendor
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Here is the problem:
<img width="1440" alt="Screenshot 2021-11-12 at 1 16 27 PM" src="https://user-images.githubusercontent.com/8463287/141431162-fd5887fb-b52a-40e6-9688-3990d5ab5036.png">

mentioning a specific version for LaunchBar plugin is causing this issue.


