### PR TITLE
IEP-703: Saving a target attribute for a config each time when editing.

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -443,6 +443,17 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 						String selectedItem = fTarget.getText();
 						if (!selectedItem.contentEquals(updatedSelectedTarget))
 						{
+							try
+							{
+								ILaunchConfigurationWorkingCopy wc = launchBarManager.getActiveLaunchConfiguration()
+										.getWorkingCopy();
+								wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
+								wc.doSave();
+							}
+							catch (CoreException e1)
+							{
+								Logger.log(e1);
+							}
 							updateLaunchBar(selectedItem);
 						}
 						fGdbClientExecutable.setText(IDFUtil.getXtensaToolchainExecutablePathByTarget(selectedItem));


### PR DESCRIPTION
We need to save the launch target attribute for the configuration each time we edit it. Otherwise, it may cause the value ​​from the configuration to get out of sync with a value from the launch target bar.

We are already doing it for launch configuration, so this PR contains changes for debug configurations only.