### PR TITLE
Eclipse 2022-09 support

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
@@ -40,10 +40,12 @@ public class IDFEnvironmentVariables
 
 	public static String IDF_COMPONENT_MANAGER = "IDF_COMPONENT_MANAGER"; //$NON-NLS-1$
 
-	public static final String GIT_PATH ="GIT_PATH"; //$NON-NLS-1$
-	
-	public static final String PYTHON_EXE_PATH ="PYTHON_EXE_PATH"; //$NON-NLS-1$
-	
+	public static final String GIT_PATH = "GIT_PATH"; //$NON-NLS-1$
+
+	public static final String PYTHON_EXE_PATH = "PYTHON_EXE_PATH"; //$NON-NLS-1$
+
+	public static final String ESP_IDF_VERSION = "ESP_IDF_VERSION"; //$NON-NLS-1$
+
 	/**
 	 * @param variableName Environment variable Name
 	 * @return IEnvironmentVariable
@@ -51,11 +53,11 @@ public class IDFEnvironmentVariables
 	public IEnvironmentVariable getEnv(String variableName)
 	{
 		IContributedEnvironment contributedEnvironment = getEnvironment();
-		
+
 		IEnvironmentVariable variable = contributedEnvironment.getVariable(variableName, null);
 		return variable;
 	}
-	
+
 	public void removeEnvVariable(String variableName)
 	{
 		IContributedEnvironment contributedEnvironment = getEnvironment();
@@ -94,7 +96,7 @@ public class IDFEnvironmentVariables
 		// Without this environment variables won't be persisted
 		EnvironmentVariableManager.fUserSupplier.storeWorkspaceEnvironment(true);
 	}
-	
+
 	public void prependEnvVariableValue(String variableName, String value)
 	{
 		Logger.log(MessageFormat.format("Prepending environment variables with key:{0} to value:{1}", variableName, //$NON-NLS-1$
@@ -103,7 +105,7 @@ public class IDFEnvironmentVariables
 				IBuildEnvironmentVariable.ENVVAR_PREPEND,
 				EnvironmentVariableManager.getDefault().getDefaultDelimiter());
 	}
-	
+
 	/**
 	 * @return CDT build environment variables map
 	 */

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -190,7 +190,8 @@ public class IDFSizeDataManager
 	private List<String> addJsonParseCommand()
 	{
 		List<String> arguments = new ArrayList<String>();
-		IEnvironmentVariable idfVersionEnv = new IDFEnvironmentVariables().getEnv("ESP_IDF_VERSION"); //$NON-NLS-1$
+		IEnvironmentVariable idfVersionEnv = new IDFEnvironmentVariables()
+				.getEnv(IDFEnvironmentVariables.ESP_IDF_VERSION);
 		String idfVersion = idfVersionEnv != null ? idfVersionEnv.getValue() : null;
 		if (idfVersion != null && Double.parseDouble(idfVersion) >= 5.0)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -85,7 +85,8 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.worked(1);
 
 				monitor.setTaskName(Messages.InstallToolsHandler_ExportingPathsMsg);
-				status = new ExportIDFTools().runToolsExport(pythonExecutablenPath, gitExecutablePath, console, errorConsoleStream);
+				status = new ExportIDFTools().runToolsExport(pythonExecutablenPath, gitExecutablePath, console,
+						errorConsoleStream);
 				if (status.getSeverity() == IStatus.ERROR)
 				{
 					return status;
@@ -99,11 +100,11 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				monitor.worked(1);
 
 				configEnv();
-				
+
 				monitor.setTaskName(Messages.InstallToolsHandler_InstallingWebscoketMsg);
 				handleWebSocketClientInstall();
 				monitor.worked(1);
-				
+
 				copyOpenOcdRules();
 				console.println(Messages.InstallToolsHandler_ConfiguredCMakeMsg);
 
@@ -232,7 +233,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 
 	protected IStatus handleWebSocketClientInstall()
 	{
-		 
+
 		// pip install websocket-client
 		List<String> arguments = new ArrayList<String>();
 		final String pythonEnvPath = IDFUtil.getIDFPythonEnvPath();
@@ -240,8 +241,10 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		{
 			console.println(String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
 					IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD));
-			return IDFCorePlugin.errorStatus(String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
-					IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD), null);
+			return IDFCorePlugin.errorStatus(
+					String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
+							IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD),
+					null);
 		}
 		arguments.add(pythonEnvPath);
 		arguments.add("-m"); //$NON-NLS-1$
@@ -287,6 +290,8 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		@Override
 		public void aboutToRun(IJobChangeEvent event)
 		{
+			// clean the ESP_IDF_VERSION variable first, because it's not coming from older versions of the ESP-IDF
+			new IDFEnvironmentVariables().removeEnvVariable(IDFEnvironmentVariables.ESP_IDF_VERSION);
 			this.existingVarMap = loadExistingVars();
 		}
 
@@ -294,7 +299,6 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		{
 			IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
 			Map<String, String> existingVarMap = new HashMap<>();
-
 			existingVarMap.put(IDFEnvironmentVariables.IDF_COMPONENT_MANAGER,
 					idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_COMPONENT_MANAGER));
 			existingVarMap.put(IDFEnvironmentVariables.IDF_PATH,
@@ -332,7 +336,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				idfEnvironmentVariables.addEnvVariable(varsEntry.getKey(), varsEntry.getValue());
 			}
 		}
