### PR TITLE
Fix: Removing requirements.txt validation check

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFDownloadPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFDownloadPage.java
@@ -299,14 +299,6 @@ public class IDFDownloadPage extends WizardPage
 				return;
 			}
 			
-			String requirementsPath = idfPath + File.separator + "requirements.txt"; //$NON-NLS-1$
-			if (!new File (requirementsPath).exists())
-			{
-				setErrorMessage(MessageFormat.format(Messages.IDFDownloadPage_CantFindRequirementsFile, idfPath));
-				setPageComplete(false);
-				return;
-			}
-			
 			setPageComplete(true);
 			setErrorMessage(null);
 			setMessage(Messages.IDFDownloadPage_ClickOnFinish + idfPath);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/messages.properties
@@ -6,7 +6,6 @@ IDFDownloadPage_0=icons/espressif_logo.png
 IDFDownloadPage_BrowseBtn=Browse...
 IDFDownloadPage_BrowseBtnTxt=Browse...
 IDFDownloadPage_CantfindIDFpy=Can not find idf.py in {0} tools
-IDFDownloadPage_CantFindRequirementsFile=Can not find requirements.txt in {0}
 IDFDownloadPage_ChooseAnExistingIDF=Use an existing ESP-IDF directory from file system
 IDFDownloadPage_ChooseDirIDF=Choose existing ESP-IDF directory:
 IDFDownloadPage_ChooseIDFDir=Choose a directory to download ESP-IDF to:


### PR DESCRIPTION
Removing `requirements.txt` additional validation check as part of the esp-idf folder validation. Will rely on `/<esp-idf folder>/tools/idf.py` file check to validate whether it's an esp-idf directory or not.

Will keep this for v2.4.1 release