### PR TITLE
Version 2.4.1 (Eclipse) and 2.4.0 (Espressif IDE): Build fail after image is build for working project without clear reason. (IEP-647)

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
@@ -37,10 +37,11 @@ public class ParitionSizeHandler
 	// checking the size consists of the idf_size.py command and checking the remaining size from the partition table
 	public void startCheckingSize() throws IOException, CoreException
 	{
-		if (getMapFilePath(project) != null)
+		IPath mapFilePath = getMapFilePath(project);
+		if (mapFilePath != null)
 		{
 			startIdfSizeProcess();
-			checkRemainingSize();			
+			checkRemainingSize(mapFilePath.removeFileExtension().addFileExtension("bin")); //$NON-NLS-1$	
 		}
 	}
 	
@@ -97,14 +98,12 @@ public class ParitionSizeHandler
 		return null;
 	}
 	
-	private void checkRemainingSize()
+	private void checkRemainingSize(IPath path)
 			throws IOException, CoreException
 	{
 		String partitionTableContent = getPartitionTable();
-		Path path = Paths.get(project.getLocation() + File.separator + IDFConstants.BUILD_FOLDER + File.separator
-				+ project.getName().replace(" ", "_") + ".bin"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		long imageSize = Files.size(path);
-
+		
+		long imageSize = path.toFile().length();
 		String[] lines = partitionTableContent.split("\n"); //$NON-NLS-1$
 		for (String line : lines)
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
@@ -37,11 +37,13 @@ public class ParitionSizeHandler
 	// checking the size consists of the idf_size.py command and checking the remaining size from the partition table
 	public void startCheckingSize() throws IOException, CoreException
 	{
-		IPath mapFilePath = getMapFilePath(project);
-		if (mapFilePath != null)
+		if (getMapFilePath(project) != null)
 		{
 			startIdfSizeProcess();
-			checkRemainingSize(mapFilePath.removeFileExtension().addFileExtension("bin")); //$NON-NLS-1$	
+		}
+		IPath binPath = getBinFilePath(project);
+		if (binPath != null) {
+			checkRemainingSize(binPath);
 		}
 	}
 	
@@ -98,11 +100,21 @@ public class ParitionSizeHandler
 		return null;
 	}
 	
+	private IPath getBinFilePath(IProject project) {
+		GenericJsonReader jsonReader = new GenericJsonReader(project,
+				IDFConstants.BUILD_FOLDER + File.separator + "project_description.json"); //$NON-NLS-1$
+		String value = jsonReader.getValue("app_bin"); //$NON-NLS-1$
+		if (!StringUtil.isEmpty(value))
+		{
+			return project.getFile(new org.eclipse.core.runtime.Path("build").append(value)).getLocation(); //$NON-NLS-1$
+		}
+		return null;
+	}
+	
 	private void checkRemainingSize(IPath path)
 			throws IOException, CoreException
 	{
 		String partitionTableContent = getPartitionTable();
-		
 		long imageSize = path.toFile().length();
 		String[] lines = partitionTableContent.split("\n"); //$NON-NLS-1$
 		for (String line : lines)


### PR DESCRIPTION
Made code for checking the remaining size more robust. Works if the binary name and project name do not match and if a binary file is missing