### PR TITLE
IEP-687 Random NPE when opening the launch configuration options

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
@@ -1,23 +1,7 @@
 package com.espressif.idf.core.resources;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.ICBuildConfiguration;
-import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
-import org.eclipse.cdt.core.build.ICBuildConfigurationManager2;
-import org.eclipse.cdt.core.build.IToolChain;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -25,17 +9,14 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.ILaunchBarManager;
-import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFCorePlugin;
-import com.espressif.idf.core.build.ESP32S2ToolChain;
-import com.espressif.idf.core.build.ESP32ToolChain;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.RecheckConfigsHelper;
 
 public class ResourceChangeListener implements IResourceChangeListener 
 {
@@ -74,15 +55,7 @@ public class ResourceChangeListener implements IResourceChangeListener
 						IProject project = (IProject) resource;
 						if (project.isOpen()) 
 						{
-							Preferences settings = InstanceScope.INSTANCE.getNode(CCorePlugin.PLUGIN_ID).node("config")
-									.node(project.getName()).node(project.getActiveBuildConfig().getName()); //$NON-NLS-1$
-							IToolChainManager toolChainManager = CCorePlugin.getService(IToolChainManager.class);
-							IToolChain toolChain = getESPToolChain(toolChainManager);
-							settings.put(ICBuildConfiguration.TOOLCHAIN_TYPE,
-									Optional.ofNullable(toolChain).map(o -> o.getTypeId()).orElse("")); //$NON-NLS-1$
-							settings.put(ICBuildConfiguration.TOOLCHAIN_ID,
-									Optional.ofNullable(toolChain).map(o -> o.getId()).orElse("")); //$NON-NLS-1$
-							recheckConfigs();
+							RecheckConfigsHelper.revalidateToolchain(project);
 						}
 					}
 					return true;
@@ -154,28 +127,6 @@ public class ResourceChangeListener implements IResourceChangeListener
 			}
 		}
 		return directoryToBeDeleted.delete();
-	}
-
-	private void recheckConfigs()
-	{
-		ICBuildConfigurationManager mgr = CCorePlugin.getService(ICBuildConfigurationManager.class);
-		ICBuildConfigurationManager2 manager = (ICBuildConfigurationManager2) mgr;
-		manager.recheckConfigs();
-	}
-	
-	private IToolChain getESPToolChain(IToolChainManager toolChainManager) throws CoreException
-	{
-		Iterator<IToolChain> iter = toolChainManager.getAllToolChains().iterator();
-		IToolChain toolChain = null;
-		while (iter.hasNext())
-		{
-			toolChain = iter.next();
-			if (toolChain instanceof ESP32ToolChain ||  toolChain instanceof ESP32S2ToolChain) //TODO: remove specific conditions
-			{
-				return toolChain;
-			}
-		}
-		return toolChain;
 	}
 }
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/RecheckConfigsHelper.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/RecheckConfigsHelper.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.ICBuildConfiguration;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager2;
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.build.IToolChainManager;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.osgi.service.prefs.Preferences;
+
+import com.espressif.idf.core.build.ESP32S2ToolChain;
+import com.espressif.idf.core.build.ESP32ToolChain;
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * A class for revalidating the build configuration and adding the correct toolchain to the settings. This helps to
+ * resolve the "Build not configured correctly" issue and also resolves the build config creation issue due to the issue
+ * of getting the toolchain.
+ * 
+ * @author Denys Almazov
+ *
+ */
+public class RecheckConfigsHelper
+{
+
+	public static void revalidateToolchain(IProject project)
+	{
+		Preferences settings;
+		try
+		{
+			settings = InstanceScope.INSTANCE.getNode(CCorePlugin.PLUGIN_ID).node("config").node(project.getName())
+					.node(project.getActiveBuildConfig().getName());
+			IToolChainManager toolChainManager = CCorePlugin.getService(IToolChainManager.class);
+			IToolChain toolChain = getESPToolChain(toolChainManager);
+			settings.put(ICBuildConfiguration.TOOLCHAIN_TYPE,
+					Optional.ofNullable(toolChain).map(o -> o.getTypeId()).orElse("")); //$NON-NLS-1$
+			settings.put(ICBuildConfiguration.TOOLCHAIN_ID,
+					Optional.ofNullable(toolChain).map(o -> o.getId()).orElse("")); //$NON-NLS-1$
+			recheckConfigs();
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
+	}
+
+	private static void recheckConfigs()
+	{
+		ICBuildConfigurationManager mgr = CCorePlugin.getService(ICBuildConfigurationManager.class);
+		ICBuildConfigurationManager2 manager = (ICBuildConfigurationManager2) mgr;
+		manager.recheckConfigs();
+	}
+
+	private static IToolChain getESPToolChain(IToolChainManager toolChainManager) throws CoreException
+	{
+		Iterator<IToolChain> iter = toolChainManager.getAllToolChains().iterator();
+		IToolChain toolChain = null;
+		while (iter.hasNext())
+		{
+			toolChain = iter.next();
+			if (toolChain instanceof ESP32ToolChain || toolChain instanceof ESP32S2ToolChain) // TODO: remove specific
+																								// conditions
+			{
+				return toolChain;
+			}
+		}
+		return toolChain;
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -14,7 +14,10 @@ import java.util.Map;
 
 import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
+import org.eclipse.cdt.debug.core.launch.CoreBuildLaunchConfigDelegate;
 import org.eclipse.cdt.launch.ui.corebuild.CommonBuildTab;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.swt.SWT;
@@ -30,6 +33,8 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 
 import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.RecheckConfigsHelper;
 
 public class CMakeBuildTab2 extends CommonBuildTab {
 
@@ -111,10 +116,18 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
+		try
+		{
+			IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
+			RecheckConfigsHelper.revalidateToolchain(project);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
 		super.initializeFrom(configuration);
-
 		ICBuildConfiguration buildConfig = getBuildConfiguration();
-
 		String generator = buildConfig.getProperty(CMakeBuildConfiguration.CMAKE_GENERATOR);
 		updateGeneratorButtons(generator);
 


### PR DESCRIPTION
Briefly about the issue. Sometimes launch configurations are bugged for some reason, so it's impossible to edit them because of the NPE in process of getting the build configuration. As figured out, the problem is similar to the old problem with "Build not configured correctly", which we fixed a long time ago. 

The fix for that issue is to recheck configs and put any of the ESP toolchains to the settings, so it will be possible to create an IDF build configuration. Since we already have code for these purposes, this PR is mainly about refactoring and using the same code in different places.