### PR TITLE
IEP-584: Logic fixed in finding the path from the system path

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/ExecutableFinder.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/ExecutableFinder.java
@@ -32,7 +32,11 @@ public class ExecutableFinder
 		for (String pathString : paths)
 		{
 			IPath path = Path.fromOSString(pathString).append(executableName);
-			return findExecutable(path, appendExtension);
+			IPath execPath = findExecutable(path, appendExtension);
+			if (execPath != null)
+			{
+				return execPath;
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
### Win OS: Git executable location is not found

The class `ExecutableFinder` was returning the match in find method for only the first path and if found it was okay if not it was null which it was for majority cases. Fixed that by adding null check and continuing the loop till it finds the path.

![image](https://user-images.githubusercontent.com/85216275/144027964-4b0c2b30-33ae-4023-a25a-f063ec79f4dd.png)
