### PR TITLE
IEP-736: CCache enable/disable control from preferences page

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
@@ -1,0 +1,60 @@
+
+/*******************************************************************************
+ * Copyright 2022 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+
+/**
+ * @author Kondal Kolipaka
+ * 
+ *         Any preference constants which are intended to be used across IDE
+ *
+ */
+public class IDFCorePreferenceConstants
+{
+	// CMake CCache preferences
+	public static final String CMAKE_CCACHE_STATUS = "cmakeCCacheStatus"; //$NON-NLS-1$
+	public static final boolean CMAKE_CCACHE_DEFAULT_STATUS = true;
+
+	/**
+	 * Returns the node in the preference in the given context.
+	 *
+	 * @param key     The preference key.
+	 * @param project The current context or {@code null} if no context is available and the workspace setting should be
+	 *                taken. Note that passing {@code null} should be avoided.
+	 * @return Returns the node matching the given context.
+	 */
+	public static IEclipsePreferences getPreferenceNode(String key, IProject project)
+	{
+		IEclipsePreferences node = null;
+		if (project != null)
+		{
+			node = new ProjectScope(project).getNode(IDFCorePlugin.PLUGIN_ID);
+			if (node.get(key, null) != null)
+			{
+				return node;
+			}
+		}
+		node = InstanceScope.INSTANCE.getNode(IDFCorePlugin.PLUGIN_ID);
+		if (node.get(key, null) != null)
+		{
+			return node;
+		}
+
+		node = ConfigurationScope.INSTANCE.getNode(IDFCorePlugin.PLUGIN_ID);
+		if (node.get(key, null) != null)
+		{
+			return node;
+		}
+
+		return DefaultScope.INSTANCE.getNode(IDFCorePlugin.PLUGIN_ID);
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -325,10 +325,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 				{
 					command.add("-DCCACHE_ENABLE=1"); //$NON-NLS-1$
 				}
-				else
-				{
-					command.add("-DCCACHE_ENABLE=0"); //$NON-NLS-1$
-				}
 
 				if (launchtarget != null) {
 					String idfTargetName = launchtarget.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -76,11 +76,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
+
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.IDFCorePreferenceConstants;
 import com.espressif.idf.core.internal.CMakeConsoleWrapper;
 import com.espressif.idf.core.internal.CMakeErrorParser;
 import com.espressif.idf.core.logging.Logger;
@@ -318,7 +321,14 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 				}
 
 				command.add("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"); //$NON-NLS-1$
-				command.add("-DCCACHE_ENABLE=1"); //$NON-NLS-1$
+				if (isCCacheEnabled())
+				{
+					command.add("-DCCACHE_ENABLE=1"); //$NON-NLS-1$
+				}
+				else
+				{
+					command.add("-DCCACHE_ENABLE=0"); //$NON-NLS-1$
+				}
 
 				if (launchtarget != null) {
 					String idfTargetName = launchtarget.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
@@ -462,6 +472,12 @@ public class IDFBuildConfiguration extends CBuildConfiguration {
 							project.getName()),
 					e));
 		}
+	}
+
+	private boolean isCCacheEnabled()
+	{
+		IEclipsePreferences node = IDFCorePreferenceConstants.getPreferenceNode(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, null);
+		return node.getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, true);
 	}
 
 	

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -6,6 +6,7 @@ import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
@@ -14,8 +15,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
+import com.espressif.idf.core.IDFCorePreferenceConstants;
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.ui.UIPlugin;
 
 public class EspresssifPreferencesPage extends PreferencePage implements IWorkbenchPreferencePage
 {
@@ -29,11 +31,12 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	private Text numberOfCharsInLineText;
 	private Text numberLineText;
 	private Text gdbSettingsText;
+	private Button ccacheBtn;
 
 	public EspresssifPreferencesPage()
 	{
 		super();
-		setPreferenceStore(new ScopedPreferenceStoreWithoutDefaults(InstanceScope.INSTANCE, UIPlugin.PLUGIN_ID));
+		setPreferenceStore(new ScopedPreferenceStoreWithoutDefaults(InstanceScope.INSTANCE, IDFCorePlugin.PLUGIN_ID));
 		setDescription(Messages.EspresssifPreferencesPage_IDFSpecificPrefs);
 	}
 
@@ -58,11 +61,27 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		data.horizontalAlignment = GridData.FILL;
 		mainComposite.setLayoutData(data);
 
+		addccacheControl(mainComposite);
+		
 		addGdbSettings(mainComposite);
 
 		addSerialSettings(mainComposite);
 
 		return mainComposite;
+	}
+
+	private void addccacheControl(Composite mainComposite)
+	{
+		Composite ccacheComp = new Composite(mainComposite, SWT.SHADOW_ETCHED_IN);
+		ccacheComp.setLayout(new GridLayout(1, false));
+		ccacheComp.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
+
+		ccacheBtn = new Button(ccacheComp, SWT.CHECK);
+		ccacheBtn.setText("Enable CMake CCache");
+		ccacheBtn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		ccacheBtn.setToolTipText("This sets CCACHE_ENABLE=1 to the IDF CMake build");
+		ccacheBtn.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS));
+
 	}
 
 	private void addSerialSettings(Composite parent)