-		
+
 		@Override
 		public void running(IJobChangeEvent event)
 		{

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -1,120 +1,127 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
 <target name="com.espressif.idf.target" sequenceNumber="25">
-   <locations>
+	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/eclipse/updates/latest"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.help.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			
+			<repository location="http://download.eclipse.org/eclipse/updates/latest" />
+			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.rcp.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.help.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.pde.feature.group" version="0.0.0" />
+
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/latest"/>
-			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0"/>
--			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/releases/latest" />
+			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0" />
+			-
+			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0" />
 		</location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.google.gson" version="0.0.0"/>
-         <unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818"/>
-         <unit id="javax.activation" version="1.2.2.v20201119-1642"/>
-         <unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818"/>
-         <unit id="javax.xml.stream" version="0.0.0"/>
-         <unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
-         <unit id="org.antlr.runtime" version="0.0.0"/>
-         <unit id="org.apache.commons.compress" version="0.0.0"/>
-         <unit id="org.apache.log4j" version="0.0.0"/>
-         <unit id="org.assertj" version="0.0.0"/>
-         <unit id="org.freemarker" version="0.0.0"/>
-         <unit id="org.hamcrest" version="0.0.0"/>
-         <unit id="org.hamcrest.core" version="0.0.0"/>
-         <unit id="org.junit" version="0.0.0"/>
-         <unit id="org.junit.jupiter.api" version="0.0.0"/>
-         <unit id="org.mockito" version="0.0.0"/>
-         <unit id="org.slf4j.impl.log4j12" version="0.0.0"/>
-         <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-         <unit id="com.sun.jna" version="5.6.0.v20200716-0148"/>
-         <unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209"/>
-         <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.lsp4e" version="0.0.0"/>
-         <unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/lsp4e/releases/0.18.0/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
-         <repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/egit/updates"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
-      </location>
-       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.38/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <repository location="https://download.eclipse.org/mylyn/drops/3.25.2/v20200831-1956/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
-         <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
-      </location>
-      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/tm4e/releases/0.4.1/"/>
-      </location>
-	   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		   <repository location="http://download.eclipse.org/nebula/releases/latest"/>
-		   <unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0"/>
-	   </location>
-	   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		   <repository location="https://download.eclipse.org/embed-cdt/releases/6.1.2/p2/"/>
-		   <unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.source.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.debug.gdbjtag.source.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.doc.user.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.doc.user.source.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.feature.group" version="6.1.2.202102181132"/>
-		   <unit id="org.eclipse.embedcdt.packs.source.feature.group" version="6.1.2.202102181132"/>
-	   </location>
-   </locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="com.google.gson" version="0.0.0" />
+			<unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818" />
+			<unit id="javax.activation" version="1.2.2.v20201119-1642" />
+			<unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818" />
+			<unit id="javax.xml.stream" version="0.0.0" />
+			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0" />
+			<unit id="org.antlr.runtime" version="0.0.0" />
+			<unit id="org.apache.commons.compress" version="0.0.0" />
+			<unit id="org.apache.log4j" version="0.0.0" />
+			<unit id="org.assertj" version="0.0.0" />
+			<unit id="org.freemarker" version="0.0.0" />
+			<unit id="org.hamcrest" version="0.0.0" />
+			<unit id="org.hamcrest.core" version="0.0.0" />
+			<unit id="org.junit" version="0.0.0" />
+			<unit id="org.junit.jupiter.api" version="0.0.0" />
+			<unit id="org.mockito" version="0.0.0" />
+			<unit id="org.slf4j.impl.log4j12" version="0.0.0" />
+			<unit id="org.yaml.snakeyaml" version="0.0.0" />
+			<unit id="com.sun.jna" version="5.6.0.v20200716-0148" />
+			<unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.lsp4e" version="0.0.0" />
+			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.18.0/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0" />
+			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/egit/updates" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.apache.batik.xml" version="0.0.0" />
+			<unit id="org.apache.batik.dom" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.38/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/mylyn/drops/3.25.2/v20200831-1956/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tm4e/releases/0.4.1/" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="http://download.eclipse.org/nebula/releases/latest" />
+			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/embed-cdt/updates/v6/" />
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.packs.feature.group" version="" />
+		</location>
+	</locations>
 </target>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -68,7 +68,7 @@
       </location>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
-         <repository location="https://download.eclipse.org/swtchart/releases/0.12.0/repository"/>
+         <repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository"/>
       </location>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -18,5 +18,8 @@
    <feature id="org.eclipse.embedcdt.debug.gdbjtag">
       <category name="com.espressif.idf"/>
    </feature>
+   <bundle id="org.apache.batik.xml">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="Espressif IDF"/>
 </site>


### PR DESCRIPTION
## Description

Unable to install IDF eclipse plugin on Eclipse 2022-09 CDT due to the following reasons:
1. Latest Eclipse CDT is missing with the org.apache.batik.xml plugin
2. Old embedded CDT plugins have become invalid with the latest CDT

What did we do?
1. Added org.apache.xml.batik  to the idf update site plugins update
2. Updated swtcharts from 0.12.0 to 0.1.3.0
3. Updated embedded CDT core plugins to the latest
4. Removed unwanted embedded plugins from the target definition

Fixes # ([IEP-768](https://jira.espressif.com:8443/browse/IEP-768))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testes which are required?

Test:1
- Install Eclipse CDT 2022-09
- Install PR using the update site 

Test:2
- Install Embedded CDT 2022-09
- Install PR using the update site 

Test:3
- Install Espressif-IDE v2.6.0
- Install PR using the update site

Test:4
- Install Espressif-IDE v2.6.0
- Install PR using the update site
- Verify features which impacted with this - application size analysis, OpenOCD debugging 

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): All

## Dependent components impacted by this PR:

- IEP plugin update site
- Application size analysis
- OpenOCD debugging
- Eclispe 2022-09 is a new release, so it would be great if we could test all basic scenarios with this PR

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
