### PR TITLE
IEP-540 Not opening Aplication Size Analysis on esp-idf 4.4 and higher

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -8,12 +8,16 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -22,7 +26,9 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import com.espressif.idf.core.ExecutableFinder;
 import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.build.ESP32C3ToolChain;
 import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
@@ -385,5 +391,44 @@ public class IDFUtil
 				+ IDFConstants.ESP_TOOL_FOLDER_PY + IPath.SEPARATOR + IDFConstants.ESP_TOOL_FOLDER + IPath.SEPARATOR
 				+ IDFConstants.ESP_TOOL_SCRIPT;
 		return new File(esp_tool_script);
+	}
+	
+	public static String getEspIdfVersion()
+	{
+		if (IDFUtil.getIDFPath() != null && IDFUtil.getIDFPythonEnvPath() != null)
+		{
+			List<String> commands = new ArrayList<>();
+			commands.add(IDFUtil.getIDFPythonEnvPath());
+			commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+			commands.add("--version"); //$NON-NLS-1$
+			Map<String, String> envMap = new IDFEnvironmentVariables().getEnvMap();
+			return runCommand(commands, envMap);
+		}
+		
+		return ""; //$NON-NLS-1$
+	}
+	
+	private static String runCommand(List<String> arguments, Map<String, String> env)
+	{
+		String exportCmdOp = ""; //$NON-NLS-1$
+		ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
+		try
+		{
+			IStatus status = processRunner.runInBackground(arguments, Path.ROOT, env);
+			if (status == null)
+			{
+				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
+				return exportCmdOp;
+			}
+
+			// process export command output
+			exportCmdOp = status.getMessage();
+			Logger.log(exportCmdOp);
+		}
+		catch (Exception e1)
+		{
+			Logger.log(IDFCorePlugin.getPlugin(), e1);
+		}
+		return exportCmdOp;
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
@@ -53,9 +53,9 @@ public class IDFSizeConstants {
 	public static String USED_DIRAM_RATIO = "used_diram_ratio"; //$NON-NLS-1$
 	
 	static {
-		String versing = getEspIdfVersion();
+		String version = IDFUtil.getEspIdfVersion();
 		Pattern p = Pattern.compile("([0-9][.][0-9])"); //$NON-NLS-1$
-		Matcher m = p.matcher(versing);
+		Matcher m = p.matcher(version);
 		if (m.find() && Double.parseDouble(m.group(0)) > 4.3) {
 			FLASH_RODATA_OVERVIEW = "flash_rodata"; //$NON-NLS-1$
 			DATA = ".dram0.data"; // DRAM .data //$NON-NLS-1$
@@ -85,44 +85,4 @@ public class IDFSizeConstants {
 			USED_DIRAM_RATIO = "used_diram_ratio"; //$NON-NLS-1$
 		}
 	}
-	
-	private static String getEspIdfVersion()
-	{
-		if (IDFUtil.getIDFPath() != null && IDFUtil.getIDFPythonEnvPath() != null)
-		{
-			List<String> commands = new ArrayList<>();
-			commands.add(IDFUtil.getIDFPythonEnvPath());
-			commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
-			commands.add("--version"); //$NON-NLS-1$
-			Map<String, String> envMap = new IDFEnvironmentVariables().getEnvMap();
-			return runCommand(commands, envMap);
-		}
-		
-		return ""; //$NON-NLS-1$
-	}
-	
-	private static String runCommand(List<String> arguments, Map<String, String> env)
-	{
-		String exportCmdOp = ""; //$NON-NLS-1$
-		ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
-		try
-		{
-			IStatus status = processRunner.runInBackground(arguments, Path.ROOT, env);
-			if (status == null)
-			{
-				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
-
-			}
-
-			// process export command output
-			exportCmdOp = status.getMessage();
-			Logger.log(exportCmdOp);
-		}
-		catch (Exception e1)
-		{
-			Logger.log(IDFCorePlugin.getPlugin(), e1);
-		}
-		return exportCmdOp;
-	}
-
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
@@ -1,3 +1,7 @@
+/*******************************************************************************
+ * Copyright 2020 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.ui.size;
 
 import java.util.ArrayList;
@@ -14,8 +18,11 @@ import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.ui.update.Messages;
 
+/**
+ * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
+ *
+ */
 public class IDFSizeConstants {
 
 	public static String DATA = "data"; // DRAM .data //$NON-NLS-1$

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
@@ -1,40 +1,121 @@
-/*******************************************************************************
- * Copyright 2020 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
- * Use is subject to license terms.
- *******************************************************************************/
 package com.espressif.idf.ui.size;
 
-/**
- * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
- *
- */
-public interface IDFSizeConstants
-{
-	String DATA = "data"; // DRAM .data //$NON-NLS-1$
-	String BSS = "bss"; // DRAM .bss //$NON-NLS-1$
-	String IRAM = "iram"; //$NON-NLS-1$
-	String DIRAM = "diram"; //$NON-NLS-1$
-	String FLASH_TEXT = "flash_text"; //$NON-NLS-1$
-	String FLASH_RODATA = "flash_rodata"; //$NON-NLS-1$
-	String OTHER = "other"; //$NON-NLS-1$
-	String TOTAL = "total"; //$NON-NLS-1$
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.ProcessBuilderFactory;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.ui.update.Messages;
+
+public class IDFSizeConstants {
+
+	public static String DATA = "data"; // DRAM .data //$NON-NLS-1$
+	public static String BSS = "bss"; // DRAM .bss //$NON-NLS-1$
+	public static String IRAM = "iram"; //$NON-NLS-1$
+	public static String DIRAM = "diram"; //$NON-NLS-1$
+	public static String FLASH_TEXT = "flash_text"; //$NON-NLS-1$
+	public static String FLASH_RODATA = "flash_rodata"; //$NON-NLS-1$
+	public static String OTHER = "other"; //$NON-NLS-1$
+	public static String TOTAL = "total"; //$NON-NLS-1$
 
 	//idf_size.py overview constants
-	String DRAM_DATA = "dram_data"; //$NON-NLS-1$
-	String DRAM_BSS = "dram_bss"; //$NON-NLS-1$
-	String FLASH_CODE = "flash_code"; //$NON-NLS-1$
-	String TOTAL_SIZE = "total_size"; //$NON-NLS-1$
-	String USED_IRAM = "used_iram"; //$NON-NLS-1$
-	String AVAILABLE_IRAM = "available_iram"; //$NON-NLS-1$
-	String USED_IRAM_RATIO = "used_iram_ratio"; //$NON-NLS-1$
-	String USED_DRAM = "used_dram"; //$NON-NLS-1$
-	String AVAILABLE_DRAM = "available_dram"; //$NON-NLS-1$
-	String USED_DRAM_RATIO = "used_dram_ratio"; //$NON-NLS-1$
+	public static String FLASH_RODATA_OVERVIEW = "flash_rodata"; //$NON-NLS-1$
+	public static String DRAM_DATA = "dram_data"; //$NON-NLS-1$
+	public static String DRAM_BSS = "dram_bss"; //$NON-NLS-1$
+	public static String FLASH_CODE = "flash_code"; //$NON-NLS-1$
+	public static String TOTAL_SIZE = "total_size"; //$NON-NLS-1$
+	public static String USED_IRAM = "used_iram"; //$NON-NLS-1$
+	public static String AVAILABLE_IRAM = "available_iram"; //$NON-NLS-1$
+	public static String USED_IRAM_RATIO = "used_iram_ratio"; //$NON-NLS-1$
+	public static String USED_DRAM = "used_dram"; //$NON-NLS-1$
+	public static String AVAILABLE_DRAM = "available_dram"; //$NON-NLS-1$
+	public static String USED_DRAM_RATIO = "used_dram_ratio"; //$NON-NLS-1$
 	
 	//esp32-s2 specific
-	String USED_DIRAM = "used_diram"; //$NON-NLS-1$
-	String AVAILABLE_DIRAM = "available_diram"; //$NON-NLS-1$
-	String USED_DIRAM_RATIO = "used_diram_ratio"; //$NON-NLS-1$
+	public static String USED_DIRAM = "used_diram"; //$NON-NLS-1$
+	public static String AVAILABLE_DIRAM = "available_diram"; //$NON-NLS-1$
+	public static String USED_DIRAM_RATIO = "used_diram_ratio"; //$NON-NLS-1$
 	
+	static {
+		String versing = getEspIdfVersion();
+		Pattern p = Pattern.compile("([0-9][.][0-9])"); //$NON-NLS-1$
+		Matcher m = p.matcher(versing);
+		if (m.find() && Double.parseDouble(m.group(0)) > 4.3) {
+			FLASH_RODATA_OVERVIEW = "flash_rodata"; //$NON-NLS-1$
+			DATA = ".dram0.data"; // DRAM .data //$NON-NLS-1$
+			BSS = ".dram0.bss"; // DRAM .bss //$NON-NLS-1$
+			IRAM = ".iram0.text"; //$NON-NLS-1$
+			DIRAM = "diram"; //$NON-NLS-1$
+			FLASH_TEXT = ".flash.text"; //$NON-NLS-1$
+			FLASH_RODATA = ".flash.rodata"; //$NON-NLS-1$
+			OTHER = "ram_st_total"; //$NON-NLS-1$
+			TOTAL = "flash_total"; //$NON-NLS-1$
+
+			//idf_size.py overview constants
+			DRAM_DATA = "dram_data"; //$NON-NLS-1$
+			DRAM_BSS = "dram_bss"; //$NON-NLS-1$
+			FLASH_CODE = "flash_code"; //$NON-NLS-1$
+			TOTAL_SIZE = "total_size"; //$NON-NLS-1$
+			USED_IRAM = "used_iram"; //$NON-NLS-1$
+			AVAILABLE_IRAM = "iram_remain"; //$NON-NLS-1$
+			USED_IRAM_RATIO = "used_iram_ratio"; //$NON-NLS-1$
+			USED_DRAM = "used_dram"; //$NON-NLS-1$
+			AVAILABLE_DRAM = "dram_remain"; //$NON-NLS-1$
+			USED_DRAM_RATIO = "used_dram_ratio"; //$NON-NLS-1$
+			
+			//esp32-s2 specific
+			USED_DIRAM = "used_diram"; //$NON-NLS-1$
+			AVAILABLE_DIRAM = "diram_remain"; //$NON-NLS-1$
+			USED_DIRAM_RATIO = "used_diram_ratio"; //$NON-NLS-1$
+		}
+	}
+	
+	private static String getEspIdfVersion()
+	{
+		if (IDFUtil.getIDFPath() != null && IDFUtil.getIDFPythonEnvPath() != null)
+		{
+			List<String> commands = new ArrayList<>();
+			commands.add(IDFUtil.getIDFPythonEnvPath());
+			commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+			commands.add("--version"); //$NON-NLS-1$
+			Map<String, String> envMap = new IDFEnvironmentVariables().getEnvMap();
+			return runCommand(commands, envMap);
+		}
+		
+		return ""; //$NON-NLS-1$
+	}
+	
+	private static String runCommand(List<String> arguments, Map<String, String> env)
+	{
+		String exportCmdOp = ""; //$NON-NLS-1$
+		ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
+		try
+		{
+			IStatus status = processRunner.runInBackground(arguments, Path.ROOT, env);
+			if (status == null)
+			{
+				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
+
+			}
+
+			// process export command output
+			exportCmdOp = status.getMessage();
+			Logger.log(exportCmdOp);
+		}
+		catch (Exception e1)
+		{
+			Logger.log(IDFCorePlugin.getPlugin(), e1);
+		}
+		return exportCmdOp;
+	}
 
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -58,6 +58,7 @@ public class IDFSizeDataManager
 		String pythonExecutablePath = preconditionsCheck();
 		List<String> commandArgs = getCommandArgs(pythonExecutablePath, mapFile, targetName);
 		String detailsJsonOp = getOutput(mapFile, commandArgs);
+		detailsJsonOp = detailsJsonOp.replace("NaN", "0");
 		if (!StringUtil.isEmpty(detailsJsonOp))
 		{
 			return getJSON(detailsJsonOp);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -58,7 +58,7 @@ public class IDFSizeDataManager
 		String pythonExecutablePath = preconditionsCheck();
 		List<String> commandArgs = getCommandArgs(pythonExecutablePath, mapFile, targetName);
 		String detailsJsonOp = getOutput(mapFile, commandArgs);
-		detailsJsonOp = detailsJsonOp.replace("NaN", "0");
+		detailsJsonOp = detailsJsonOp.replace("NaN", "0"); //$NON-NLS-1$ //$NON-NLS-2$ 
 		if (!StringUtil.isEmpty(detailsJsonOp))
 		{
 			return getJSON(detailsJsonOp);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDetailsComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDetailsComposite.java
@@ -31,6 +31,10 @@ public class IDFSizeDetailsComposite
 	private TreeViewer treeViewer;
 	private String columnProperties[] = new String[] { "File Name", "DRAM .data", "DRAM .bss", "DIRAM", "IRAM", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 			"Flash Code", "Flash rodata", "Other", "Total" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	
+	//For ESP-IDF 4.4 and higher
+	private String columnPropertiesV2[] = new String[] { "File Name", "DRAM .data", "DRAM .bss", "DIRAM", "IRAM", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+			"Flash Code", "Flash rodata", "Ram Total", "Flash Total" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
 	public void createPartControl(Composite parent, IFile iFile)
 	{
@@ -58,7 +62,10 @@ public class IDFSizeDetailsComposite
 		treeViewer.getTree().setLayoutData(new GridData(GridData.FILL_BOTH));
 
 		IDFSizeComparator comparator = new IDFSizeComparator();
-
+		if (IDFSizeConstants.OTHER != "other") { //$NON-NLS-1$ 
+			columnProperties[7] = "Ram Total"; //$NON-NLS-1$ 
+			columnProperties[8] = "Flash Total"; //$NON-NLS-1$ 
+		}
 		for (int i = 0; i < columnProperties.length; i++)
 		{
 			TreeColumn tc = new TreeColumn(tree, SWT.NONE, i);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDetailsComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDetailsComposite.java
@@ -32,10 +32,6 @@ public class IDFSizeDetailsComposite
 	private String columnProperties[] = new String[] { "File Name", "DRAM .data", "DRAM .bss", "DIRAM", "IRAM", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 			"Flash Code", "Flash rodata", "Other", "Total" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	
-	//For ESP-IDF 4.4 and higher
-	private String columnPropertiesV2[] = new String[] { "File Name", "DRAM .data", "DRAM .bss", "DIRAM", "IRAM", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-			"Flash Code", "Flash rodata", "Ram Total", "Flash Total" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-
 	public void createPartControl(Composite parent, IFile iFile)
 	{
 		PatternFilter patternFilter = new IDFSizePatternFilter();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
@@ -55,12 +55,11 @@ public class IDFSizeOverviewComposite
 		ec2.setClient(overviewComp);
 
 		overviewJson = getIDFSizeOverviewData(file, targetName);
-		long dram_data = (long) overviewJson.get(IDFSizeConstants.DRAM_DATA);
+		long dram_data = (long) overviewJson.get(IDFSizeConstants.AVAILABLE_DIRAM);
 		long dram_bss = (long) overviewJson.get(IDFSizeConstants.DRAM_BSS);
 		long flash_code = (long) overviewJson.get(IDFSizeConstants.FLASH_CODE);
-		long flash_rodata = (long) overviewJson.get(IDFSizeConstants.FLASH_RODATA);
+		long flash_rodata = (long) overviewJson.get(IDFSizeConstants.FLASH_RODATA_OVERVIEW);
 		long total_size = (long) overviewJson.get(IDFSizeConstants.TOTAL_SIZE);
-
 		Label sizeLbl = toolkit.createLabel(overviewComp, Messages.IDFSizeOverviewComposite_TotalSize);
 		Label sizeVal = toolkit.createLabel(overviewComp, convertToKB(total_size));
 
@@ -108,7 +107,7 @@ public class IDFSizeOverviewComposite
 		}
 
 	}
-
+	
 	private void plotSingleBar()
 	{
 		// esps2-s2 specific


### PR DESCRIPTION
Application Size Analysis is now working with all versions of the esp-idf.
Tested on Esp-idf 4.2, 4.3, 4.4 and 5.0. Windows10 and macOS. 

also works with different targets:
esp32 -
<img width="934" alt="Screenshot 2021-12-10 at 9 50 16" src="https://user-images.githubusercontent.com/24419842/145537501-1a63cfca-7a20-47cb-979b-b1a0776b9a79.png">

esp32c3 with single diram column:
<img width="936" alt="Screenshot 2021-12-10 at 9 52 31" src="https://user-images.githubusercontent.com/24419842/145537573-b872b6ec-89ae-4ecd-8b3d-34fab542a699.png">

for ESP-IDF 4.4 and higher, in the details, columns Other and Total have been changed to Ram Total and Flash Total accordingly
 