### PR TITLE
IEP-525 Show Application RAM and flash usage info after the build

### DIFF
--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jgit,
  org.eclipse.cdt.jsoncdb.core,
  org.eclipse.cdt.jsoncdb.core.ui,
- org.eclipse.cdt.cmake.ui
+ org.eclipse.cdt.cmake.ui,
+ org.eclipse.swt
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy
@@ -37,3 +38,6 @@ Bundle-ClassPath: .,
  lib/commons-collections4-4.4.jar,
  lib/commons-io-2.9.0.jar,
  lib/commons-lang3-3.12.0.jar
+Import-Package: org.eclipse.jface.dialogs,
+ org.eclipse.jface.layout,
+ org.eclipse.jface.window

--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -20,9 +20,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.debug.core;visibility:=reexport,
  org.eclipse.jgit,
  org.eclipse.cdt.jsoncdb.core,
- org.eclipse.cdt.jsoncdb.core.ui,
- org.eclipse.cdt.cmake.ui,
- org.eclipse.swt
+ org.eclipse.cdt.jsoncdb.core.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy
@@ -38,6 +36,3 @@ Bundle-ClassPath: .,
  lib/commons-collections4-4.4.jar,
  lib/commons-io-2.9.0.jar,
  lib/commons-lang3-3.12.0.jar
-Import-Package: org.eclipse.jface.dialogs,
- org.eclipse.jface.layout,
- org.eclipse.jface.window

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -584,7 +584,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 	private IPath getMapFilePath(IProject project)
 	{
 		GenericJsonReader jsonReader = new GenericJsonReader(project,
-				"build" + File.separator + "project_description.json"); //$NON-NLS-1$ //$NON-NLS-2$
+				IDFConstants.BUILD_FOLDER + File.separator + "project_description.json"); //$NON-NLS-1$
 		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
 		if (!StringUtil.isEmpty(value))
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -72,13 +72,18 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.internal.CMakeConsoleWrapper;
 import com.espressif.idf.core.internal.CMakeErrorParser;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.DataSizeUtil;
+import com.espressif.idf.core.util.GenericJsonReader;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.MessageLinkDialog;
+import com.espressif.idf.core.util.StringUtil;
 import com.google.gson.Gson;
 
 @SuppressWarnings(value = { "restriction" })
@@ -360,29 +365,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 
 				watchProcess(p, new IConsoleParser[] { epm });
 				
-				List<String> commands = new ArrayList<>();
-				commands.add(IDFUtil.getIDFPythonEnvPath());
-				commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
-				commands.add("size");
-
-				infoStream.write(String.join(" ", commands) + '\n'); //$NON-NLS-1$
-				workingDir = (org.eclipse.core.runtime.Path) project.getLocation();
-				ProcessBuilder processBuilder = new ProcessBuilder(commands).directory(workingDir.toFile());
-				// Override environment variables
-				Map<String, String> environment = processBuilder.environment();
-				for (IEnvironmentVariable envVar : envVars) {
-					environment.put(envVar.getName(), envVar.getValue());
-				}
-				setBuildEnvironment(environment);
-				Process process = processBuilder.start();
-				if (process == null) {
-					console.getErrorStream().write(String
-							.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
-					return null;
-				}
-				console.getOutputStream().write(process.getInputStream().readAllBytes());
-				//watchProcess(process, new IConsoleParser[] { epm });
-				
 				final String isSkip = System.getProperty("skip.idf.components"); //$NON-NLS-1$
 				if(!Boolean.parseBoolean(isSkip)) { //no property defined
 					linkBuildComponents(project, monitor);
@@ -401,6 +383,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 
 				Instant finish = Instant.now();
 				long timeElapsed = Duration.between(start, finish).toMillis();
+				startIdfSizeProcess(console, project, infoStream);
+				checkRemainingSize(console, project, infoStream);
 				infoStream.write(MessageFormat.format("Total time taken to build the project: {0} ms", timeElapsed)); //$NON-NLS-1$
 			}
 
@@ -414,6 +398,83 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 							project.getName()),
 					e));
 		}
