### PR TITLE
IEP-790: remove duplicate targets from target lists

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -12,12 +12,16 @@ import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.eclipse.cdt.build.gcc.core.GCCToolChain;
 import org.eclipse.cdt.build.gcc.core.GCCToolChain.GCCInfo;
@@ -378,6 +382,34 @@ public class ESPToolChainManager
 		propertiesList.add(esp32h2);
 
 		return propertiesList;
+	}
+
+	public List<String> getAvailableEspTargetList()
+	{
+		Set<String> targetSet = new HashSet<>();
+		Collection<IToolChain> toolchains = getAllEspToolchains();
+		for (IToolChain toolchain : toolchains)
+		{
+			targetSet.add(toolchain.getProperty(IToolChain.ATTR_OS));
+		}
+		return targetSet.stream().collect(Collectors.toList());
+	}
+
+	public Collection<IToolChain> getAllEspToolchains()
+	{
+		IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
+		Collection<IToolChain> toolchains = Collections.emptyList();
+		try
+		{
+			toolchains = tcManager.getAllToolChains();
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		return toolchains.stream().filter(tc -> tc.getProperty(IToolChain.ATTR_OS).contains("esp"))
+				.collect(Collectors.toList());
+
 	}
 
 	protected String getIdfCMakePath(String idfPath)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -387,8 +387,7 @@ public class ESPToolChainManager
 	public List<String> getAvailableEspTargetList()
 	{
 		Set<String> targetSet = new HashSet<>();
-		Collection<IToolChain> toolchains = getAllEspToolchains();
-		for (IToolChain toolchain : toolchains)
+		for (IToolChain toolchain : getAllEspToolchains())
 		{
 			targetSet.add(toolchain.getProperty(IToolChain.ATTR_OS));
 		}
@@ -407,7 +406,7 @@ public class ESPToolChainManager
 		{
 			Logger.log(e);
 		}
-		return toolchains.stream().filter(tc -> tc.getProperty(IToolChain.ATTR_OS).contains("esp"))
+		return toolchains.stream().filter(tc -> tc.getProperty(IToolChain.ATTR_OS).contains("esp")) //$NON-NLS-1$
 				.collect(Collectors.toList());
 
 	}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,6 +37,9 @@ import org.eclipse.cdt.core.build.IToolChainProvider;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.launchbar.core.target.ILaunchTargetManager;
+import org.eclipse.launchbar.core.target.ILaunchTargetWorkingCopy;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
@@ -409,6 +414,48 @@ public class ESPToolChainManager
 		return toolchains.stream().filter(tc -> tc.getProperty(IToolChain.ATTR_OS).contains("esp")) //$NON-NLS-1$
 				.collect(Collectors.toList());
 
+	}
+
+	public void addToolchainBasedTargets(ILaunchTargetManager targetManager)
+	{
+		Collection<IToolChain> toolchainsWithoutDuplicateTargets = getAllEspToolchains().stream()
+				.filter(distinctByOs(tc -> tc.getProperty(IToolChain.ATTR_OS))).collect(Collectors.toList());
+
+		try
+		{
+			addLaunchTargets(targetManager, toolchainsWithoutDuplicateTargets);
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
+	}
+
+	private <T> Predicate<T> distinctByOs(Function<? super T, Object> extractor)
+	{
+		HashSet<Object> osSet = new HashSet<>();
+		return t -> osSet.add(extractor.apply(t));
+	}
+
+	private void addLaunchTargets(ILaunchTargetManager targetManager,
+			Collection<IToolChain> toolchainsWithoutDuplicateTargets) throws SecurityException, IllegalArgumentException
+	{
+
+		for (IToolChain toolchain : toolchainsWithoutDuplicateTargets)
+		{
+			String os = toolchain.getProperty(IToolChain.ATTR_OS);
+			String arch = toolchain.getProperty(IToolChain.ATTR_ARCH);
+
+			if (targetManager.getLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os) == null)
+			{
+				ILaunchTarget target = targetManager.addLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os);
+				ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
+				wc.setAttribute(ILaunchTarget.ATTR_OS, os);
+				wc.setAttribute(ILaunchTarget.ATTR_ARCH, arch);
+				wc.setAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, os);
+				wc.save();
+			}
+		}
 	}
 
 	protected String getIdfCMakePath(String idfPath)

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/SerialFlashLaunchTargetProvider.java
@@ -15,22 +15,12 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.launchbar.core.target.ILaunchTargetProvider;
-import org.eclipse.launchbar.core.target.ILaunchTargetWorkingCopy;
 import org.eclipse.launchbar.core.target.TargetStatus;
 
 import com.espressif.idf.core.build.ESPToolChainManager;
