### PR TITLE
IEP-744: Fix for eclipse launch parameter for CI Issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'adopt'
 
     - name: Build with Maven
-      run: sudo dbus-uuidgen > /var/lib/dbus/machine-id && export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
+      run: export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
     - uses: jwgmeligmeyling/spotbugs-github-action@master
       with:
         path: '**/spotbugsXml.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         maven-version: 3.8.4
    
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Build with Maven
       run: export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'adopt'
 
     - name: Build with Maven
-      run: dbus-uuidgen > /var/lib/dbus/machine-id && export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
+      run: sudo dbus-uuidgen > /var/lib/dbus/machine-id && export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
     - uses: jwgmeligmeyling/spotbugs-github-action@master
       with:
         path: '**/spotbugsXml.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'adopt'
 
     - name: Build with Maven
-      run: export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
+      run: dbus-uuidgen > /var/lib/dbus/machine-id && export NO_AT_BRIDGE=1 && mvn clean verify -Djarsigner.skip=true spotbugs:spotbugs -DskipTests=false
     - uses: jwgmeligmeyling/spotbugs-github-action@master
       with:
         path: '**/spotbugsXml.xml'


### PR DESCRIPTION
## Description

Fix for eclipse launch parameter for CI Issues
_**-vmargs -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8989**_

Fixes # ([IEP-744](https://jira.espressif.com:8443/browse/IEP-744))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Running builds on self hosted runner.

## Checklist
- [x] PR Self Reviewed
- [x] Verified Builds
