### PR TITLE
IEP-671: ESP-IDF Install Components not fetching the components sources for installed components.

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/installcomponents/handler/InstallCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/installcomponents/handler/InstallCommandHandler.java
@@ -69,7 +69,7 @@ public class InstallCommandHandler
 		commands.add(IDFUtil.getIDFPythonEnvPath());
 		commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
 
-		Job job = new Job("Install Components Job")
+		Job job = new Job("Install Components Job") //$NON-NLS-1$
 		{
 
 			@Override


### PR DESCRIPTION
The initial code was not catering for the download of sources and headers for the components. We just need to specify the IDF_COMPONENT_MANAGER variable in the environment and the CMake build system will take care of the rest.
Sources for this change are the documentation from
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html

<img width="537" alt="image" src="https://user-images.githubusercontent.com/85216275/159285678-db2aabf6-6fdc-4f61-8e29-090820705948.png">

 
Also updated the code to use the Eclipse Jobs API to avoid the UI getting stuck on the install operation