+	}
+
+	private void checkRemainingSize(IConsole console, IProject project, ConsoleOutputStream infoStream)
+			throws IOException, CoreException
+	{
+		String partitionTableContent = getPartitionTable(project, infoStream);
+		Path path = Paths.get(project.getLocation() + File.separator + IDFConstants.BUILD_FOLDER + File.separator
+				+ project.getName() + ".bin"); //$NON-NLS-1$
+		long imageSize = Files.size(path);
+
+		String[] lines = partitionTableContent.split("\n"); //$NON-NLS-1$
+		for (String line : lines)
+		{
+			if (!line.contains("app")) //$NON-NLS-1$
+			{
+				continue;
+			}
+			String[] columns = line.split(","); //$NON-NLS-1$
+			double maxSize = DataSizeUtil.parseSize(columns[4]);
+			double remainSize = 100 * (maxSize - imageSize) / (maxSize);
+			if (remainSize < 30)
+			{
+				showMessage();
+				break;
+			}
+		}
+	}
+
+	private String getPartitionTable(IProject project, ConsoleOutputStream infoStream) throws IOException
+	{
+		List<String> commands;
+		commands = new ArrayList<>();
+		commands.add(IDFUtil.getIDFPythonEnvPath());
+		commands.add(IDFUtil.getIDFPath() + "/components/partition_table/gen_esp32part.py"); //$NON-NLS-1$
+		commands.add(project.getLocation() + "/build/partition_table/partition-table.bin"); //$NON-NLS-1$
+
+		Process process = startProcess(project, infoStream, commands);
+		String partitionTableContent = new String(process.getInputStream().readAllBytes());
+		return partitionTableContent;
+	}
+
+	private Process startProcess(IProject project, ConsoleOutputStream infoStream, List<String> commands)
+			throws IOException
+	{
+		infoStream.write(String.join(" ", commands) + '\n'); //$NON-NLS-1$
+		org.eclipse.core.runtime.Path workingDir = (org.eclipse.core.runtime.Path) project.getLocation();
+		ProcessBuilder processBuilder = new ProcessBuilder(commands).directory(workingDir.toFile());
+		Process process = processBuilder.start();
+		return process;
+	}
+	
+	private static void showMessage() {
+
+		Display.getDefault().asyncExec(new Runnable() {
+			@Override
+			public void run() {
+				MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
+						Messages.IncreasePartitionSizeTitle,
+						Messages.IncreasePartitionSizeMessage);
+			}
+		});
+	}
+
+	private void startIdfSizeProcess(IConsole console, IProject project, ConsoleOutputStream infoStream)
+			throws IOException, CoreException
+	{
+		List<String> commands = new ArrayList<>();
+		commands.add(IDFUtil.getIDFPythonEnvPath());
+		commands.add(IDFUtil.getIDFSizeScriptFile().getAbsolutePath());
+		commands.add(getMapFilePath(project).toString());
+
+		Process process = startProcess(project, infoStream, commands);
+		if (process != null)
+		{
+			console.getOutputStream().write(process.getInputStream().readAllBytes());
+		}
+
 	}
 	
 	public void update(IProject project) {
@@ -518,6 +579,20 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 			setLinkLocation(folderLink, new org.eclipse.core.runtime.Path(sourceFile));
 
 		}
+	}
+
+	private IPath getMapFilePath(IProject project)
+	{
+		GenericJsonReader jsonReader = new GenericJsonReader(project,
+				"build" + File.separator + "project_description.json"); //$NON-NLS-1$ //$NON-NLS-2$
+		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
+		if (!StringUtil.isEmpty(value))
+		{
+			value = value.replace(".elf", ".map"); // Assuming .elf and .map files have the //$NON-NLS-1$ //$NON-NLS-2$
+													// same file name
+			return project.getFile(new org.eclipse.core.runtime.Path("build").append(value)).getLocation(); //$NON-NLS-1$
+		}
+		return null;
 	}
 
 	protected int getUpdateOptions()

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -23,6 +23,9 @@ public class Messages extends NLS
 	public static String CMakeBuildConfiguration_Failure;
 	public static String CMakeErrorParser_NotAWorkspaceResource;
 	public static String IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile;
