### PR TITLE
IEP-679: Auto change the launch target after clicking on the launch configuration

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -289,8 +289,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 							wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
 							wc.doSave();
 						} catch (CoreException e2) {
-							// TODO Auto-generated catch block
-							e2.printStackTrace();
+							Logger.log(e2);
 						}
 						updateLaunchBar(selectedItem);
 					}

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -110,6 +110,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 					argumentField.setText(argumentsForSerialFlash);
 				} else {
 					argumentField.setText(argumentsForJtagFlash);
+					fTarget.notifyListeners(SWT.Selection, null);
 				}
 				switchUI();
 			}
@@ -281,7 +282,12 @@ public class CMakeMainTab2 extends GenericMainTab {
 				public void widgetSelected(SelectionEvent e) {
 					String updatedSelectedTarget = getLaunchTarget();
 					String selectedItem = fTarget.getItem(fTarget.getSelectionIndex());
-					if (!selectedItem.contentEquals(updatedSelectedTarget)) {
+					if (!selectedItem.contentEquals(updatedSelectedTarget) && isFlashOverJtag) {
+						try {
+							performApply(launchBarManager.getActiveLaunchConfiguration().getWorkingCopy());
+						} catch (CoreException e1) {
+							Logger.log(e1);
+						}
 						updateLaunchBar(selectedItem);
 					}
 					boardConfigsMap = parser.getBoardsConfigs(selectedItem);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -284,9 +284,15 @@ public class CMakeMainTab2 extends GenericMainTab {
 					String selectedItem = fTarget.getItem(fTarget.getSelectionIndex());
 					if (!selectedItem.contentEquals(updatedSelectedTarget) && isFlashOverJtag) {
 						try {
-							performApply(launchBarManager.getActiveLaunchConfiguration().getWorkingCopy());
-						} catch (CoreException e1) {
-							Logger.log(e1);
+							ILaunchConfigurationWorkingCopy wc = launchBarManager.getActiveLaunchConfiguration()
+									.getWorkingCopy();
+							wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
+							wc.doSave();
+							System.out.print(wc.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""));
+
+						} catch (CoreException e2) {
+							// TODO Auto-generated catch block
+							e2.printStackTrace();
 						}
 						updateLaunchBar(selectedItem);
 					}

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -288,8 +288,6 @@ public class CMakeMainTab2 extends GenericMainTab {
 									.getWorkingCopy();
 							wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
 							wc.doSave();
-							System.out.print(wc.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""));
-
 						} catch (CoreException e2) {
 							// TODO Auto-generated catch block
 							e2.printStackTrace();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -5,7 +5,6 @@
 package com.espressif.idf.ui;
 
 import java.io.File;
-import java.util.Map;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
@@ -17,22 +16,15 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.ui.ILaunchConfigurationTabGroup;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
-import org.eclipse.launchbar.core.internal.Activator;
-import org.eclipse.launchbar.core.internal.ExecutableExtension;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.ui.ILaunchBarUIManager;
-import org.eclipse.launchbar.ui.internal.LaunchBarLaunchConfigDialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 
-import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
@@ -95,16 +87,17 @@ public class LaunchBarListener implements ILaunchBarListener
 					{
 						// get current target
 						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
-
-						if(activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false)) 
+						final String jtag_device_id = activeConfig.getAttribute("org.eclipse.cdt.debug.gdbjtag.core.jtagDeviceId", ""); //$NON-NLS-1$ //$NON-NLS-2$
+						if(activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false) || jtag_device_id.contentEquals("ESP-IDF GDB OpenOCD")) //$NON-NLS-1$
 						{
-							String targetForJtagFlash = activeConfig.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
+							String targetForJtagFlash = activeConfig.getWorkingCopy().getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
 							if (!newTarget.equals(targetForJtagFlash)) 
 							{
-								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(), "stest", "selected target don't match the target for jtag flash");
+								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(), Messages.LaunchBarListener_TargetChanged_Title, Messages.LaunchBarListener_TargetDontMatch_Msg);
 								if (isYes) {
-									ILaunchBarUIManager uiManager = Activator.getService(ILaunchBarUIManager.class);
+									ILaunchBarUIManager uiManager = UIPlugin.getService(ILaunchBarUIManager.class);
 									uiManager.openConfigurationEditor(launchBarManager.getActiveLaunchDescriptor());
+									return;
 								}
 							}
 						}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -5,6 +5,7 @@
 package com.espressif.idf.ui;
 
 import java.io.File;
