### PR TITLE
Add splashscreen progress monitor

### DIFF
--- a/bundles/com.espressif.idf.branding/plugin.xml
+++ b/bundles/com.espressif.idf.branding/plugin.xml
@@ -33,6 +33,18 @@
                name="preferenceCustomization"
                value="plugin_customization.ini">
          </property>
+     <property
+           name="startupForegroundColor"
+           value="000000">
+     </property>
+     <property
+           name="startupMessageRect"
+           value="7,305,285,20">
+     </property>
+     <property
+           name="startupProgressRect"
+           value="7,290,490,15">
+     </property>
       </product>
    </extension>
 

--- a/bundles/com.espressif.idf.branding/plugin_customization.ini
+++ b/bundles/com.espressif.idf.branding/plugin_customization.ini
@@ -17,10 +17,10 @@ org.eclipse.ui/SHOW_TRADITIONAL_STYLE_TABS=false
 org.eclipse.ui/DOCK_PERSPECTIVE_BAR=topRight
 
 # show progress on startup
-org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=false
+org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=true
 
 # show build id in the splash - only for nightly, integration, and milestone builds
-org.eclipse.ui.workbench/SHOW_BUILDID_ON_STARTUP=false
+org.eclipse.ui.workbench/SHOW_BUILDID_ON_STARTUP=true
 
 # use the window set by default
 org.eclipse.ui/USE_WINDOW_WORKING_SET_BY_DEFAULT=true

--- a/bundles/com.espressif.idf.branding/plugin_customization.ini
+++ b/bundles/com.espressif.idf.branding/plugin_customization.ini
@@ -20,7 +20,7 @@ org.eclipse.ui/DOCK_PERSPECTIVE_BAR=topRight
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=true
 
 # show build id in the splash - only for nightly, integration, and milestone builds
-org.eclipse.ui.workbench/SHOW_BUILDID_ON_STARTUP=true
+org.eclipse.ui.workbench/SHOW_BUILDID_ON_STARTUP=false
 
 # use the window set by default
 org.eclipse.ui/USE_WINDOW_WORKING_SET_BY_DEFAULT=true

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -27,10 +27,7 @@
    <windowImages i16="/com.espressif.idf.branding/icons/16x16.png" i32="/com.espressif.idf.branding/icons/32x32.png" i48="/com.espressif.idf.branding/icons/48x48.png" i64="/com.espressif.idf.branding/icons/64x64.png" i128="/com.espressif.idf.branding/icons/128x128.png" i256="/com.espressif.idf.branding/icons/256x256.png"/>
 
    <splash
-      location="com.espressif.idf.branding"
-      startupProgressRect="50,100,300,15"
-      startupMessageRect="100,100,300,18"
-      startupForegroundColor="FF2F92" />
+      location="com.espressif.idf.branding" />
    <launcher name="espressif-ide">
       <linux icon="laucher/espressif.xpm"/>
       <macosx icon="laucher/espressif.icns"/>

--- a/releng/com.espressif.idf.product/plugin_customization.ini
+++ b/releng/com.espressif.idf.product/plugin_customization.ini
@@ -1,1 +1,0 @@
-org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true


### PR DESCRIPTION
## Description
Added progress monitor along with the text on the espressif-ide splash screen

Fixes # ([IEP-731](https://jira.espressif.com:8443/browse/IEP-731))

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

1. Download espressif-ide from this PR
2. Verify if you are able to see the progress monitor and text message on the splash screen

**Test Configuration**:
* ESP-IDF Version: master
* Espressif-IDE version: Current PR build

## Dependent components impacted by this PR:

- Splash screen

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS

