### PR TITLE
IEP-621 ESP-IDF version check breaks IDF download page

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
@@ -73,7 +73,7 @@ public class IDFVersionsReader
 			}
 			else if (version.startsWith("v")) //$NON-NLS-1$
 			{
-				if (new Version(MIN_VERSION_SUPPORT).compareTo(new Version(version.replace("v", ""))) <= 0) //$NON-NLS-1$ //$NON-NLS-2$
+				if (new Version(MIN_VERSION_SUPPORT).compareTo(new Version(version.replace("v", "").replaceAll("-.*", ".0"))) <= 0) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 				{
 					filterList.add(version);
 				}


### PR DESCRIPTION
Based on the https://github.com/espressif/esp-idf/tags. Tags could contain patterns like `-dev`, `-beta`, `-rc1`. So we are replacing `-.*` regex pattern with 0 to check if the version is higher than 4.0.0