### PR TITLE
IEP-738: select esp32s2 target for DFU test

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
@@ -37,6 +37,7 @@ import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
 import com.espressif.idf.ui.test.operations.EnvSetupOperations;
 import com.espressif.idf.ui.test.operations.ProjectTestOperations;
 import com.espressif.idf.ui.test.operations.SWTBotTreeOperations;
+import com.espressif.idf.ui.test.operations.selectors.LaunchBarTargetSelector;
 
 /**
  * Test class to test the project creation, build and basic operations
@@ -176,6 +177,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
 		Fixture.givenProjectNameIs("NewProjectTest");
 		Fixture.whenNewProjectIsSelected();
+		Fixture.thenLaunchTargetIsSelectedFromLaunchTargets("esp32s2");
 		Fixture.switchDfuStatus();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.thenProjectHasTheFile("dfu.bin", "/build");
@@ -189,12 +191,26 @@ public class NewEspressifIDFProjectTest
 		private static String subCategory;
 		private static String projectName;
 		private static String projectTemplate;
+		private static LaunchBarTargetSelector launchBarTargetSelector;
 
 		private static void loadEnv() throws Exception
 		{
 			bot = WorkBenchSWTBot.getBot();
 			EnvSetupOperations.setupEspressifEnv(bot);
 			bot.sleep(1000);
+			try
+			{
+				launchBarTargetSelector = new LaunchBarTargetSelector(bot);
+			}
+			catch (WidgetNotFoundException e)
+			{
+				launchBarTargetSelector = new LaunchBarTargetSelector(bot, false);
+			}
+		}
+
+		public static void thenLaunchTargetIsSelectedFromLaunchTargets(String launchTargetName)
+		{
+			launchBarTargetSelector.select(launchTargetName);
 		}
 
 		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)


### PR DESCRIPTION
## Description

This was cherry picked for quick merge to the master from IEP-448

Fixes # ([IEP-738](https://jira.espressif.com:8443/browse/IEP-738))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Tested on ([IEP-448 PR](https://github.com/espressif/idf-eclipse-plugin/pull/419)) builds

**Test Configuration**:
* Github Runner Ubuntu

## Dependent components impacted by this PR:
Master and all subranches should be rebased again for successful test runs. 

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