+	public static String IncreasePartitionSizeTitle;
+	public static String IncreasePartitionSizeMessage;
+
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -15,3 +15,5 @@ CMakeBuildConfiguration_ProcCompJson=Processing compile_commands.json
 CMakeBuildConfiguration_Failure=Failure running cmake: %s\n
 CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource. Did the build run in a container?
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
+IncreasePartitionSizeTitle=Low Application Partition Size
+IncreasePartitionSizeMessage=Consider increasing the application partition size, see <a href=\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\">link</a> for details.

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -16,4 +16,4 @@ CMakeBuildConfiguration_Failure=Failure running cmake: %s\n
 CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource. Did the build run in a container?
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
 IncreasePartitionSizeTitle=Low Application Partition Size
-IncreasePartitionSizeMessage=Consider increasing the application partition size, see <a href=\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\">link</a> for details.
+IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/OpenDialogListenerSupport.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/OpenDialogListenerSupport.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.resources;
+
+import java.beans.PropertyChangeSupport;
+
+public class OpenDialogListenerSupport
+{
+	private static PropertyChangeSupport support;
+
+	public static PropertyChangeSupport getSupport()
+	{
+		if (support == null)
+		{
+			support = new PropertyChangeSupport(new Object());
+		}
+		return support;
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/DataSizeUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/DataSizeUtil.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+/**
+ * Utility class for getting size in bytes. Size can be specified as decimal numbers, hex numbers with the prefix 0x, or
+ * size multipliers K or M (1024 and 1024*1024 bytes).
+ * 
+ * @author Denys Almazov
+ *
+ */
+public class DataSizeUtil
+{
+	private static final long K = 1024;
+	private static final long M = K * K;
+	private static final String M_MULTIPIER = "M"; //$NON-NLS-1$
+	private static final String K_MULTIPIER = "K"; //$NON-NLS-1$
+	private static final String HEX_PREFIX = "0x"; //$NON-NLS-1$
+
+	public static long parseSize(String size) {
+
+		long sizeInBytes;
+		if (size.contains(M_MULTIPIER))
+		{
+			sizeInBytes = Integer.parseInt(size.replace(M_MULTIPIER, "")) * M; //$NON-NLS-1$
+		}
+		else if (size.contains(K_MULTIPIER))
+		{
+			sizeInBytes = Integer.parseInt(size.replace(K_MULTIPIER, "")) * K; //$NON-NLS-1$
+		}
+		else if (size.contains(HEX_PREFIX))
+		{
+			sizeInBytes = Integer.parseInt(size.substring(2), 16);
+		}
+		else
+		{
+			sizeInBytes = Integer.parseInt(size);
+		}
+			
+		return sizeInBytes;
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/MessageLinkDialog.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * 	   Lars Vogel <Lars.Vogel@vogella.com> - Bug 472690
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+
+public class MessageLinkDialog extends MessageDialog
+{
+
+	public MessageLinkDialog(Shell parentShell, String dialogTitle, Image dialogTitleImage, String dialogMessage,
+			int dialogImageType, int defaultIndex, String[] dialogButtonLabels)
+	{
+		super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, defaultIndex, dialogButtonLabels);
+	}
+	
+	@Override
+	protected Control createMessageArea(Composite composite)
+	{
+	    Image image = getImage();
+		if (image != null)
+		{
+			imageLabel = new Label(composite, SWT.NULL);
+			image.setBackground(imageLabel.getBackground());
+			imageLabel.setImage(image);
+			GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.BEGINNING).applyTo(imageLabel);
+	    }
+		if (message != null)
+		{
+			Link link = new Link(composite, getMessageLabelStyle());
+			link.setText(message);
+			link.addListener(SWT.Selection, new Listener()
+			{
+				@Override
+				public void handleEvent(Event event)
+				{
+					Program.launch(event.text);
+
+				}
+			});
+			GridDataFactory.fillDefaults().align(SWT.FILL, SWT.BEGINNING).grab(true, false)
+					.hint(convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH), SWT.DEFAULT)
+					.applyTo(link);
+	    }
+	    return composite;
+	}
+
+	public static void openWarning(Shell parent, String title, String message)
+	{
+		open(WARNING, parent, title, message, SWT.NONE);
+	}
+
+	public static boolean open(int kind, Shell parent, String title, String message, int style)
+	{
+		MessageLinkDialog dialog = new MessageLinkDialog(parent, title, null, message, kind, 0,
+				new String[] { IDialogConstants.OK_LABEL });
+		style &= SWT.SHEET;
+		dialog.setShellStyle(dialog.getShellStyle() | style);
+		return dialog.open() == 0;
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/MessageLinkDialog.java
@@ -14,12 +14,17 @@
  *******************************************************************************/
 package com.espressif.idf.core.util;
 
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -30,11 +35,14 @@ import org.eclipse.swt.widgets.Shell;
 
 public class MessageLinkDialog extends MessageDialog
 {
+	private static final String DO_NOT_SHOW_MSG = "DO_NOT_SHOW_MSG"; //$NON-NLS-1$
+	private static IEclipsePreferences preferences;
 
 	public MessageLinkDialog(Shell parentShell, String dialogTitle, Image dialogTitleImage, String dialogMessage,
 			int dialogImageType, int defaultIndex, String[] dialogButtonLabels)
 	{
-		super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, defaultIndex, dialogButtonLabels);
+		super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, defaultIndex,
+				dialogButtonLabels);
 	}
 	
 	@Override
@@ -68,9 +76,36 @@ public class MessageLinkDialog extends MessageDialog
 	    return composite;
 	}
 
+	@Override
+	protected Control createCustomArea(Composite parent)
+	{
+		Button checkBox = new Button(parent, SWT.CHECK);
+		checkBox.addSelectionListener(new SelectionListener()
+		{
+
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				preferences.putBoolean(DO_NOT_SHOW_MSG, checkBox.getSelection());
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e)
+			{
+			}
+
+		});
+		checkBox.setText(Messages.MsgLinkDialog_DoNotShowMsg);
+		return parent;
+	}
+
 	public static void openWarning(Shell parent, String title, String message)
 	{
-		open(WARNING, parent, title, message, SWT.NONE);
+		preferences = InstanceScope.INSTANCE.getNode("com.espressif.idf.launch.serial.ui"); //$NON-NLS-1$
+		if (!preferences.getBoolean(DO_NOT_SHOW_MSG, false))
+		{
+			open(WARNING, parent, title, message, SWT.NONE);
+		}
 	}
 
 	public static boolean open(int kind, Shell parent, String title, String message, int style)
