### PR TITLE
IEP-729: ESP32-C2 and ESP32-H2 support in IDEs

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -32,6 +32,12 @@
      <provider
            class="com.espressif.idf.core.build.ESP32C3CMakeToolChainProvider">
      </provider>
+     <provider
+           class="com.espressif.idf.core.build.ESP32C2CMakeToolChainProvider">
+     </provider>
+     <provider
+           class="com.espressif.idf.core.build.ESP32H2CMakeToolChainProvider">
+     </provider>
   </extension>
   <extension
         point="org.eclipse.cdt.core.toolChainProvider">

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
@@ -40,11 +40,14 @@ public class IDFEnvironmentVariables
 
 	public static String IDF_COMPONENT_MANAGER = "IDF_COMPONENT_MANAGER"; //$NON-NLS-1$
 
-	public static final String GIT_PATH = "GIT_PATH"; //$NON-NLS-1$
-
-	public static final String PYTHON_EXE_PATH = "PYTHON_EXE_PATH"; //$NON-NLS-1$
-
 	public static final String ESP_IDF_VERSION = "ESP_IDF_VERSION"; //$NON-NLS-1$
+
+	public static String GIT_PATH ="GIT_PATH"; //$NON-NLS-1$
+	
+	public static String PYTHON_EXE_PATH ="PYTHON_EXE_PATH"; //$NON-NLS-1$
+	
+	public static String IDF_MAINTAINER = "IDF_MAINTAINER"; //$NON-NLS-1$
+
 
 	/**
 	 * @param variableName Environment variable Name

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2CMakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2CMakeToolChainProvider.java
@@ -1,0 +1,18 @@
+package com.espressif.idf.core.build;
+
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.core.runtime.CoreException;
+
+public class ESP32C2CMakeToolChainProvider extends AbstractESPCMakeToolChainProvider
+{
+
+	public static final String TOOLCHAIN_NAME = "toolchain-esp32c2.cmake"; //$NON-NLS-1$
+
+	@Override
+	protected IToolChain getToolchain() throws CoreException
+	{
+		IToolChain toolChain = tcManager.getToolChain(ESPToolChainProvider.ID, ESP32C2ToolChain.ID);
+		return toolChain;
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
@@ -1,0 +1,34 @@
+package com.espressif.idf.core.build;
+
+import java.nio.file.Path;
+
+import org.eclipse.cdt.core.build.IToolChainProvider;
+
+public class ESP32C2ToolChain extends AbstractESPToolchain
+{
+
+	/**
+	 * Toolchain target ID
+	 */
+	public static final String ID = "riscv32-esp-elf"; //$NON-NLS-1$
+
+	/**
+	 * Property: The OS the toolchain builds for.
+	 */
+	public static final String OS = "esp32c2"; //$NON-NLS-1$
+
+	/**
+	 * Property: The CPU architecture the toolchain supports.
+	 */
+	public static final String ARCH = "riscv32"; //$NON-NLS-1$
+
+	/**
+	 * @param provider
+	 * @param pathToToolChain
+	 */
+	public ESP32C2ToolChain(IToolChainProvider provider, Path pathToToolChain)
+	{
+		super(provider, pathToToolChain, OS, ARCH);
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
@@ -1,3 +1,8 @@
+/*******************************************************************************
+
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.core.build;
 
 import java.nio.file.Path;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32C2ToolChain.java
@@ -31,4 +31,11 @@ public class ESP32C2ToolChain extends AbstractESPToolchain
 		super(provider, pathToToolChain, OS, ARCH);
 	}
 
+	@Override
+	public String getId()
+	{
+		// TODO Auto-generated method stub
+		return super.getId() + "-" + OS; //$NON-NLS-1$
+	}
+
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32CMakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32CMakeToolChainProvider.java
@@ -19,7 +19,7 @@ public class ESP32CMakeToolChainProvider extends AbstractESPCMakeToolChainProvid
 	@Override
 	protected IToolChain getToolchain() throws CoreException
 	{
-		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ToolChain.ID);
+		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ClangToolChain.ID);
 	}
 
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32CMakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32CMakeToolChainProvider.java
@@ -19,7 +19,7 @@ public class ESP32CMakeToolChainProvider extends AbstractESPCMakeToolChainProvid
 	@Override
 	protected IToolChain getToolchain() throws CoreException
 	{
-		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ClangToolChain.ID);
+		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ToolChain.ID);
 	}
 
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangCmakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangCmakeToolChainProvider.java
@@ -1,0 +1,17 @@
+package com.espressif.idf.core.build;
+
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.core.runtime.CoreException;
+
+public class ESP32ClangCmakeToolChainProvider extends AbstractESPCMakeToolChainProvider
+{
+
+	public static final String TOOLCHAIN_NAME = "toolchain-clang-esp32.cmake"; //$NON-NLS-1$
+
+	@Override
+	protected IToolChain getToolchain() throws CoreException
+	{
+		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ToolChain.ID);
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangCmakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangCmakeToolChainProvider.java
@@ -1,3 +1,8 @@
+/*******************************************************************************
+
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.core.build;
 
 import org.eclipse.cdt.core.build.IToolChain;
@@ -11,7 +16,7 @@ public class ESP32ClangCmakeToolChainProvider extends AbstractESPCMakeToolChainP
 	@Override
 	protected IToolChain getToolchain() throws CoreException
 	{
-		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ToolChain.ID);
+		return tcManager.getToolChain(ESPToolChainProvider.ID, ESP32ClangToolChain.ID);
 	}
 
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangToolChain.java
@@ -1,0 +1,29 @@
+package com.espressif.idf.core.build;
+
+import java.nio.file.Path;
+
+import org.eclipse.cdt.build.gcc.core.ClangToolChain;
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.IToolChainProvider;
+
+public class ESP32ClangToolChain extends ClangToolChain
+{
+
+	public static final String ID = "xtensa-esp32-elf"; //$NON-NLS-1$
+	public static final String OS = "esp32"; //$NON-NLS-1$
+	public static final String ARCH = "xtensa"; //$NON-NLS-1$
+
+	public ESP32ClangToolChain(IToolChainProvider provider, Path pathToToolChain)
+	{
+		super(provider, pathToToolChain, ARCH, null);
+		setProperty(ATTR_OS, OS);
+		setProperty(ATTR_ARCH, ARCH);
+		setProperty("ATTR_ID", ESP32ClangCmakeToolChainProvider.TOOLCHAIN_NAME); //$NON-NLS-1$
+	}
+
+	@Override
+	public String getBinaryParserId()
+	{
+		return CCorePlugin.PLUGIN_ID + ".ELF"; //$NON-NLS-1$
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ClangToolChain.java
@@ -9,7 +9,7 @@ import org.eclipse.cdt.core.build.IToolChainProvider;
 public class ESP32ClangToolChain extends ClangToolChain
 {
 
-	public static final String ID = "xtensa-esp32-elf"; //$NON-NLS-1$
+	public static final String ID = "xtensa"; //$NON-NLS-1$
 	public static final String OS = "esp32"; //$NON-NLS-1$
 	public static final String ARCH = "xtensa"; //$NON-NLS-1$
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2CMakeToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2CMakeToolChainProvider.java
@@ -1,0 +1,17 @@
+package com.espressif.idf.core.build;
+
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.core.runtime.CoreException;
+
+public class ESP32H2CMakeToolChainProvider extends AbstractESPCMakeToolChainProvider
+{
+
+	public static final String TOOLCHAIN_NAME = "toolchain-esp32h2.cmake"; //$NON-NLS-1$
+
+	@Override
+	protected IToolChain getToolchain() throws CoreException
+	{
+		IToolChain toolChain = tcManager.getToolChain(ESPToolChainProvider.ID, ESP32H2ToolChain.ID);
+		return toolChain;
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
@@ -30,4 +30,11 @@ public class ESP32H2ToolChain extends AbstractESPToolchain
 		super(provider, pathToToolChain, OS, ARCH);
 	}
 
+	@Override
+	public String getId()
+	{
+		// TODO Auto-generated method stub
+		return super.getId() + "-" + OS;
+	}
+
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
@@ -1,3 +1,8 @@
+/*******************************************************************************
+
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.core.build;
 
 import java.nio.file.Path;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32H2ToolChain.java
@@ -1,0 +1,33 @@
+package com.espressif.idf.core.build;
+
+import java.nio.file.Path;
+
+import org.eclipse.cdt.core.build.IToolChainProvider;
+
+public class ESP32H2ToolChain extends AbstractESPToolchain
+{
+	/**
+	 * Toolchain target ID
+	 */
+	public static final String ID = "riscv32-esp-elf"; //$NON-NLS-1$
+
+	/**
+	 * Property: The OS the toolchain builds for.
+	 */
+	public static final String OS = "esp32h2"; //$NON-NLS-1$
+
+	/**
+	 * Property: The CPU architecture the toolchain supports.
+	 */
+	public static final String ARCH = "riscv32"; //$NON-NLS-1$
+
+	/**
+	 * @param provider
+	 * @param pathToToolChain
+	 */
+	public ESP32H2ToolChain(IToolChainProvider provider, Path pathToToolChain)
+	{
+		super(provider, pathToToolChain, OS, ARCH);
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ToolChain.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESP32ToolChain.java
@@ -23,6 +23,7 @@ public class ESP32ToolChain extends AbstractESPToolchain
 	public ESP32ToolChain(IToolChainProvider provider, Path pathToToolChain)
 	{
 		super(provider, pathToToolChain, OS, ARCH);
+		setProperty("ATTR_ID", ESP32CMakeToolChainProvider.TOOLCHAIN_NAME); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -139,17 +139,16 @@ public class ESPToolChainManager
 		try
 		{
 			GCCInfo info = new GCCInfo(file.toString());
-			if (info.target != null && info.version != null)
+			if (info.target != null)
 			{
 				GCCToolChain gcc = null;
 				switch (info.target)
 				{
 				case ESP32ToolChain.ID:
 					gcc = new ESP32ToolChain(toolchainProvider, file.toPath());
-					if (file.toString().contains("clang")) //$NON-NLS-1$
-					{
-						gcc = new ESP32ClangToolChain(toolchainProvider, file.toPath());
-					}
+					break;
+				case ESP32ClangToolChain.ID:
+					gcc = new ESP32ClangToolChain(toolchainProvider, file.toPath());
 					break;
 				case ESP32S2ToolChain.ID:
 					gcc = new ESP32S2ToolChain(toolchainProvider, file.toPath());

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -146,6 +146,10 @@ public class ESPToolChainManager
 				{
 				case ESP32ToolChain.ID:
 					gcc = new ESP32ToolChain(toolchainProvider, file.toPath());
+					if (file.toString().contains("clang")) //$NON-NLS-1$
+					{
+						gcc = new ESP32ClangToolChain(toolchainProvider, file.toPath());
+					}
 					break;
 				case ESP32S2ToolChain.ID:
 					gcc = new ESP32S2ToolChain(toolchainProvider, file.toPath());
@@ -169,8 +173,8 @@ public class ESPToolChainManager
 						{
 							if (info.target.contentEquals(ESP32C3ToolChain.ID))
 							{
-								manager.addToolChain(new ESP32C2ToolChain(toolchainProvider, file.toPath()));
 								manager.addToolChain(new ESP32H2ToolChain(toolchainProvider, file.toPath()));
+								manager.addToolChain(new ESP32C2ToolChain(toolchainProvider, file.toPath()));
 							}
 							manager.addToolChain(gcc);
 						}
@@ -326,6 +330,12 @@ public class ESPToolChainManager
 		esp32.put(IToolChain.ATTR_ARCH, ESP32ToolChain.ARCH);
 		esp32.put(TOOLCHAIN_ATTR_ID, ESP32CMakeToolChainProvider.TOOLCHAIN_NAME);
 		propertiesList.add(esp32);
+
+		Map<String, String> esp32Clang = new HashMap<>();
+		esp32Clang.put(IToolChain.ATTR_OS, ESP32ClangToolChain.OS);
+		esp32Clang.put(IToolChain.ATTR_ARCH, ESP32ClangToolChain.ARCH);
+		esp32Clang.put(TOOLCHAIN_ATTR_ID, ESP32ClangCmakeToolChainProvider.TOOLCHAIN_NAME);
+		propertiesList.add(esp32Clang);
 
 		// esp32s2
 		Map<String, String> esp32s2 = new HashMap<>();

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -31,7 +31,6 @@ import org.eclipse.cdt.core.build.IToolChainProvider;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.jgit.transport.TcpTransport;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
@@ -120,12 +119,16 @@ public class ESPToolChainManager
 		}
 	}
 
-	public void removePrevInstalledToolchains(IToolChainManager manager) {
-		try {
+	public void removePrevInstalledToolchains(IToolChainManager manager)
+	{
+		try
+		{
 			Collection<IToolChain> toolchains = manager.getAllToolChains();
 			ArrayList<IToolChain> tcList = new ArrayList<IToolChain>(toolchains);
 			tcList.forEach(tc -> manager.removeToolChain(tc));
-		} catch (CoreException e) {
+		}
+		catch (CoreException e)
+		{
 			Logger.log(e);
 		}
 	}
@@ -164,6 +167,11 @@ public class ESPToolChainManager
 						// Only add if another provider hasn't already added it
 						if (matcher.matches())
 						{
+							if (info.target.contentEquals(ESP32C3ToolChain.ID))
+							{
+								manager.addToolChain(new ESP32C2ToolChain(toolchainProvider, file.toPath()));
+								manager.addToolChain(new ESP32H2ToolChain(toolchainProvider, file.toPath()));
+							}
 							manager.addToolChain(gcc);
 						}
 					}
@@ -339,6 +347,20 @@ public class ESPToolChainManager
 		esp32c3.put(IToolChain.ATTR_ARCH, ESP32C3ToolChain.ARCH);
 		esp32c3.put(TOOLCHAIN_ATTR_ID, ESP32C3CMakeToolChainProvider.TOOLCHAIN_NAME);
 		propertiesList.add(esp32c3);
+
+		// esp32c2
+		Map<String, String> esp32c2 = new HashMap<>();
+		esp32c2.put(IToolChain.ATTR_OS, ESP32C2ToolChain.OS);
+		esp32c2.put(IToolChain.ATTR_ARCH, ESP32C2ToolChain.ARCH);
+		esp32c2.put(TOOLCHAIN_ATTR_ID, ESP32C2CMakeToolChainProvider.TOOLCHAIN_NAME);
+		propertiesList.add(esp32c2);
+
+		// esp32h2
+		Map<String, String> esp32h2 = new HashMap<>();
+		esp32h2.put(IToolChain.ATTR_OS, ESP32H2ToolChain.OS);
+		esp32h2.put(IToolChain.ATTR_ARCH, ESP32H2ToolChain.ARCH);
+		esp32h2.put(TOOLCHAIN_ATTR_ID, ESP32H2CMakeToolChainProvider.TOOLCHAIN_NAME);
+		propertiesList.add(esp32h2);
 
 		return propertiesList;
 	}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -138,14 +138,20 @@ public class ESPToolChainManager
 	{
 		try
 		{
-			GCCInfo info = new GCCInfo(file.toString());
+			Map<String, String> pathEnv = new HashMap<>();
+			pathEnv.put(IDFEnvironmentVariables.PATH,
+					new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.PATH));
+			GCCInfo info = new GCCInfo(file.toString(), pathEnv);
 			if (info.target != null)
 			{
 				GCCToolChain gcc = null;
 				switch (info.target)
 				{
 				case ESP32ToolChain.ID:
-					gcc = new ESP32ToolChain(toolchainProvider, file.toPath());
+					if (!file.toPath().toString().contains("clang"))
+					{
+						gcc = new ESP32ToolChain(toolchainProvider, file.toPath());
+					}
 					break;
 				case ESP32ClangToolChain.ID:
 					gcc = new ESP32ClangToolChain(toolchainProvider, file.toPath());
@@ -165,7 +171,7 @@ public class ESPToolChainManager
 				}
 				try
 				{
-					if (manager.getToolChain(gcc.getTypeId(), gcc.getId()) == null)
+					if (gcc != null && manager.getToolChain(gcc.getTypeId(), gcc.getId()) == null)
 					{
 						// Only add if another provider hasn't already added it
 						if (matcher.matches())

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
@@ -26,6 +26,7 @@ public class ESPToolChainProvider implements IToolChainProvider
 	 */
 	public static final String ID = "com.espressif.idf.core.esp.toolchainprovider"; //$NON-NLS-1$
 
+	public static final Pattern CLANG_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-clang(\\.exe)?"); //$NON-NLS-1$ xtensa-esp32s2-elf-readelf
 	// esp32, esp32s2, esp32s3
 	public static final Pattern GCC_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gcc(\\.exe)?"); //$NON-NLS-1$ xtensa-esp32s2-elf-readelf
 	public static final Pattern GDB_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gdb(\\.exe)?"); //$NON-NLS-1$
@@ -51,6 +52,7 @@ public class ESPToolChainProvider implements IToolChainProvider
 	public static Collection<Pattern> getToolchainPatterns()
 	{
 		List<Pattern> list = new ArrayList<>();
+		list.add(CLANG_PATTERN);
 		list.add(GCC_PATTERN);
 		list.add(GCC_PATTERN_ESP32C3);
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainProvider.java
@@ -30,7 +30,7 @@ public class ESPToolChainProvider implements IToolChainProvider
 	public static final Pattern GCC_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gcc(\\.exe)?"); //$NON-NLS-1$ xtensa-esp32s2-elf-readelf
 	public static final Pattern GDB_PATTERN = Pattern.compile("xtensa-esp32(.*)-elf-gdb(\\.exe)?"); //$NON-NLS-1$
 
-	// esp32c3
+	// esp32c3, esp32c2, esp32h2
 	public static final Pattern GCC_PATTERN_ESP32C3 = Pattern.compile("riscv32-esp-elf-gcc(\\.exe)?"); //$NON-NLS-1$ //riscv32-esp-elf-gcc
 	public static final Pattern GDB_PATTERN_ESP32C3 = Pattern.compile("riscv32-esp-elf-gdb(\\.exe)?"); //$NON-NLS-1$
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.eclipse.cdt.build.gcc.core.ClangToolChain;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.cmake.core.internal.CMakeUtils;
@@ -342,6 +343,11 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 					{
 						command.add("-DIDF_TARGET=" + idfTargetName); //$NON-NLS-1$
 					}
+				}
+
+				if (getToolChain().getTypeId() == ClangToolChain.TYPE_ID)
+				{
+					command.add("-DIDF_TOOLCHAIN=clang");
 				}
 
 				String userArgs = getProperty(CMAKE_ARGUMENTS);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -118,6 +118,7 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		{
 			properties.put(IToolChain.ATTR_ARCH, arch);
 		}
+		properties.put("ATTR_ID", toolChain.getProperty("ATTR_ID")); //$NON-NLS-1$ //$NON-NLS-2$
 		ICMakeToolChainFile file = manager.getToolChainFileFor(toolChain);
 		if (file == null)
 		{
@@ -130,15 +131,19 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 
 		// Let's generate build artifacts directly under the build folder so that CLI and eclipse IDF will be in sync
 		String name = ICBuildConfiguration.DEFAULT_NAME;
-
-		if (configManager.hasConfiguration(this, project, name)
-				&& project.getActiveBuildConfig().getName().contains(name))
+		IBuildConfiguration buildConfig;
+		if (configManager.hasConfiguration(this, project, name))
 		{
-			return configManager.getBuildConfiguration(project.getActiveBuildConfig());
+			buildConfig = project.getActiveBuildConfig();
 		}
-		IBuildConfiguration config = configManager.createBuildConfiguration(this, project, name, monitor);
-		CBuildConfiguration cmakeConfig = new IDFBuildConfiguration(config, name, toolChain, file, launchMode);
-		configManager.addBuildConfiguration(config, cmakeConfig);
+		else
+		{
+			buildConfig = configManager.createBuildConfiguration(this, project, name, monitor);
+
+		}
+
+		CBuildConfiguration cmakeConfig = new IDFBuildConfiguration(buildConfig, name, toolChain, file, launchMode);
+		configManager.addBuildConfiguration(buildConfig, cmakeConfig);
 		return cmakeConfig;
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
@@ -25,7 +25,9 @@ import org.eclipse.launchbar.core.target.ILaunchTargetWorkingCopy;
 import org.eclipse.launchbar.core.target.TargetStatus;
 
 import com.espressif.idf.core.build.AbstractESPToolchain;
+import com.espressif.idf.core.build.ESP32C2ToolChain;
 import com.espressif.idf.core.build.ESP32C3ToolChain;
+import com.espressif.idf.core.build.ESP32H2ToolChain;
 import com.espressif.idf.core.build.ESP32S2ToolChain;
 import com.espressif.idf.core.build.ESP32S3ToolChain;
 import com.espressif.idf.core.build.ESP32ToolChain;
@@ -50,6 +52,8 @@ public class SerialFlashLaunchTargetProvider implements ILaunchTargetProvider {
 		toolchainlist.add(ESP32S2ToolChain.class);
 		toolchainlist.add(ESP32S3ToolChain.class);
 		toolchainlist.add(ESP32C3ToolChain.class);
+		toolchainlist.add(ESP32C2ToolChain.class);
+		toolchainlist.add(ESP32H2ToolChain.class);
 
 		try {
 			addLaunchTarget(targetManager, toolchainlist);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -136,6 +136,8 @@ public class InstallToolsHandler extends AbstractToolsHandler
 
 		// Enable IDF_COMPONENT_MANAGER by default
 		idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_COMPONENT_MANAGER, "1");
+		// IDF_MAINTAINER=1 to be able to build with the clang toolchain
+		idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_MAINTAINER, "1");
 
 	}
 


### PR DESCRIPTION
## Description

Added esp32-c2 and esp32-h2 targets, which are using the same riscv toolchain as the esp32-c3 target, so it's safe to add these targets with older version esp-idf as well. 
Also, the bug fix related to changing the toolchain to the xtensa-clang was added to this PR

New feature # ([IEP-756](https://jira.espressif.com:8443/browse/IEP-756))

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Test 1:
- install tools from IDE
- check existing toolchains. `Eclipse -> Preferences -> C/C++ -> Core Build Toolchains`. There should be all toolchains including esp32-c2 and esp32-h2. Xtensa-clang toolchain has a clang type 
- select esp32-c2 or esp32-h2 and build a project with it. Check if a building is ok.

Test 2:
- select esp32 target
- edit the launch configuration. In the build tab select the xtensa-clang toolchain.
- build the project. Check if it's built with xtensa-clang toolchain

Test 3:
- Create a debug configuration
- edit the debug configuration. In the debugger tab, select esp32-c2 board (esp32-h2 board not yet in the list provided by openocd). 
- Check if the gdb executable is correct

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):


## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
