### PR TITLE
Fix: single quote for messageformat when string has arbitrary chars

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -100,7 +100,7 @@ public class InitializeToolsStartup implements IStartup
 		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
 		if (!idf_json_file.exists())
 		{
-			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: {0}", url.getPath()));
+			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: '{0}'", url.getPath()));
 			return;
 		}
 


### PR DESCRIPTION
Apply a single quote for the string when the string has arbitrary chars. It is essentially to fix the below message.
```
!ENTRY com.espressif.idf.core 1 0 2022-06-07 21:15:07.400
!MESSAGE esp-idf.json file doesnt exist at this location: {0}
```