### PR TITLE
IEP-692: Fix to restart eclipse for different platforms

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
@@ -98,10 +98,7 @@ public class LanguageDynamicMenuItem extends ContributionItem
 
 	private void restartEclipse() throws Exception
 	{
-		URL eclipseInstallationUrl = new URL(
-				Platform.getInstallLocation().getURL() + System.getProperty("eclipse.launcher.name")); //$NON-NLS-1$
-		String pathToEclipse = new File(eclipseInstallationUrl.toURI()).toString();
-		ProcessBuilder processBuilder = new ProcessBuilder(pathToEclipse);
+		ProcessBuilder processBuilder = new ProcessBuilder(System.getProperty("eclipse.launcher")); //$NON-NLS-1$
 		processBuilder.start();
 		PlatformUI.getWorkbench().close();
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/menuitem/LanguageDynamicMenuItem.java
@@ -5,9 +5,6 @@
 
 package com.espressif.idf.ui.menuitem;
 
-import java.io.File;
-import java.net.URL;
-
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.ContributionItem;


### PR DESCRIPTION
Changed to system property **eclipse.launcher** for restarting eclipse.