### PR TITLE
IEP-732: Remove "Python declared in PATH variable" from the product info

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/help/ProductInformationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/help/ProductInformationHandler.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -55,8 +54,6 @@ public class ProductInformationHandler extends ListInstalledToolsHandler
 		showEspIdfVersion();
 		console.println(Messages.PythonIdfEnvMsg + (Optional
 				.ofNullable(getPythonExeVersion(IDFUtil.getIDFPythonEnvPath())).orElse(Messages.NotFoundMsg)));
-		console.println(Messages.PythonPathMsg
-				+ (Optional.ofNullable(getPythonExeVersion("python")).orElse(Messages.NotFoundMsg))); //$NON-NLS-1$
 
 		return null;
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
@@ -48,7 +48,6 @@ public class Messages extends NLS
 	public static String IdfEclipseMsg;
 	public static String EclipseMsg;
 	public static String PythonIdfEnvMsg;
-	public static String PythonPathMsg;
 	public static String MissingIdfPathMsg;
 	public static String NotFoundMsg;
 	

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
@@ -41,6 +41,5 @@ EclipseCDTMsg=Eclipse CDT Version:
 IdfEclipseMsg=IDF Eclipse Plugin Version: 
 EclipseMsg=Eclipse Version: 
 PythonIdfEnvMsg=Python set for IDF_PYTHON_ENV: 
-PythonPathMsg=Python declared in PATH variable: 
 MissingIdfPathMsg=ESP-IDF version cannot be checked. IDF_PATH or IDF_PYTHON_ENV_PATH  are not set.
 NotFoundMsg=<NOT FOUND>


### PR DESCRIPTION
## Description

Remove "Python declared in PATH variable" info from the product information which IDE generates.

It was trying to run the "python -v" command with the system environment and I think this is not required to be reported by the IDE, will get rid of it to avoid confusion.

This is a learning from one of the customer, where the system is configured with python 2.7 and eclipse build is configured to run with 3.7, however, when product information is generated it was showing that "Python declared in PATH variable is 2.7" that created confusion to the user why 2.7 is getting used!

Fixes # ([IEP-732](https://jira.espressif.com:8443/browse/IEP-732))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Launch Espressif-IDE
- Go to Espressif Menu
- Click on "Product Information"
- Generated product information should not contain "Python declared in PATH variable"

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): Windows or Mac. Testing on one machine should be sufficent

## Dependent components impacted by this PR:

- Product Information
- 
## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
