### PR TITLE
Espressif preferences for the serial monitor has no effect on it

### DIFF
--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/SerialMonitorBundle.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/SerialMonitorBundle.java
@@ -1,6 +1,5 @@
 package com.espressif.idf.serial.monitor;
 
-import org.eclipse.jface.preference.IPreferenceStore;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
@@ -13,19 +12,10 @@ import ilg.gnumcueclipse.core.AbstractUIActivator;
 public class SerialMonitorBundle extends AbstractUIActivator
 {
 	public static final String PLUGIN_ID = "com.espressif.idf.serial.monitor"; //$NON-NLS-1$
-	public static final String SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE = "numberOfCharsInALine"; //$NON-NLS-1$
-	public static final String SERIAL_MONITOR_NUMBER_OF_LINES = "numberOfLines"; //$NON-NLS-1$
 
 	private static BundleContext context;
 
 	private static SerialMonitorBundle fgInstance;
-
-	@Override
-	protected void initializeDefaultPreferences(IPreferenceStore preferenceStore)
-	{
-		preferenceStore.setDefault(SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, 500);
-		preferenceStore.setDefault(SERIAL_MONITOR_NUMBER_OF_LINES, 1000);
-	}
 
 	public SerialMonitorBundle()
 	{

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
@@ -5,7 +5,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.runtime.Platform;
+
 import com.espressif.idf.serial.monitor.SerialMonitorBundle;
+import com.espressif.idf.ui.UIPlugin;
 import com.pty4j.PtyProcess;
 import com.pty4j.PtyProcessBuilder;
 
@@ -19,7 +22,10 @@ public class LocalTerminal
 	private List<String> arguments;
 	private File workingDir;
 	private Map<String, String> environment;
-
+	
+	private final int DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES = 1000;
+	private final int DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE = 500;
+	
 	public LocalTerminal(List<String> commandArgs, File projectWorkingDir, Map<String, String> environment)
 	{
 		this.arguments = commandArgs;
@@ -30,10 +36,8 @@ public class LocalTerminal
 	public Process connect() throws IOException
 	{
 		String[] args = arguments.toArray(new String[arguments.size()]);
-		int numberOfRows = SerialMonitorBundle.getInstance().getPreferenceStore()
-				.getInt(SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_LINES);
-		int numberOfCols = SerialMonitorBundle.getInstance().getPreferenceStore()
-				.getInt(SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE);
+		int numberOfRows =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null);
+		int numberOfCols =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);
 		PtyProcessBuilder ptyProcessBuilder = new PtyProcessBuilder(args).setEnvironment(environment)
 				.setDirectory(workingDir.getAbsolutePath()).setInitialColumns(numberOfCols).setInitialRows(numberOfRows)
 				.setConsole(false).setCygwin(false).setLogFile(null);

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.Platform;
 
-import com.espressif.idf.serial.monitor.SerialMonitorBundle;
 import com.espressif.idf.ui.UIPlugin;
+import com.espressif.idf.ui.preferences.EspresssifPreferencesPage;
 import com.pty4j.PtyProcess;
 import com.pty4j.PtyProcessBuilder;
 
@@ -23,9 +23,6 @@ public class LocalTerminal
 	private File workingDir;
 	private Map<String, String> environment;
 	
-	private final int DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES = 1000;
-	private final int DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE = 500;
-	
 	public LocalTerminal(List<String> commandArgs, File projectWorkingDir, Map<String, String> environment)
 	{
 		this.arguments = commandArgs;
@@ -36,8 +33,8 @@ public class LocalTerminal
 	public Process connect() throws IOException
 	{
 		String[] args = arguments.toArray(new String[arguments.size()]);
-		int numberOfRows =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null);
-		int numberOfCols =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, SerialMonitorBundle.SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);
+		int numberOfRows =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_LINES, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null);
+		int numberOfCols =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_CHARS_IN_A_LINE, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);
 		PtyProcessBuilder ptyProcessBuilder = new PtyProcessBuilder(args).setEnvironment(environment)
 				.setDirectory(workingDir.getAbsolutePath()).setInitialColumns(numberOfCols).setInitialRows(numberOfRows)
 				.setConsole(false).setCygwin(false).setLogFile(null);

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -45,6 +45,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.espressif.idf.ui,
  com.espressif.idf.ui.dialogs,
  com.espressif.idf.ui.handlers,
+ com.espressif.idf.ui.preferences,
  com.espressif.idf.ui.tracing
 Bundle-ClassPath: .,
  lib/commonmark-0.16.1.jar,

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -1,15 +1,10 @@
 package com.espressif.idf.ui.preferences;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.jface.preference.FieldEditor;
-import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
@@ -26,10 +21,12 @@ import ilg.gnumcueclipse.core.preferences.ScopedPreferenceStoreWithoutDefaults;
 public class EspresssifPreferencesPage extends PreferencePage implements IWorkbenchPreferencePage
 {
 
-	private static final String NUMBER_OF_LINES = "numberOfLines"; //$NON-NLS-1$
-	private static final String NUMBER_OF_CHARS_IN_A_LINE = "numberOfCharsInALine"; //$NON-NLS-1$
+	public static final String NUMBER_OF_LINES = "numberOfLines"; //$NON-NLS-1$
+	public static final String NUMBER_OF_CHARS_IN_A_LINE = "numberOfCharsInALine"; //$NON-NLS-1$
+	public static final int DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES = 1000;
+	public static final int DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE = 500;
+	
 	private static final String GDB_SERVER_LAUNCH_TIMEOUT = "fGdbServerLaunchTimeout"; //$NON-NLS-1$
-
 	private Text numberOfCharsInLineText;
 	private Text numberLineText;
 	private Text gdbSettingsText;
@@ -138,7 +135,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	private void initializeDefaults()
 	{
 		getPreferenceStore().setDefault(GDB_SERVER_LAUNCH_TIMEOUT, 25);
-		getPreferenceStore().setDefault(NUMBER_OF_CHARS_IN_A_LINE, 500);
-		getPreferenceStore().setDefault(NUMBER_OF_LINES, 1000);
+		getPreferenceStore().setDefault(NUMBER_OF_CHARS_IN_A_LINE, DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE);
+		getPreferenceStore().setDefault(NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES);
 	}
 }

--- a/tests/com.espressif.idf.ui.test/.gitignore
+++ b/tests/com.espressif.idf.ui.test/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /screenshots/
+/target/


### PR DESCRIPTION
Changed the preference store, to get SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE and SERIAL_MONITOR_NUMBER_OF_LINES variables from the espressif preference page. If these changes are ok, we can remove the initializeDefaultPreferences method, since looks like we don't use it anywhere else