### PR TITLE
IEP-634: Bug fix for Language Change

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
@@ -29,7 +29,7 @@ import com.espressif.idf.core.logging.Logger;
  */
 public class EclipseIniUtil
 {
-	private String ECLIPSE_INI_FILE = "espressif-ide.ini"; //$NON-NLS-1$
+	private String ECLIPSE_INI_FILE;
 	private static final String ECLIPSE_INI_VMARGS = "-vmargs"; //$NON-NLS-1$
 
 	private List<String> eclipseIniFileContents;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
@@ -8,6 +8,7 @@ package com.espressif.idf.core.util;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,6 +19,8 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 
+import com.espressif.idf.core.logging.Logger;
+
 /**
  * Utility class for managing and editing different parameter in eclipse.ini and config.ini file for eclipse
  * 
@@ -26,8 +29,7 @@ import org.eclipse.core.runtime.URIUtil;
  */
 public class EclipseIniUtil
 {
-	private final String ECLIPSE_HOME_LOCATION;
-	private final String ECLIPSE_INI_FILE = "eclipse.ini"; //$NON-NLS-1$
+	private String ECLIPSE_INI_FILE = "espressif-ide.ini"; //$NON-NLS-1$
 	private static final String ECLIPSE_INI_VMARGS = "-vmargs"; //$NON-NLS-1$
 
 	private List<String> eclipseIniFileContents;
@@ -38,11 +40,19 @@ public class EclipseIniUtil
 
 	public EclipseIniUtil() throws Exception
 	{
-		ECLIPSE_HOME_LOCATION = Platform.getInstallLocation().getURL().toString();
-		eclipseIniUri = URIUtil.fromString(ECLIPSE_HOME_LOCATION.concat(ECLIPSE_INI_FILE));
+		loadIniFilePath();
+		Logger.log(Platform.getLocation().toOSString());
+		eclipseIniUri = URIUtil.fromString(ECLIPSE_INI_FILE);
 		loadEclipseIniFileContents();
 		loadEclipseIniSwitchMap();
 		loadEclipseVmArgMap();
+	}
+	
+	private void loadIniFilePath() throws Exception
+	{
+		URL url = new URL(
+				Platform.getInstallLocation().getURL() + System.getProperty("eclipse.launcher.name") + ".ini"); //$NON-NLS-1$ //$NON-NLS-2$
+		ECLIPSE_INI_FILE = url.toString();
 	}
 
 	/**

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
@@ -34,6 +34,7 @@ import com.espressif.idf.ui.handlers.Messages;
 public class LanguageDynamicMenuItem extends ContributionItem
 {
 	private static final String LANGUAGE_SWITCH = "-nl"; //$NON-NLS-1$
+//	private static final String ECLIPSE_RCP_NAME = "espressif-ide"; //$NON-NLS-1$
 	private EclipseIniUtil eclipseIniUtil;
 
 	public LanguageDynamicMenuItem()
@@ -52,7 +53,7 @@ public class LanguageDynamicMenuItem extends ContributionItem
 	public void fill(Menu menu, int index)
 	{
 		IConfigurationElement[] configElements = Platform.getExtensionRegistry()
-				.getConfigurationElementsFor("com.espressif.idf.ui.locale.support");
+				.getConfigurationElementsFor("com.espressif.idf.ui.locale.support"); //$NON-NLS-1$
 		for (IConfigurationElement iConfigurationElement : configElements)
 		{
 			MenuItem menuItem = new MenuItem(menu, SWT.PUSH);
@@ -98,8 +99,9 @@ public class LanguageDynamicMenuItem extends ContributionItem
 
 	private void restartEclipse() throws Exception
 	{
-		URL eclipseInstallationUrl = Platform.getInstallLocation().getURL();
-		String pathToEclipse = new File(eclipseInstallationUrl.toURI().resolve("eclipse")).toString();
+		URL eclipseInstallationUrl = new URL(
+				Platform.getInstallLocation().getURL() + System.getProperty("eclipse.launcher.name")); //$NON-NLS-1$
+		String pathToEclipse = new File(eclipseInstallationUrl.toURI()).toString();
 		ProcessBuilder processBuilder = new ProcessBuilder(pathToEclipse);
 		processBuilder.start();
 		PlatformUI.getWorkbench().close();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
@@ -34,7 +34,6 @@ import com.espressif.idf.ui.handlers.Messages;
 public class LanguageDynamicMenuItem extends ContributionItem
 {
 	private static final String LANGUAGE_SWITCH = "-nl"; //$NON-NLS-1$
-//	private static final String ECLIPSE_RCP_NAME = "espressif-ide"; //$NON-NLS-1$
 	private EclipseIniUtil eclipseIniUtil;
 
 	public LanguageDynamicMenuItem()


### PR DESCRIPTION
Original issue: Unable to change a language when the root folder name is not eclipse

Fixed
The issue was we were using constant name eclipse while getting install location which was failing as the RCP is now named espressif-ide
We are now using the system property to fetch the name of the launcher and appending that to the path which resolves the error.

Tested on Windows need testing on MAC and LINUX