### PR TITLE
IEP-805: Fix for Unable to install 2.7.0 nightly on eclipse 2022-09 CDT

### DIFF
--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -21,5 +21,8 @@
    <bundle id="org.apache.batik.xml">
       <category name="com.espressif.idf"/>
    </bundle>
+   <bundle id="org.eclipse.embedcdt.templates.core">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="Espressif IDF"/>
 </site>


### PR DESCRIPTION
## Description

Unable to install 2.7.0 nightly on eclipse 2022-09 CDT due to missing dependencies
<img width="1171" alt="Screenshot 2022-11-09 at 1 06 45 PM" src="https://user-images.githubusercontent.com/8463287/200826271-e0ea3688-db02-4a5a-b877-674308267722.png">

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Download and install 2022-09 Eclipse CDT
- Install the latest 2.7.0 nightly - this will fail
- Try with PR build and the update should go through without any issues

These steps should be repeated for Espressif-IDE 2.6.0 and Embedded CDT 2022-09 and 06 versions

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site installation

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
