### PR TITLE
Opening a terminal for the first time after Eclipse starts hangs at "Connecting..." and throws an NPE (IEP-637)

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
@@ -181,9 +181,7 @@ public class SerialPortHandler
 				serialConnector.filterOptions);
 
 		process = serialMonitorHandler.invokeIDFMonitor(withSocketServer);
-
 		serialConnector.process = process;
-
 		thread = new Thread()
 		{
 			@Override


### PR DESCRIPTION
sometimes socket server starts after the SocketServerHandler.getServerPort(), because the Socket server starts in a different thread. These changes are forcing to start socket server first