### PR TITLE
IEP-542 Serial port was not found error while JTAG flashing

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.core.variables,
  com.espressif.idf.core,
  com.espressif.idf.ui,
- com.espressif.idf.terminal.connector.serial
+ com.espressif.idf.terminal.connector.serial,
+ org.eclipse.launchbar.ui
 Export-Package: com.espressif.idf.launch.serial,
  com.espressif.idf.launch.serial.core,
  com.espressif.idf.launch.serial.internal,


### PR DESCRIPTION
The "Serial port not found" error does not occur when the user selects "flash over jtag" in the launch configuration.
But I decided to edit this error message anyway to make it more user-friendly. Instead of showing an error, we now guide the user to edit their launch target, where they can select a serial port.
How to reproduce:

1. Create the launch target without selecting the serial port
2. Flash the project over UART
3. You will see confirm dialog, click OK
<img width="659" alt="Screenshot 2021-12-30 at 11 46 02" src="https://user-images.githubusercontent.com/24419842/147741747-68daf81a-279a-417e-aa4b-20398a601f5e.png">
4. Now you will see the "Edit launch target" dialog, where you can select the Serial Port
<img width="670" alt="Screenshot 2021-12-30 at 11 47 00" src="https://user-images.githubusercontent.com/24419842/147742128-ce76f233-56af-4733-96aa-c899f53d78cf.png">