### PR TITLE
Fix: Enable IDF_COMPONENT_MANAGER by default

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
@@ -29,13 +29,15 @@ public class IDFEnvironmentVariables
 	 * 
 	 */
 	public static String IDF_PATH = "IDF_PATH"; //$NON-NLS-1$
-	
+
 	public static String IDF_PYTHON_ENV_PATH = "IDF_PYTHON_ENV_PATH"; //$NON-NLS-1$
-	
+
 	public static String PATH = "PATH"; //$NON-NLS-1$
-	
+
 	public static String OPENOCD_SCRIPTS = "OPENOCD_SCRIPTS"; //$NON-NLS-1$
-	
+
+	public static String IDF_COMPONENT_MANAGER = "IDF_COMPONENT_MANAGER"; //$NON-NLS-1$
+
 	/**
 	 * @param variableName Environment variable Name
 	 * @return IEnvironmentVariable
@@ -69,18 +71,18 @@ public class IDFEnvironmentVariables
 
 		return envValue;
 	}
-	
+
 	@SuppressWarnings("restriction")
 	public void addEnvVariable(String name, String value)
 	{
 		Logger.log(MessageFormat.format("Updating environment variables with key:{0} value:{1}", name, value)); //$NON-NLS-1$
 		IContributedEnvironment contributedEnvironment = getEnvironment();
 		contributedEnvironment.addVariable(name, value, IEnvironmentVariable.ENVVAR_REPLACE, null, null);
-		
-		//Without this environment variables won't be persisted
+
+		// Without this environment variables won't be persisted
 		EnvironmentVariableManager.fUserSupplier.storeWorkspaceEnvironment(true);
 	}
-	
+
 	/**
 	 * @return CDT build environment variables map
 	 */

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -33,6 +33,7 @@ import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.build.ESPToolChainManager;
 import com.espressif.idf.core.build.ESPToolChainProvider;
@@ -84,6 +85,9 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.setTaskName(Messages.InstallToolsHandler_AutoConfigureToolchain);
 				configureToolChain();
 				monitor.worked(1);
+				
+				configEnv();
+				
 				copyOpenOcdRules();
 				console.println(Messages.InstallToolsHandler_ConfiguredCMakeMsg);
 
@@ -103,6 +107,18 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			Logger.log(e);
 		}
 		installToolsJob.schedule();
+	}
+
+	/**
+	 * Configure all the required environment variables here
+	 */
+	protected void configEnv()
+	{
+		IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
+		
+		//Enable IDF_COMPONENT_MANAGER by default
+		idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_COMPONENT_MANAGER, "1");
+		
 	}
 
 	private void copyOpenOcdRules()


### PR DESCRIPTION
This will avoid build errors when components are added but the component manager is not enabled