@@ -81,5 +116,4 @@ public class MessageLinkDialog extends MessageDialog
 		dialog.setShellStyle(dialog.getShellStyle() | style);
 		return dialog.open() == 0;
 	}
-
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
@@ -19,6 +19,7 @@ public class Messages extends NLS {
 	public static String FileUtil_UnableToCopy;
 	public static String FileUtil_WritableProblemMsg;
 	public static String IDFUtil_CouldNotFindDir;
+	public static String MsgLinkDialog_DoNotShowMsg;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.cdt.core.ConsoleOutputStream;
+import org.eclipse.cdt.core.resources.IConsole;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+
+import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.resources.OpenDialogListenerSupport;
+
+public class ParitionSizeHandler
+{
+	private IProject project;
+	private ConsoleOutputStream infoStream;
+	private IConsole console;
+	
+	public ParitionSizeHandler(IProject project, ConsoleOutputStream infoStream, IConsole console)
+	{
+		this.project = project;
+		this.infoStream = infoStream;
+		this.console = console;
+	}
+
+	// checking the size consists of the idf_size.py command and checking the remaining size from the partition table
+	public void startCheckingSize() throws IOException, CoreException
+	{
+		startIdfSizeProcess();
+		checkRemainingSize();
+	}
+	
+	private String getPartitionTable() throws IOException
+	{
+		List<String> commands;
+		commands = new ArrayList<>();
+		commands.add(IDFUtil.getIDFPythonEnvPath());
+		commands.add(IDFUtil.getIDFPath() + "/components/partition_table/gen_esp32part.py"); //$NON-NLS-1$
+		commands.add(project.getLocation() + "/build/partition_table/partition-table.bin"); //$NON-NLS-1$
+
+		Process process = startProcess(commands);
+		String partitionTableContent = new String(process.getInputStream().readAllBytes());
+		return partitionTableContent;
+	}
+
+	private Process startProcess(List<String> commands)
+			throws IOException
+	{
+		infoStream.write(String.join(" ", commands) + '\n'); //$NON-NLS-1$
+		org.eclipse.core.runtime.Path workingDir = (org.eclipse.core.runtime.Path) project.getLocation();
+		ProcessBuilder processBuilder = new ProcessBuilder(commands).directory(workingDir.toFile());
+		Process process = processBuilder.start();
+		return process;
+	}
+	
+	private void startIdfSizeProcess()
+			throws IOException, CoreException
+	{
+		List<String> commands = new ArrayList<>();
+		commands.add(IDFUtil.getIDFPythonEnvPath());
+		commands.add(IDFUtil.getIDFSizeScriptFile().getAbsolutePath());
+		commands.add(getMapFilePath(project).toString());
+
+		Process process = startProcess(commands);
+		if (process != null)
+		{
+			console.getOutputStream().write(process.getInputStream().readAllBytes());
+		}
+
+	}
+	
+	private IPath getMapFilePath(IProject project)
+	{
+		GenericJsonReader jsonReader = new GenericJsonReader(project,
+				IDFConstants.BUILD_FOLDER + File.separator + "project_description.json"); //$NON-NLS-1$
+		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
+		if (!StringUtil.isEmpty(value))
+		{
+			value = value.replace(".elf", ".map"); // Assuming .elf and .map files have the //$NON-NLS-1$ //$NON-NLS-2$
+													// same file name
+			return project.getFile(new org.eclipse.core.runtime.Path("build").append(value)).getLocation(); //$NON-NLS-1$
+		}
+		return null;
+	}
+	
+	private void checkRemainingSize()
+			throws IOException, CoreException
+	{
+		String partitionTableContent = getPartitionTable();
+		Path path = Paths.get(project.getLocation() + File.separator + IDFConstants.BUILD_FOLDER + File.separator
+				+ project.getName() + ".bin"); //$NON-NLS-1$
+		long imageSize = Files.size(path);
+
+		String[] lines = partitionTableContent.split("\n"); //$NON-NLS-1$
+		for (String line : lines)
+		{
+			if (!line.contains("app")) //$NON-NLS-1$
+			{
+				continue;
+			}
+			String[] columns = line.split(","); //$NON-NLS-1$
+			double maxSize = DataSizeUtil.parseSize(columns[4]);
+			double remainSize = (maxSize - imageSize) / (maxSize);
+			if (remainSize < 0.3)
+			{
+				OpenDialogListenerSupport.getSupport().firePropertyChange(null, maxSize, remainSize * maxSize);
+				break;
+			}
+		}
+	}
+	
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
@@ -5,3 +5,4 @@ FileUtil_SourceDirNotavailable=the source directory is not readable
 FileUtil_UnableToCopy=Unable to copy {0} to {1} because {2}
 FileUtil_WritableProblemMsg=the destination directory is not writable
 IDFUtil_CouldNotFindDir=Could not find the build directory {0}
+MsgLinkDialog_DoNotShowMsg=Do not show this warning again

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -68,8 +68,6 @@ public class InitializeToolsStartup implements IStartup
 			@Override
 			public void propertyChange(PropertyChangeEvent evt)
 			{
-				evt.getNewValue();
-				System.out.println("test");
 				Display.getDefault().asyncExec(new Runnable()
 				{
 					@Override

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -4,6 +4,8 @@
  *******************************************************************************/
 package com.espressif.idf.ui;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -19,6 +21,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IStartup;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -29,9 +32,12 @@ import org.osgi.service.prefs.Preferences;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.build.ESPToolChainManager;
 import com.espressif.idf.core.build.ESPToolChainProvider;
+import com.espressif.idf.core.build.Messages;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.ResourceChangeListener;
 import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.ui.dialogs.MessageLinkDialog;
 import com.espressif.idf.ui.update.ExportIDFTools;
 import com.espressif.idf.ui.update.InstallToolsHandler;
 
@@ -50,11 +56,34 @@ public class InitializeToolsStartup implements IStartup
 	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet" ; //$NON-NLS-1$
+	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
 
 	@SuppressWarnings("restriction")
 	@Override
 	public void earlyStartup()
 	{
+		OpenDialogListenerSupport.getSupport().addPropertyChangeListener(new PropertyChangeListener()
+		{
+
+			@Override
+			public void propertyChange(PropertyChangeEvent evt)
+			{
+				evt.getNewValue();
+				System.out.println("test");
+				Display.getDefault().asyncExec(new Runnable()
+				{
+					@Override
+					public void run()
+					{
+						MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
+								Messages.IncreasePartitionSizeTitle,
+								MessageFormat.format(Messages.IncreasePartitionSizeMessage, evt.getNewValue(),
+										evt.getOldValue(), DOC_URL));
+					}
+				});
+
+			}
+		});
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener());
 		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 		launchBarManager.addListener(new LaunchBarListener());

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
@@ -12,7 +12,7 @@
  *     IBM Corporation - initial API and implementation
  * 	   Lars Vogel <Lars.Vogel@vogella.com> - Bug 472690
  *******************************************************************************/
-package com.espressif.idf.core.util;
+package com.espressif.idf.ui.dialogs;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -32,6 +32,8 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+
+import com.espressif.idf.core.util.Messages;
 
 public class MessageLinkDialog extends MessageDialog
 {
@@ -101,7 +103,7 @@ public class MessageLinkDialog extends MessageDialog
 
 	public static void openWarning(Shell parent, String title, String message)
 	{
-		preferences = InstanceScope.INSTANCE.getNode("com.espressif.idf.launch.serial.ui"); //$NON-NLS-1$
+		preferences = InstanceScope.INSTANCE.getNode(""); //$NON-NLS-1$
 		if (!preferences.getBoolean(DO_NOT_SHOW_MSG, false))
 		{
 			open(WARNING, parent, title, message, SWT.NONE);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
@@ -103,7 +103,7 @@ public class MessageLinkDialog extends MessageDialog
 
 	public static void openWarning(Shell parent, String title, String message)
 	{
-		preferences = InstanceScope.INSTANCE.getNode(""); //$NON-NLS-1$
+		preferences = InstanceScope.INSTANCE.getNode("com.espressif.idf.core"); //$NON-NLS-1$
 		if (!preferences.getBoolean(DO_NOT_SHOW_MSG, false))
 		{
 			open(WARNING, parent, title, message, SWT.NONE);


### PR DESCRIPTION
Now, after the build, we can see the application's RAM and flash usage using the idf_size.py command:

<img width="622" alt="Screenshot 2022-01-05 at 20 56 50" src="https://user-images.githubusercontent.com/24419842/148277347-86d4bb6e-5841-4170-bd65-fb48ca88f90d.png">


If the remaining app size is less than 30%, we will show the warning message with the link to the [documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables)

<img width="654" alt="Screenshot 2022-01-05 at 20 56 20" src="https://user-images.githubusercontent.com/24419842/148277774-26020dd3-fd0a-47a5-8bc0-4f46105a9e47.png">

