### PR TITLE
IEP-636: Two versions of the toolchain for each target after installing the new esp-idf and tools.

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -75,14 +75,7 @@ public class ESPToolChainManager
 	 */
 	public void initToolChain(IToolChainManager manager, IToolChainProvider toolchainProvider)
 	{
-		try {
-			Collection<IToolChain> toolchains = manager.getAllToolChains();
-			ArrayList<IToolChain> tcList = new ArrayList<IToolChain>(toolchains);
-			tcList.forEach(tc -> manager.removeToolChain(tc));
-		} catch (CoreException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+		removePrevInstalledToolchains(manager);
 		Logger.log("Initializing toolchain..."); //$NON-NLS-1$
 		List<String> paths = new ArrayList<String>();
 		String idfToolsExportPath = getIdfToolsExportPath();
@@ -125,6 +118,16 @@ public class ESPToolChainManager
 					}
 				}
 			}
+		}
+	}
+
+	private void removePrevInstalledToolchains(IToolChainManager manager) {
+		try {
+			Collection<IToolChain> toolchains = manager.getAllToolChains();
+			ArrayList<IToolChain> tcList = new ArrayList<IToolChain>(toolchains);
+			tcList.forEach(tc -> manager.removeToolChain(tc));
+		} catch (CoreException e) {
+			Logger.log(e);
 		}
 	}
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -75,7 +75,6 @@ public class ESPToolChainManager
 	 */
 	public void initToolChain(IToolChainManager manager, IToolChainProvider toolchainProvider)
 	{
-		removePrevInstalledToolchains(manager);
 		Logger.log("Initializing toolchain..."); //$NON-NLS-1$
 		List<String> paths = new ArrayList<String>();
 		String idfToolsExportPath = getIdfToolsExportPath();
@@ -121,7 +120,7 @@ public class ESPToolChainManager
 		}
 	}
 
-	private void removePrevInstalledToolchains(IToolChainManager manager) {
+	public void removePrevInstalledToolchains(IToolChainManager manager) {
 		try {
 			Collection<IToolChain> toolchains = manager.getAllToolChains();
 			ArrayList<IToolChain> tcList = new ArrayList<IToolChain>(toolchains);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -31,6 +31,7 @@ import org.eclipse.cdt.core.build.IToolChainProvider;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jgit.transport.TcpTransport;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
@@ -74,6 +75,14 @@ public class ESPToolChainManager
 	 */
 	public void initToolChain(IToolChainManager manager, IToolChainProvider toolchainProvider)
 	{
+		try {
+			Collection<IToolChain> toolchains = manager.getAllToolChains();
+			ArrayList<IToolChain> tcList = new ArrayList<IToolChain>(toolchains);
+			tcList.forEach(tc -> manager.removeToolChain(tc));
+		} catch (CoreException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		Logger.log("Initializing toolchain..."); //$NON-NLS-1$
 		List<String> paths = new ArrayList<String>();
 		String idfToolsExportPath = getIdfToolsExportPath();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -155,6 +155,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 	protected void configureToolChain()
 	{
 		ESPToolChainManager toolchainManager = new ESPToolChainManager();
+		toolchainManager.removePrevInstalledToolchains(tcManager);
 		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
 		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
 	}


### PR DESCRIPTION
added: removing previously installed toolchains after installing new tools.

before changes:
![build error and toolchains](https://user-images.githubusercontent.com/24419842/152741484-4a7f53c0-78c3-40e6-a9f9-db4d14931d49.png)

after changes:
![Toolchains after fix](https://user-images.githubusercontent.com/24419842/152741862-c965e6bb-bbf9-498a-8212-0958cc726ec0.png)

