### PR TITLE
IEP-612: ESP-IDF: Application Size Analyis Crashes with Cannot invoke "java.lang.Long.longValue()" because the return value of "org.json.simple.JSONObject.get(Object)" is null 

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
@@ -59,7 +59,7 @@ public class IDFSizeConstants {
 		final String oldIdfSizeConstantsVersion = "4.3.1"; //$NON-NLS-1$
 		Pattern p = Pattern.compile(regexToFindVersion); 
 		Matcher m = p.matcher(version);
-		if (m.find() &&  new Version(oldIdfSizeConstantsVersion).compareTo(new Version(m.group(1).replaceAll("-.*", ".0"))) <= 0) { //$NON-NLS-1$ //$NON-NLS-2$
+		if (m.find() &&  new Version(oldIdfSizeConstantsVersion).compareTo(new Version(m.group(1).replaceAll("-.*", ".0"))) < 0) { //$NON-NLS-1$ //$NON-NLS-2$
 			FLASH_RODATA_OVERVIEW = "flash_rodata"; //$NON-NLS-1$
 			DATA = ".dram0.data"; // DRAM .data //$NON-NLS-1$
 			BSS = ".dram0.bss"; // DRAM .bss //$NON-NLS-1$

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeConstants.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.osgi.framework.Version;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
@@ -54,9 +55,11 @@ public class IDFSizeConstants {
 	
 	static {
 		String version = IDFUtil.getEspIdfVersion();
-		Pattern p = Pattern.compile("([0-9][.][0-9])"); //$NON-NLS-1$
+		final String regexToFindVersion = "v([0-9][.0-9]+)"; //$NON-NLS-1$
+		final String oldIdfSizeConstantsVersion = "4.3.1"; //$NON-NLS-1$
+		Pattern p = Pattern.compile(regexToFindVersion); 
 		Matcher m = p.matcher(version);
-		if (m.find() && Double.parseDouble(m.group(0)) > 4.3) {
+		if (m.find() &&  new Version(oldIdfSizeConstantsVersion).compareTo(new Version(m.group(1).replaceAll("-.*", ".0"))) <= 0) { //$NON-NLS-1$ //$NON-NLS-2$
 			FLASH_RODATA_OVERVIEW = "flash_rodata"; //$NON-NLS-1$
 			DATA = ".dram0.data"; // DRAM .data //$NON-NLS-1$
 			BSS = ".dram0.bss"; // DRAM .bss //$NON-NLS-1$


### PR DESCRIPTION
the changed version check for IDF size constants.  Previously I thought, that we need new IDF size constants for IDF versions equal to or higher than 4.4, but it's actually 4.3.2

link to the issue: https://github.com/espressif/idf-eclipse-plugin/issues/431