### PR TITLE
Fix: Add default user workspace

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -14,8 +14,6 @@
    </configIni>
 
    <launcherArgs>
-      <programArgs>-data @noDefault
-      </programArgs>
       <vmArgsLin>-Xms256m -Xmx2048m  -Dosgi.requiredJavaVersion=11 -Dosgi.instance.area.default=@user.home/espressif-workspace
       </vmArgsLin>
       <vmArgsMac>-Xms256m -Xmx2048m  -Xdock:icon=../Resources/espressif.icns -XstartOnFirstThread -Dosgi.requiredJavaVersion=11 -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.instance.area.default=@user.home/espressif-workspace
@@ -86,7 +84,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
-      <property name="osgi.instance.area.default" value="@user.home/espressif-workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
    </configurations>
 
    <repositories>

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -86,6 +86,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
+      <property name="osgi.instance.area.default" value="@user.home/espressif-workspace" />
    </configurations>
 
    <repositories>


### PR DESCRIPTION
## Description

Set the default user workspace to the /USER_HOME/workspace

Fixes # ([IEP-xxx](https://jira.espressif.com:8443/browse/IEP-xxx))

## Type of change

- Bugfix


## How has this been tested?

Test Case:
- Download Espressif-IDE with this PR
- Observe the workspace selection dialog during the launch, it should set a default workspace to /USER_HOME/workspace

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:
- Espressif-IDE startup workspace selection dialog

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
