### PR TITLE
IEP-635 Provide diagnostic info on why GDB is crashed

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -196,7 +196,6 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 		}
 
 		String gdbVersion = LaunchUtils.getGDBVersionFromText(status.getMessage());
-		// String gdbVersion = "7.10";
 		if (gdbVersion == null || gdbVersion.isEmpty())
 		{
 			throw new DebugException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, DebugException.REQUEST_FAILED,
@@ -205,9 +204,6 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 					null));// $NON-NLS-1$
 		}
 
-		// Used to test if version comparison works
-		// System.out.println(gdbVersion);
-		// gdbVersion = "7.10";
 		return gdbVersion;
 	}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -202,9 +202,9 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			String errorMessage = status.getCode() == STATUS_DLL_NOT_FOUND ? Messages.DllNotFound_ExceptionMessage
 					: status.getMessage();
 			throw new DebugException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, DebugException.REQUEST_FAILED,
-					"Could not determine GDB version after sending: " + StringUtils.join(cmdArray, " ") + ", response: "
-							+ errorMessage,
-					null));// $NON-NLS-1$
+					"Could not determine GDB version after sending: " + StringUtils.join(cmdArray, " ")
+							+ ", response: \n" + errorMessage + "\nERROR CODE:" + status.getCode(),
+					null));// $NON-NLS-1$ // $NON-NLS-2$
 		}
 
 		return gdbVersion;

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
@@ -22,7 +22,8 @@ import org.eclipse.osgi.util.NLS;
 
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 
-public class Messages {
+public class Messages
+{
 
 	// ------------------------------------------------------------------------
 
@@ -36,7 +37,7 @@ public class Messages {
 
 	public static String McuPage_executable_label;
 	public static String McuPage_executable_folder;
-	
+
 	public static String BreakPointPage_RadioGroupTitle;
 	public static String BreakPointPage_BtnStartHeapTrace;
 	public static String BreakPointPage_BtnStopHeapTrace;
@@ -55,36 +56,48 @@ public class Messages {
 	public static String MissingDebugConfigurationTitle;
 	public static String DebugConfigurationNotFoundMsg;
 	public static String AppLvlTracingJob;
+
+	public static String DllNotFound_ExceptionMessage;
 	// ------------------------------------------------------------------------
 
-	static {
+	static
+	{
 		// initialise resource bundle
 		NLS.initializeMessages(MESSAGES, Messages.class);
 	}
 
 	private static ResourceBundle RESOURCE_BUNDLE;
 
-
-	static {
-		try {
+	static
+	{
+		try
+		{
 			RESOURCE_BUNDLE = ResourceBundle.getBundle(MESSAGES);
-		} catch (MissingResourceException e) {
+		}
+		catch (MissingResourceException e)
+		{
 			Activator.log(e);
 		}
 	}
 
-	private Messages() {
+	private Messages()
+	{
 	}
 
-	public static String getString(String key) {
-		try {
+	public static String getString(String key)
+	{
+		try
+		{
 			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
+		}
+		catch (MissingResourceException e)
+		{
 			return '!' + key + '!';
 		}
 	}
 
-	public static ResourceBundle getResourceBundle() {
+	public static ResourceBundle getResourceBundle()
+	{
 		return RESOURCE_BUNDLE;
 	}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
@@ -397,3 +397,5 @@ MissingDebugConfigurationTitle=Missing debug configuration
 OpenOcdFailedMsg=OpenOCD was not started
 DebugConfigurationNotFoundMsg=No matching debug configuration was found for the selected project. Do you want to create it?
 AppLvlTracingJob=Launching application level tracing
+
+DllNotFound_ExceptionMessage=some required DLL(s) not found


### PR DESCRIPTION
## Description
Provide simple error messages based on the error code without specifying the name of the dll that is missing. This fix is ​​specific to Windows OS.

Fixes # ([IEP-635](https://jira.espressif.com:8443/browse/IEP-635))

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Case 1:
- To make GDB crash you need to remove libgcc_s_seh-1.dll from the toolchain.
```
C:\projects\esp-idf>where libgcc_s_seh-1.dll
C:\Users\alexey\.espressif\tools\xtensa-esp32-elf\esp-2021r2-patch2-8.4.0\xtensa-esp32-elf\bin\libgcc_s_seh-1.dll
C:\Users\alexey\.espressif\tools\xtensa-esp32s2-elf\esp-2021r2-patch2-8.4.0\xtensa-esp32s2-elf\bin\libgcc_s_seh-1.dll
C:\Users\alexey\.espressif\tools\xtensa-esp32s3-elf\esp-2021r2-patch2-8.4.0\xtensa-esp32s3-elf\bin\libgcc_s_seh-1.dll
C:\Users\alexey\.espressif\tools\riscv32-esp-elf\esp-2021r2-patch2-8.4.0\riscv32-esp-elf\bin\libgcc_s_seh-1.dll
```
- Create a project in eclipse
- [Create a debug configuration](https://github.com/espressif/idf-eclipse-plugin/blob/master/docs/OpenOCD%20Debugging.md#create-a-new-debug-configuration)  for this project 
- Build the project
- Debug the project should fail with such error message 
![image](https://user-images.githubusercontent.com/24419842/181778683-aa591df4-15a0-4d10-b81e-5070ff85a8d3.png)

**Test Configuration**:
* ESP-IDF Version:master
* OS Windows

## Dependent components impacted by this PR:

- Project debugging 

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows
