### PR TITLE
IEP-681: Show Tools installation error messages in red color

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
@@ -30,19 +30,19 @@ public class IDFEnvironmentVariables
 	 * ESPRESSIF IDF_PATH environment variable identifier
 	 * 
 	 */
-	public static String IDF_PATH = "IDF_PATH"; //$NON-NLS-1$
+	public static final String IDF_PATH = "IDF_PATH"; //$NON-NLS-1$
 
-	public static String IDF_PYTHON_ENV_PATH = "IDF_PYTHON_ENV_PATH"; //$NON-NLS-1$
+	public static final String IDF_PYTHON_ENV_PATH = "IDF_PYTHON_ENV_PATH"; //$NON-NLS-1$
 
-	public static String PATH = "PATH"; //$NON-NLS-1$
+	public static final String PATH = "PATH"; //$NON-NLS-1$
 
-	public static String OPENOCD_SCRIPTS = "OPENOCD_SCRIPTS"; //$NON-NLS-1$
+	public static final String OPENOCD_SCRIPTS = "OPENOCD_SCRIPTS"; //$NON-NLS-1$
 
-	public static String IDF_COMPONENT_MANAGER = "IDF_COMPONENT_MANAGER"; //$NON-NLS-1$
+	public static final String IDF_COMPONENT_MANAGER = "IDF_COMPONENT_MANAGER"; //$NON-NLS-1$
 
-	public static String GIT_PATH ="GIT_PATH"; //$NON-NLS-1$
+	public static final String GIT_PATH ="GIT_PATH"; //$NON-NLS-1$
 	
-	public static String PYTHON_EXE_PATH ="PYTHON_EXE_PATH"; //$NON-NLS-1$
+	public static final String PYTHON_EXE_PATH ="PYTHON_EXE_PATH"; //$NON-NLS-1$
 	
 	/**
 	 * @param variableName Environment variable Name

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
@@ -39,8 +39,7 @@ public class IDFVersionsReader
 		{
 			URL url = new URL(VERSIONS_URL);
 			URLConnection yc = url.openConnection();
-			BufferedReader in = new BufferedReader(new InputStreamReader(yc.getInputStream(), yc.getContentEncoding()));
-
+			BufferedReader in = new BufferedReader(new InputStreamReader(yc.getInputStream()));
 			String inputLine;
 			while ((inputLine = in.readLine()) != null)
 			{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.osgi.framework.Version;
 
@@ -38,7 +39,7 @@ public class IDFVersionsReader
 		{
 			URL url = new URL(VERSIONS_URL);
 			URLConnection yc = url.openConnection();
-			BufferedReader in = new BufferedReader(new InputStreamReader(yc.getInputStream()));
+			BufferedReader in = new BufferedReader(new InputStreamReader(yc.getInputStream(), yc.getContentEncoding()));
 
 			String inputLine;
 			while ((inputLine = in.readLine()) != null)
@@ -127,10 +128,10 @@ public class IDFVersionsReader
 	{
 		IDFVersionsReader reader = new IDFVersionsReader();
 		Map<String, IDFVersion> versionsMap = reader.getVersionsMap();
-		for (String version : versionsMap.keySet())
+		for (Entry<String, IDFVersion> entry : versionsMap.entrySet())
 		{
-			IDFVersion idfVersion = versionsMap.get(version);
-			System.out.println("Version:" + version); //$NON-NLS-1$
+			IDFVersion idfVersion = entry.getValue();
+			System.out.println("Version:" + entry.getKey()); //$NON-NLS-1$
 			System.out.println("URL:" + idfVersion.getUrl()); //$NON-NLS-1$
 			System.out.println("Mirror URL:" + idfVersion.getMirrorUrl()); //$NON-NLS-1$
 			System.out.println(""); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/Version.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/Version.java
@@ -51,4 +51,9 @@ public class Version implements Comparable<Version>
 		return this.compareTo((Version) that) == 0;
 	}
 
+	@Override
+	public int hashCode()
+	{
+		return version.hashCode();
+	}
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.runtime.Platform;
@@ -108,27 +109,27 @@ public class EclipseIniUtil
 	{
 		File file = new File(eclipseIniUri);
 		List<String> contentsToWrite = new ArrayList<String>();
-		for (String key : eclipseIniSwitchMap.keySet())
+		for (Entry<String, String> entry : eclipseIniSwitchMap.entrySet())
 		{
-			contentsToWrite.add(key);
-			if (!StringUtil.isEmpty(eclipseIniSwitchMap.get(key)))
+			contentsToWrite.add(entry.getKey());
+			if (!StringUtil.isEmpty(entry.getValue()))
 			{
-				contentsToWrite.add(eclipseIniSwitchMap.get(key));
+				contentsToWrite.add(entry.getValue());
 			}
 		}
 
 		contentsToWrite.add(ECLIPSE_INI_VMARGS);
 
-		for (String key : eclipseVmArgMap.keySet())
+		for (Entry<String, String> entry : eclipseVmArgMap.entrySet())
 		{
-			if (!StringUtil.isEmpty(eclipseVmArgMap.get(key)))
+			if (!StringUtil.isEmpty(entry.getValue()))
 			{
-				String contentToWrite = key + "=" + eclipseVmArgMap.get(key); //$NON-NLS-1$
+				String contentToWrite = entry.getKey() + "=" + entry.getValue(); //$NON-NLS-1$
 				contentsToWrite.add(contentToWrite);
 			}
 			else
 			{
-				contentsToWrite.add(key);
+				contentsToWrite.add(entry.getKey());
 			}
 		}
 

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -359,7 +359,7 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 	{
 
 		// Create console
-		MessageConsoleStream console = new IDFConsole().getConsoleStream("JSON Configuration Server Console", null); //$NON-NLS-1$
+		MessageConsoleStream console = new IDFConsole().getConsoleStream("JSON Configuration Server Console", null, false); //$NON-NLS-1$
 
 
 		configServer = ConfigServerManager.INSTANCE.getServer(project);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/IDFConsole.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/IDFConsole.java
@@ -7,6 +7,7 @@ package com.espressif.idf.ui;
 import java.net.URL;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -29,10 +30,10 @@ public class IDFConsole
 	
 	public MessageConsoleStream getConsoleStream()
 	{
-		return getConsoleStream("ESP-IDF Console", null); //$NON-NLS-1$
+		return getConsoleStream("ESP-IDF Console", null, false); //$NON-NLS-1$
 	}
 	
-	public MessageConsoleStream getConsoleStream(String consoleName, URL imageUrl)
+	public MessageConsoleStream getConsoleStream(String consoleName, URL imageUrl, boolean errorStream)
 	{
 		// Create Tools console
 		MessageConsole msgConsole = findConsole(consoleName, imageUrl);
@@ -47,9 +48,10 @@ public class IDFConsole
 			public void run()
 			{
 				openConsoleView();
+				if (errorStream) console.setColor(new Color(255, 0, 0));
 			}
 		});
-
+		
 		return console;
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -41,6 +41,7 @@ import com.espressif.idf.ui.dialogs.MessageLinkDialog;
 import com.espressif.idf.ui.update.ExportIDFTools;
 import com.espressif.idf.ui.update.InstallToolsHandler;
 
+@SuppressWarnings("restriction")
 public class InitializeToolsStartup implements IStartup
 {
 
@@ -58,7 +59,6 @@ public class InitializeToolsStartup implements IStartup
 	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
 
-	@SuppressWarnings("restriction")
 	@Override
 	public void earlyStartup()
 	{
@@ -126,7 +126,7 @@ public class InitializeToolsStartup implements IStartup
 				if (!StringUtil.isEmpty(pythonExecutablePath) && !StringUtil.isEmpty(gitExecutablePath))
 				{
 					ExportIDFTools exportIDFTools = new ExportIDFTools();
-					exportIDFTools.runToolsExport(pythonExecutablePath, gitExecutablePath, null);
+					exportIDFTools.runToolsExport(pythonExecutablePath, gitExecutablePath, null, null);
 
 					// Configure toolchains
 					configureToolChain();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tracing/AppLvlTracingDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tracing/AppLvlTracingDialog.java
@@ -327,7 +327,7 @@ public class AppLvlTracingDialog extends TitleAreaDialog {
 	private void activateTracingConsoleView()
 	{
 		URL imageUrl = FileLocator.find(UIPlugin.getDefault().getBundle(), new Path("icons/ESP-IDF_Application_Level_Tracing.png")); //$NON-NLS-1$
-		console = new IDFConsole().getConsoleStream(Messages.AppLvlTracing_ConsoleName, imageUrl);
+		console = new IDFConsole().getConsoleStream(Messages.AppLvlTracing_ConsoleName, imageUrl, false);
 	}
 
 	private void browseButtonSelected(String title, Text text) {

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -167,7 +167,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 			}
 			if (status.getSeverity() == IStatus.ERROR)
 			{
-				errorConsoleStream.print(status.getException().getMessage());
+				errorConsoleStream.print(status.getException() != null ? status.getException().getMessage() : status.getMessage());
 			}
 			console.println(status.getMessage());
 			console.println();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -17,9 +17,6 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.MessageConsoleStream;
 
 import com.espressif.idf.core.ExecutableFinder;
@@ -42,6 +39,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 	 * Tools console
 	 */
 	protected MessageConsoleStream console;
+	protected MessageConsoleStream errorConsoleStream;
 	protected String idfPath;
 	protected String pythonExecutablenPath;
 	protected String gitExecutablePath;