-import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
 
 /**
  * Launch Target used to flash images to a device over a serial port, usually
@@ -44,40 +34,7 @@ public class SerialFlashLaunchTargetProvider implements ILaunchTargetProvider {
 
 	@Override
 	public void init(ILaunchTargetManager targetManager) {
-
-		Collection<IToolChain> toolchainsWithoutDuplicateTargets = new ESPToolChainManager().getAllEspToolchains()
-				.stream().filter(distinctByOs(tc -> tc.getProperty(IToolChain.ATTR_OS))).collect(Collectors.toList());
-
-		try {
-			addLaunchTarget(targetManager, toolchainsWithoutDuplicateTargets);
-		} catch (Exception e) {
-			Logger.log(e);
-		}
-
-	}
-
-	private <T> Predicate<T> distinctByOs(Function<? super T, Object> extractor) {
-		HashSet<Object> osSet = new HashSet<>();
-		return t -> osSet.add(extractor.apply(t));
-	}
-
-	private void addLaunchTarget(ILaunchTargetManager targetManager,
-			Collection<IToolChain> toolchainsWithoutDuplicateTargets)
-			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-
-		for (IToolChain toolchain : toolchainsWithoutDuplicateTargets) {
-			String os = toolchain.getProperty(IToolChain.ATTR_OS);
-			String arch = toolchain.getProperty(IToolChain.ATTR_ARCH);
-
-			if (targetManager.getLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os) == null) {
-				ILaunchTarget target = targetManager.addLaunchTarget(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE, os);
-				ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
-				wc.setAttribute(ILaunchTarget.ATTR_OS, os);
-				wc.setAttribute(ILaunchTarget.ATTR_ARCH, arch);
-				wc.setAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, os);
-				wc.save();
-			}
-		}
+		new ESPToolChainManager().addToolchainBasedTargets(targetManager);
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -16,10 +16,8 @@
 package com.espressif.idf.launch.serial.ui.internal;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.cdt.serial.SerialPort;
@@ -144,10 +142,9 @@ public class NewSerialFlashTargetWizardPage extends WizardPage {
 	}
 
 	public String getArch() {
-		Collection<Map<String, String>> toolchains = getToolchains();
-		for (Map<String, String> map : toolchains) {
-			if (map.get(IToolChain.ATTR_OS).equals(getIDFTarget())) {
-				return map.get(IToolChain.ATTR_ARCH);
+		for (IToolChain map : getToolchains()) {
+			if (map.getProperty(IToolChain.ATTR_OS).equals(getIDFTarget())) {
+				return map.getProperty(IToolChain.ATTR_ARCH);
 			}
 		}
 		return ARCH;
@@ -162,19 +159,11 @@ public class NewSerialFlashTargetWizardPage extends WizardPage {
 	}
 
 	private List<String> getIDFTargetList() {
-		List<String> targetList = new ArrayList<>();
-
-		Collection<Map<String, String>> toolchains = getToolchains();
-		for (Map<String, String> toolchain : toolchains) {
-			targetList.add(toolchain.get(IToolChain.ATTR_OS));
-		}
-
-		return targetList;
+		return new ESPToolChainManager().getAvailableEspTargetList();
 
 	}
 
-	private Collection<Map<String, String>> getToolchains() {
-		Collection<Map<String, String>> toolchains = new ESPToolChainManager().getToolchainProperties();
-		return toolchains;
+	private Collection<IToolChain> getToolchains() {
+		return new ESPToolChainManager().getAllEspToolchains();
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
@@ -371,6 +372,7 @@ public class ToolsInstallationHandler extends Thread
 				updatePaths(versionsVO.getAvailablePath(), toolsVO.getName(), toolsVO.getExportPaths());
 			}
 		}
+
 	}
 
 	private void updatePaths(String toolPath, String toolName, List<String> exportPaths)
@@ -391,7 +393,7 @@ public class ToolsInstallationHandler extends Thread
 				exportPathBuilder.append(PATH_SPLITOR);
 			}
 		}
-		
+
 		Path pathToExport = Paths.get(exportPathBuilder.toString()); // for correcting the path error in windows
 		String currentPath = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.PATH);
 		StringBuilder finalPathToExport = new StringBuilder(currentPath);
@@ -702,6 +704,7 @@ public class ToolsInstallationHandler extends Thread
 			ESPToolChainManager toolchainManager = new ESPToolChainManager();
 			toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
 			toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
+			toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
 		}
 
 		private void copyOpenOcdRules()
@@ -823,14 +826,15 @@ public class ToolsInstallationHandler extends Thread
 			final String pythonEnvPath = IDFUtil.getIDFPythonEnvPath();
 			if (pythonEnvPath == null || !new File(pythonEnvPath).exists())
 			{
-				logQueue.add(String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
-						IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD));
+				logQueue.add(
+						String.format("%s executable not found. Unable to run `%s -m pip install websocket-client`", //$NON-NLS-1$
+								IDFConstants.PYTHON_CMD, IDFConstants.PYTHON_CMD));
 				return;
 			}
 			arguments.add(pythonEnvPath);
 			arguments.add("-m"); //$NON-NLS-1$
 			arguments.add("pip"); //$NON-NLS-1$
-			
+
 			arguments.add("install"); //$NON-NLS-1$
 			arguments.add("websocket-client"); //$NON-NLS-1$
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -210,7 +210,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		toolchainManager.removePrevInstalledToolchains(tcManager);
 		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
 		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
-		toolchainManager.addToolChainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
+		toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
 	}
 
 	protected IStatus handleToolsInstall()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
@@ -109,7 +110,6 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				console.println(Messages.InstallToolsHandler_ConfiguredCMakeMsg);
 
 				console.println(Messages.InstallToolsHandler_ToolsCompleted);
-
 				return Status.OK_STATUS;
 			}
 		};
@@ -210,6 +210,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		toolchainManager.removePrevInstalledToolchains(tcManager);
 		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
 		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
+		toolchainManager.addToolChainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
 	}
 
 	protected IStatus handleToolsInstall()

--- a/tests/com.espressif.idf.ui.test/resources/default-files/NewProjectTest/main/.project
+++ b/tests/com.espressif.idf.ui.test/resources/default-files/NewProjectTest/main/.project
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NewProjectTest_main</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.core.cBuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.cmake.core.cmakeNature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
## Description

Removed duplicate targets from a target list. Refactored code related to getting targets from the toolchains list.

Note: If you downgrade esp-idf, you will still see new targets such as esp32c2 or esp32h2 in the target list bar. For now, we agreed to keep them, so users will be able to change esp-idf versions dynamically without losing saved launch targets.

Fixes # ([IEP-790](https://jira.espressif.com:8443/browse/IEP-790))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
- Install some old esp-idf version (4.1 for example)
- When editing or creating new target, in combo will be only available targets based on existing toolchains:
<img width="166" alt="target_combo1" src="https://user-images.githubusercontent.com/24419842/198679683-8b6d917d-904b-49c3-9573-133d069ad5ba.png">

Test 2:
- Install some new esp-idf version (master for example)
- When editing or creating new target, in combo will be only available targets based on existing toolchains without duplicates:
![target_combo2](https://user-images.githubusercontent.com/24419842/198679770-c0a0ae4e-5311-422b-b079-704b0cbd36f9.jpg)

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch target bar
-  New Serial Flash Target Wizard Page

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
