### PR TITLE
IEP-670 GH #509: Switching to different Serial Port in the ESP Target selector does not take effect

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -134,6 +134,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		}
 		String arguments = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_TOOL_ARGUMENTS,
 				espFlashCommand);
+		arguments = arguments.replace(ESPFlashUtil.SERIAL_PORT, serialPort);
 		if (!arguments.isEmpty()) {
 			commands.addAll(Arrays.asList(varManager.performStringSubstitution(arguments).split(" "))); //$NON-NLS-1$
 		}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
@@ -22,8 +22,8 @@ import com.espressif.idf.core.util.IDFUtil;
 public class ESPFlashUtil {
 
 	private static final int OPENOCD_JTAG_FLASH_SUPPORT_V = 20201125;
-	public static String VERSION_PATTERN = "(v.\\S+)"; //$NON-NLS-1$
-	public static String SERIAL_PORT = "${serial_port}"; //$NON-NLS-1$
+	public static final String VERSION_PATTERN = "(v.\\S+)"; //$NON-NLS-1$
+	public static final String SERIAL_PORT = "${serial_port}"; //$NON-NLS-1$
 
 	/**
 	 * @param launch

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
@@ -23,6 +23,7 @@ public class ESPFlashUtil {
 
 	private static final int OPENOCD_JTAG_FLASH_SUPPORT_V = 20201125;
 	public static String VERSION_PATTERN = "(v.\\S+)"; //$NON-NLS-1$
+	public static String SERIAL_PORT = "${serial_port}"; //$NON-NLS-1$
 
 	/**
 	 * @param launch

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -188,7 +188,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 	}
 
 	private void updateArgumentsWithDefaultFlashCommand(ILaunchConfiguration configuration) {
-		String espFlashCommand = ESPFlashUtil.getEspFlashCommand(getSerialPort());
+		String espFlashCommand = ESPFlashUtil.getEspFlashCommand(ESPFlashUtil.SERIAL_PORT);
 		try {
 			argumentsForSerialFlash = configuration.getAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS,
 					espFlashCommand);


### PR DESCRIPTION
Now, in the `arguments` line for launch configuration we have the variable "${serial_port}", which will be replaced with the actual serial port, that is selected in the launch target.

![image](https://user-images.githubusercontent.com/24419842/158766292-dc51a4f5-0d7a-407b-a47b-607b72ac8737.png)