@@ -92,7 +90,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 		if (StringUtil.isEmpty(pythonExecutablenPath) || StringUtil.isEmpty(gitExecutablePath)
 				|| StringUtil.isEmpty(idfPath))
 		{
-			console.print("One or more paths are empty! Make sure you provide IDF_PATH, git and python executables"); //$NON-NLS-1$
+			errorConsoleStream.print("One or more paths are empty! Make sure you provide IDF_PATH, git and python executables"); //$NON-NLS-1$
 			return null;
 		}
 
@@ -104,10 +102,11 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 
 		return null;
 	}
-
+	
 	protected void activateIDFConsoleView()
 	{
-		console = new IDFConsole().getConsoleStream(Messages.IDFToolsHandler_ToolsManagerConsole, null);
+		console = new IDFConsole().getConsoleStream(Messages.IDFToolsHandler_ToolsManagerConsole, null, false);
+		errorConsoleStream = new IDFConsole().getConsoleStream(Messages.IDFToolsHandler_ToolsManagerConsole, null, true);
 	}
 
 	protected String getPythonExecutablePath()
@@ -166,7 +165,10 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 				Logger.log(IDFCorePlugin.getPlugin(), IDFCorePlugin.errorStatus("Status can't be null", null)); //$NON-NLS-1$
 				return IDFCorePlugin.errorStatus("Status can't be null", null); //$NON-NLS-1$
 			}
-
+			if (status.getSeverity() == IStatus.ERROR)
+			{
+				errorConsoleStream.print(status.getException().getMessage());
+			}
 			console.println(status.getMessage());
 			console.println();
 			

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
@@ -67,7 +67,7 @@ public class ExportIDFTools
 			
 			if (status.getSeverity() == IStatus.ERROR)
 			{
-				log(status.getException().getMessage(), errorConsoleStream);
+				log(status.getException() != null ? status.getException().getMessage() : status.getMessage(), errorConsoleStream);
 				return status;				
 			}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
@@ -37,8 +37,9 @@ public class ExportIDFTools
 	 * @param pythonExePath python executable full path
 	 * @param gitExePath    git executable full path
 	 * @param console       Console stream to write messages
+	 * @param errorConsoleStream
 	 */
-	public IStatus runToolsExport(final String pythonExePath, final String gitExePath, final MessageConsoleStream console)
+	public IStatus runToolsExport(final String pythonExePath, final String gitExePath, final MessageConsoleStream console, MessageConsoleStream errorConsoleStream)
 	{
 		final List<String> arguments = new ArrayList<>();
 		arguments.add(pythonExePath);
@@ -66,6 +67,7 @@ public class ExportIDFTools
 			
 			if (status.getSeverity() == IStatus.ERROR)
 			{
+				log(status.getException().getMessage(), errorConsoleStream);
 				return status;				
 			}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -85,7 +85,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.worked(1);
 
 				monitor.setTaskName(Messages.InstallToolsHandler_ExportingPathsMsg);
-				status = new ExportIDFTools().runToolsExport(pythonExecutablenPath, gitExecutablePath, console);
+				status = new ExportIDFTools().runToolsExport(pythonExecutablenPath, gitExecutablePath, console, errorConsoleStream);
 				if (status.getSeverity() == IStatus.ERROR)
 				{
 					return status;
@@ -190,7 +190,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 						catch (IOException e)
 						{
 							Logger.log(e);
-							console.println(Messages.InstallToolsHandler_OpenOCDRulesCopyError);
+							errorConsoleStream.println(Messages.InstallToolsHandler_OpenOCDRulesCopyError);
 						}
 					}
 				});
@@ -265,7 +265,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			{
 				Logger.log(IDFCorePlugin.getPlugin(),
 						IDFCorePlugin.errorStatus("Unable to get the process status.", null)); //$NON-NLS-1$
-				console.println("Unable to get the process status.");
+				errorConsoleStream.println("Unable to get the process status.");
 				return IDFCorePlugin.errorStatus("Unable to get the process status.", null); //$NON-NLS-1$ ;
 			}
 
@@ -275,7 +275,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		catch (Exception e1)
 		{
 			Logger.log(IDFCorePlugin.getPlugin(), e1);
-			console.println(e1.getLocalizedMessage());
+			errorConsoleStream.println(e1.getLocalizedMessage());
 			return IDFCorePlugin.errorStatus(e1.getLocalizedMessage(), e1); // $NON-NLS-1$;
 		}
 	}


### PR DESCRIPTION
## Description

The idea is to give user the visual feedback on the console when installing the tools. Currently all the installation was shown in the plain default color but now we are showing the error messages in the red color.

Fixes # ([IEP-681](https://jira.espressif.com:8443/browse/IEP-681))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

The scripts in the esp-idf directory install_tools.py can be edited to remove or add some lines that can cause the script to fail. This should then return an exception to the process runner which will lead to the status to be error. From there we can capture the exception message and show that error message in red color on the console.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Verified on all platforms - Windows,Linux and macOS
