### PR TITLE
IEP-722: Use python (not pip) for installing websocket client

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.IToolChainManager;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -72,10 +71,6 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.setTaskName(Messages.InstallToolsHandler_InstallingPythonMsg);
 				handleToolsInstallPython();
 				monitor.worked(1);
-				
-				monitor.setTaskName(Messages.InstallToolsHandler_InstallingWebscoketMsg);
-				handleWebSocketClientInstall();
-				monitor.worked(1);
 
 				monitor.setTaskName(Messages.InstallToolsHandler_ExportingPathsMsg);
 				new ExportIDFTools().runToolsExport(pythonExecutablenPath, gitExecutablePath, console);
@@ -87,6 +82,10 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.worked(1);
 				
 				configEnv();
+				
+				monitor.setTaskName(Messages.InstallToolsHandler_InstallingWebscoketMsg);
+				handleWebSocketClientInstall();
+				monitor.worked(1);
 				
 				copyOpenOcdRules();
 				console.println(Messages.InstallToolsHandler_ConfiguredCMakeMsg);
@@ -215,18 +214,12 @@ public class InstallToolsHandler extends AbstractToolsHandler
 	
 	protected void handleWebSocketClientInstall()
 	{
-		IPath pipPath = new org.eclipse.core.runtime.Path(pythonExecutablenPath); //$NON-NLS-1$
-		String pipPathLastSegment = pipPath.lastSegment().replace("python", "pip"); //$NON-NLS-1$ //$NON-NLS-2$
-		pipPath = pipPath.removeLastSegments(1).append(pipPathLastSegment); 
-		if (!pipPath.toFile().exists()) 
-		{
-			console.println(String.format("%s executable not found. Unable to run `%s install websocket-client`", pipPathLastSegment, pipPathLastSegment)); //$NON-NLS-1$
-			return;
-		}
-
+		 
 		// pip install websocket-client
 		List<String> arguments = new ArrayList<String>();
-		arguments.add(pipPath.toOSString());
+		arguments.add(IDFUtil.getIDFPythonEnvPath());
+		arguments.add("-m"); //$NON-NLS-1$
+		arguments.add("pip"); //$NON-NLS-1$
 		arguments.add("install"); //$NON-NLS-1$
 		arguments.add("websocket-client"); //$NON-NLS-1$
 		

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -217,7 +217,14 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		 
 		// pip install websocket-client
 		List<String> arguments = new ArrayList<String>();
-		arguments.add(IDFUtil.getIDFPythonEnvPath());
+		final String pythonEnvPath = IDFUtil.getIDFPythonEnvPath();
+		if (pythonEnvPath != null && new File(pythonEnvPath).exists())
+		{
+			console.println(String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
+					IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD));
+			return;
+		}
+		arguments.add(pythonEnvPath);
 		arguments.add("-m"); //$NON-NLS-1$
 		arguments.add("pip"); //$NON-NLS-1$
 		arguments.add("install"); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -218,7 +218,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		// pip install websocket-client
 		List<String> arguments = new ArrayList<String>();
 		final String pythonEnvPath = IDFUtil.getIDFPythonEnvPath();
-		if (pythonEnvPath != null && new File(pythonEnvPath).exists())
+		if (pythonEnvPath == null || !new File(pythonEnvPath).exists())
 		{
 			console.println(String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
 					IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD));


### PR DESCRIPTION
## Description

Installing WebSocket into the python environment instead of the global python directory.

Fixes # ([IEP-722](https://jira.espressif.com:8443/browse/IEP-722))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Clean the esp-idf python environment in the` .espressif` folder. 
- Restore eclipse env variables: Preferences -> C/C++ -> Build -> Environment - Restore Defautls
- Install Tools from the Eclipse
- Check the install tools log. Below setting `IDF_PYTHON_ENV_PATH` should be executing installing websocket command `Executing /Users/denysalmazov/.espressif/python_env/idf5.0_py3.9_env/bin/python -m pip install websocket-client`
- Try to launch [the Serial Monitor](https://github.com/espressif/idf-eclipse-plugin#viewing-serial-output) to check if it works ok.

**Test Configuration**:
* ESP-IDF Version: 4.1 and higher
* OS (Windows,Linux and macOS): Windows, Linux, macOS



## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