@@ -114,6 +133,8 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 
 			int numberOfLines = Integer.parseInt(numberLineText.getText());
 			getPreferenceStore().setValue(NUMBER_OF_LINES, numberOfLines);
+			
+			getPreferenceStore().setValue(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, ccacheBtn.getSelection());
 		}
 		catch (Exception e)
 		{
@@ -129,6 +150,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		gdbSettingsText.setText(Integer.toString(getPreferenceStore().getDefaultInt(GDB_SERVER_LAUNCH_TIMEOUT)));
 		numberLineText.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_LINES)));
 		numberOfCharsInLineText.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_CHARS_IN_A_LINE)));
+		ccacheBtn.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS));
 	}
 
 	private void initializeDefaults()
@@ -136,5 +158,6 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		getPreferenceStore().setDefault(GDB_SERVER_LAUNCH_TIMEOUT, 25);
 		getPreferenceStore().setDefault(NUMBER_OF_CHARS_IN_A_LINE, DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE);
 		getPreferenceStore().setDefault(NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, IDFCorePreferenceConstants.CMAKE_CCACHE_DEFAULT_STATUS);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -77,9 +77,9 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		ccacheComp.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
 
 		ccacheBtn = new Button(ccacheComp, SWT.CHECK);
-		ccacheBtn.setText("Enable CMake CCache");
+		ccacheBtn.setText(Messages.EspresssifPreferencesPage_EnableCCache);
 		ccacheBtn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-		ccacheBtn.setToolTipText("This sets CCACHE_ENABLE=1 to the IDF CMake build");
+		ccacheBtn.setToolTipText(Messages.EspresssifPreferencesPage_CCacheToolTip);
 		ccacheBtn.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS));
 
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
@@ -5,6 +5,8 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.preferences.messages"; //$NON-NLS-1$
+	public static String EspresssifPreferencesPage_CCacheToolTip;
+	public static String EspresssifPreferencesPage_EnableCCache;
 	public static String EspresssifPreferencesPage_IDFSpecificPrefs;
 	public static String GDBServerTimeoutPage_TimeoutField;
 	public static String SerialMonitorPage_Field_NumberOfLines;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
@@ -1,3 +1,5 @@
+EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build
+EspresssifPreferencesPage_EnableCCache=Enable CMake CCache
 EspresssifPreferencesPage_IDFSpecificPrefs=ESP-IDF Specific Preferences.
 GDBServerTimeoutPage_TimeoutField=GDB server launch timeout(s)
 SerialMonitorPage_Field_NumberOfCharsInLine=Console Line Width (maximum characters):


### PR DESCRIPTION
## Description

CCache enable/disable control from the preferences page 

Fixes # ([IEP-736](https://jira.espressif.com:8443/browse/IEP-736))

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Case 1:
- Launch Espressif-IDE
- Build a Hello-world project 
- By default project should build CCache enabled (look for -DCCACHE_ENABLE=1 in the console)

Case 2:
- Launch Espressif-IDE
- Go to Espressif preferences and disable CCache
- Build a Hello-world project 
- Project should build with CCache disabled (look for -DCCACHE_ENABLE and it shouldn't be found)

**Test Configuration**:
* ESP-IDF Version:master
* OS (Windows,Linux and macOS): All

## Dependent components impacted by this PR:

- Build
- Espressif Preferences page

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
