### PR TITLE
Espressif-IDE arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,27 +101,34 @@ jobs:
         /usr/bin/security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
         /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
         
-        echo "codesigning espressif-ide"
+        echo "codesigning espressif-ide-macosx.cocoa.x86_64"
         /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app -v
         /usr/bin/codesign -v -vvv --deep $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app
+
+        echo "codesigning espressif-ide-macosx.cocoa.aarch64"
+        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/aarch64/Espressif-IDE.app -v
+        /usr/bin/codesign -v -vvv --deep $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/aarch64/Espressif-IDE.app
         
-        echo "Creating dmg for Espressif-IDE.app"
+        echo "Creating dmg for espressif-ide-macosx.cocoa.x86_64"
         $PWD/releng/ide-dmg-builder/ide-dmg-builder.sh
-        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg -v
-        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg
+        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg -v
+        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
       
-    #TODO: Enable Notarization only when it's needed on the PR builds. Apple won't recommend notorization on PR or dev builds as it's consumes apple server resources
-    # - name: Notarize Espressif-IDE
-    #   env: 
-    #     NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
-    #     NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-    #   run: |
-    #     echo "Notarization of Espressif-IDE.dmg"
-    #     xcrun altool --notarize-app -f $PWD/releng/ide-dmg-builder/Espressif-IDE.dmg -u $NOTARIZATION_USERNAME -p $NOTARIZATION_PASSWORD --primary-bundle-id Espressif-ide.app
- 
-    - name: Upload macosx dmg
+        echo "Creating dmg for espressif-ide-macosx.cocoa.aarch64"
+        $PWD/releng/ide-dmg-builder/ide-dmg-builder-aarch64.sh
+        /usr/bin/codesign --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg -v
+        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg
+      
+    - name: Upload espressif-ide-macosx.cocoa.x86_64 dmg
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v2
       with:
-        name: espressif-ide-macosx-dmg
-        path: releng/ide-dmg-builder/Espressif-IDE.dmg
+        name: espressif-ide-macosx-cocoa-x86_64
+        path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
+
+    - name: Upload espressif-ide-macosx.cocoa.aarch64 dmg
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: espressif-ide-espressif-ide-macosx.cocoa.aarch64
+        path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,5 +130,5 @@ jobs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v2
       with:
-        name: espressif-ide-espressif-ide-macosx.cocoa.aarch64
+        name: espressif-ide-macosx.cocoa.aarch64
         path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg

--- a/releng/com.espressif.idf.product/pom.xml
+++ b/releng/com.espressif.idf.product/pom.xml
@@ -86,6 +86,11 @@
 							<arch>x86_64</arch>
 						</environment>
 						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
+						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
 							<arch>x86_64</arch>

--- a/releng/ide-dmg-builder/create-dmg/create-dmg
+++ b/releng/ide-dmg-builder/create-dmg/create-dmg
@@ -401,6 +401,10 @@ fi
 echo "Unmounting disk image..."
 hdiutil detach "${DEV_NAME}"
 
+# `hdiutil convert` cannot overwrite files, so remove items in the output
+# directory.
+rm -f "${DMG_TEMP_NAME}"
+
 # Compress image
 echo "Compressing disk image..."
 hdiutil convert ${HDIUTIL_VERBOSITY} "${DMG_TEMP_NAME}" -format ${FORMAT} ${IMAGEKEY} -o "${DMG_DIR}/${DMG_NAME}"

--- a/releng/ide-dmg-builder/create-dmg/create-dmg
+++ b/releng/ide-dmg-builder/create-dmg/create-dmg
@@ -403,7 +403,7 @@ hdiutil detach "${DEV_NAME}"
 
 # `hdiutil convert` cannot overwrite files, so remove items in the output
 # directory.
-rm -f "${DMG_TEMP_NAME}"
+# rm -f "${DMG_DIR}/${DMG_NAME}"
 
 # Compress image
 echo "Compressing disk image..."

--- a/releng/ide-dmg-builder/ide-dmg-builder-aarch64.sh
+++ b/releng/ide-dmg-builder/ide-dmg-builder-aarch64.sh
@@ -3,7 +3,7 @@
 BUILDDIR=$(cd $(dirname $0); pwd)
 parentdir="$(dirname "$BUILDDIR")"
 
-echo "Create DMG installer..."
+echo "Create DMG installer for aarch64..."
 echo $parentdir
 
 $BUILDDIR/create-dmg/create-dmg \
@@ -16,7 +16,7 @@ $BUILDDIR/create-dmg/create-dmg \
   --icon "Espressif-IDE.app" 140 155 \
   --hide-extension "Espressif-IDE.app" \
   --app-drop-link 625 155 \
-  "$BUILDDIR/Espressif-IDE-macosx-cocoa-x86_64.dmg" \
-  "$parentdir/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app"
+  "$BUILDDIR/Espressif-IDE-macosx-cocoa-aarch64.dmg" \
+  "$parentdir/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/aarch64/Espressif-IDE.app"
 
   


### PR DESCRIPTION
## Description

1. Changed macOS x86_64 Espressif-IDE.dmg to `Espressif-IDE-macosx-cocoa-x86_64.dmg`
2. Added new arm64 dmg build `espressif-ide-macosx.cocoa.aarch64.dmg`
3. Entitlements added to arm64 dmg
4. Verified espressif-ide-macosx.cocoa.aarch64.dmg on Apple M1, we are able to launch it successfully after fixing the Entitlements issue

Fixes # ([IEP-731](https://jira.espressif.com:8443/browse/IEP-731))

![Screenshot 2022-07-01 at 7 35 20](https://user-images.githubusercontent.com/8463287/176830819-da9d5c36-259b-46f4-b148-2e952eac1520.png)

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?
Need to verify whether espressif-ide is working on the Apple M1 - Launch espressif-ide, install tools, build, flash, serial monitor, and debugging

**Test Configuration**:
* ESP-IDF Version: master
* Espressif-IDE version: Current PR build
* OS: Apple M1

## Dependent components impacted by this PR:

- Espressif-IDE
- Build
- Flash
- Serial Monitor
- Debugging

