### PR TITLE
ESP-IDF Terminal: esptool.py is not accessible in terminal

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -268,8 +268,7 @@ public class IDFUtil
 		String IDF_PATH = getIDFPath();
 		if (!StringUtil.isEmpty(IDF_PATH))
 		{
-			IPath IDF_ADD_PATHS_EXTRAS = new Path(StringUtil.EMPTY);
-			IDF_ADD_PATHS_EXTRAS = IDF_ADD_PATHS_EXTRAS.append(IDF_PATH).append("components/esptool_py/esptool"); //$NON-NLS-1$
+			IPath IDF_ADD_PATHS_EXTRAS = new Path(IDF_PATH).append("components/esptool_py/esptool"); //$NON-NLS-1$
 			IDF_ADD_PATHS_EXTRAS = IDF_ADD_PATHS_EXTRAS.append(":"); //$NON-NLS-1$
 			IDF_ADD_PATHS_EXTRAS = IDF_ADD_PATHS_EXTRAS.append(IDF_PATH).append("components/espcoredump"); //$NON-NLS-1$
 			IDF_ADD_PATHS_EXTRAS = IDF_ADD_PATHS_EXTRAS.append(":"); //$NON-NLS-1$


### PR DESCRIPTION
Previously append was removing slash from the path. 

```
Users/kondal/esp/esp-idf-v4.4.1/components/esptool_py/esptool
```

As you could see there was no slash in the front of the path hence esptool.py was not accessible from the terminal. This got fixed now.

**How to verify:**
1. Go to the ESP-IDF terminal
2. type esptoo.py