+import java.util.Map;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
@@ -16,15 +17,24 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.ILaunchConfigurationTabGroup;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
+import org.eclipse.launchbar.core.internal.Activator;
+import org.eclipse.launchbar.core.internal.ExecutableExtension;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.launchbar.ui.ILaunchBarUIManager;
+import org.eclipse.launchbar.ui.internal.LaunchBarLaunchConfigDialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 
+import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.SDKConfigJsonReader;
 import com.espressif.idf.core.util.StringUtil;
@@ -60,6 +70,7 @@ public class LaunchBarListener implements ILaunchBarListener
 			if (activeConfig == null) {
 				return;
 			}
+			
 			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
 			if (projectName.isEmpty())
 			{
@@ -85,6 +96,19 @@ public class LaunchBarListener implements ILaunchBarListener
 						// get current target
 						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
 
+						if(activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false)) 
+						{
+							String targetForJtagFlash = activeConfig.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
+							if (!newTarget.equals(targetForJtagFlash)) 
+							{
+								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(), "stest", "selected target don't match the target for jtag flash");
+								if (isYes) {
+									ILaunchBarUIManager uiManager = Activator.getService(ILaunchBarUIManager.class);
+									uiManager.openConfigurationEditor(launchBarManager.getActiveLaunchDescriptor());
+								}
+							}
+						}
+						
 						// If both are not same
 						if (currentTarget != null && !newTarget.equals(currentTarget))
 						{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/Messages.java
@@ -5,6 +5,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.messages"; //$NON-NLS-1$
+	public static String LaunchBarListener_TargetDontMatch_Msg;
 	public static String LaunchBarListener_TargetChanged_Msg;
 	public static String LaunchBarListener_TargetChanged_Title;
 	static

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/UIPlugin.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/UIPlugin.java
@@ -9,6 +9,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 
 /**
  * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
@@ -40,6 +41,12 @@ public class UIPlugin extends AbstractUIPlugin {
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
 		super.stop(context);
+	}
+	
+	public static <T> T getService(Class<T> service) {
+		BundleContext context = plugin.getBundle().getBundleContext();
+		ServiceReference<T> ref = context.getServiceReference(service);
+		return ref != null ? context.getService(ref) : null;
 	}
 
 	/**

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
@@ -1,2 +1,3 @@
 LaunchBarListener_TargetChanged_Msg=IDF launch target has changed for the project. Do you want to delete the `build` folder for the project?
 LaunchBarListener_TargetChanged_Title=IDF Launch Target Changed
+LaunchBarListener_TargetDontMatch_Msg=The selected target doesn't match the target for the JTAG flashing. Do you want to change the selected board in the configuration?


### PR DESCRIPTION
Added a message, when a selected target doesn't match the target, which is selected for the jtag flashing. It will navigate the user to configuration options, where it's possible to change the selected target and a board for the jtag flashing
![IEP-678](https://user-images.githubusercontent.com/24419842/162159429-8089ad65-1d5b-4673-99f5-696a3ad0ef48.png)


Test cases:
1. For the launch configuration, select the "Flash over JTAG" option and choose some board with an esp32 chip and click OK. Then select new target esp32s2. After this, you will be able to see this message. Click "Yes" and you should be navigated to the launch target options, where it's necessary to select a new board.
2. Same as 1 test case, but for debug configuration
3. Unselect "Flash over JTAG" option from the launch configuration. In this case, after selecting a target, you should not see same message, but if project is built, you will see a message with a suggestion to delete the build folder. 