### PR TITLE
IEP-721: Add esp32c3 and esp32s3 to the launch target list

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
@@ -15,15 +15,22 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.launchbar.core.target.ILaunchTargetProvider;
 import org.eclipse.launchbar.core.target.ILaunchTargetWorkingCopy;
 import org.eclipse.launchbar.core.target.TargetStatus;
 
+import com.espressif.idf.core.build.AbstractESPToolchain;
+import com.espressif.idf.core.build.ESP32C3ToolChain;
 import com.espressif.idf.core.build.ESP32S2ToolChain;
+import com.espressif.idf.core.build.ESP32S3ToolChain;
 import com.espressif.idf.core.build.ESP32ToolChain;
 import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.logging.Logger;
 
 /**
  * Launch Target used to flash images to a device over a serial port, usually
@@ -38,28 +45,37 @@ public class SerialFlashLaunchTargetProvider implements ILaunchTargetProvider {
 	@Override
 	public void init(ILaunchTargetManager targetManager) {
 
-		//Create default esp32 target if that doesn't exist
-		if (targetManager.getLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, ESP32ToolChain.OS) == null) {
-			ILaunchTarget target = targetManager.addLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE,
-					ESP32ToolChain.OS);
-			ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
-			wc.setAttribute(ILaunchTarget.ATTR_OS, ESP32ToolChain.OS);
-			wc.setAttribute(ILaunchTarget.ATTR_ARCH, ESP32ToolChain.ARCH);
-			wc.setAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, ESP32ToolChain.OS);
-			wc.save();
+		List<Class<? extends AbstractESPToolchain>> toolchainlist = new ArrayList<>();
+		toolchainlist.add(ESP32ToolChain.class);
+		toolchainlist.add(ESP32S2ToolChain.class);
+		toolchainlist.add(ESP32S3ToolChain.class);
+		toolchainlist.add(ESP32C3ToolChain.class);
+
+		try {
+			addLaunchTarget(targetManager, toolchainlist);
+		} catch (Exception e) {
+			Logger.log(e);
 		}
 
-		//Create default esp32s2 target if that doesn't exist
-		if (targetManager.getLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, ESP32S2ToolChain.OS) == null) {
-			ILaunchTarget target = targetManager.addLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE,
-					ESP32S2ToolChain.OS);
-			ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
-			wc.setAttribute(ILaunchTarget.ATTR_OS, ESP32S2ToolChain.OS);
-			wc.setAttribute(ILaunchTarget.ATTR_ARCH, ESP32S2ToolChain.ARCH);
-			wc.setAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, ESP32S2ToolChain.OS);
-			wc.save();
-		}
+	}
 
+	private void addLaunchTarget(ILaunchTargetManager targetManager,
+			List<Class<? extends AbstractESPToolchain>> toolchainlist)
+			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+
+		for (Class<?> toolchain : toolchainlist) {
+			String os = (String) toolchain.getField("OS").get(null); //$NON-NLS-1$
+			String arch = (String) toolchain.getField("ARCH").get(null); //$NON-NLS-1$
+
+			if (targetManager.getLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os) == null) {
+				ILaunchTarget target = targetManager.addLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os);
+				ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
+				wc.setAttribute(ILaunchTarget.ATTR_OS, os);
+				wc.setAttribute(ILaunchTarget.ATTR_ARCH, arch);
+				wc.setAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, os);
+				wc.save();
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Description
Added esp32s3 and esp32c3 to the default launch target list on the eclipse toolbar

Fixes # ([IEP-721](https://jira.espressif.com:8443/browse/IEP-721))

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

1. Launch Espressif-IDE
2. Verify the default launch target list on the eclipse toolbar, it should show esp32c3 and esp32s3 in the list. 

**Test Configuration**:
* ESP-IDF Version: master
* Espressif-IDE version: Current PR build

## Dependent components impacted by this PR:

- [x] Build
- [x] Launch Configuration