### PR TITLE
IEP-805: fix for Unable to install 2.7.0 nightly on eclipse 2022-09 CDT due to missing dependencies

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -22,17 +22,11 @@
 			<repository location="http://download.eclipse.org/releases/latest" />
 			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0" />
-			-
 			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -61,7 +55,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.18.0/" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0" />
@@ -97,10 +91,7 @@
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.38/" />
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/drops/3.25.2/v20200831-1956/" />
+			<repository location="http://download.eclipse.org/mylyn/releases/latest" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />
@@ -122,6 +113,7 @@
 			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="" />
 			<unit id="org.eclipse.embedcdt.feature.group" version="" />
 			<unit id="org.eclipse.embedcdt.packs.feature.group" version="" />
+			
 		</location>
 	</locations>
 </target>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -21,5 +21,8 @@
    <bundle id="org.apache.batik.xml">
       <category name="com.espressif.idf"/>
    </bundle>
+   <bundle id="org.eclipse.embedcdt.templates.core">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="Espressif IDF"/>
 </site>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -24,5 +24,8 @@
    <bundle id="org.eclipse.embedcdt.templates.core">
       <category name="com.espressif.idf"/>
    </bundle>
+   <bundle id="org.eclipse.embedcdt.packs.core">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="Espressif IDF"/>
 </site>


### PR DESCRIPTION
## Description

Unable to install 2.7.0 nightly on eclipse 2022-09 CDT due to missing dependencies
<img width="1171" alt="Screenshot 2022-11-09 at 1 06 45 PM" src="https://user-images.githubusercontent.com/8463287/200826271-e0ea3688-db02-4a5a-b877-674308267722.png">

Fixes # ([IEP-805](https://jira.espressif.com:8443/browse/IEP-805))

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Download and install 2022-09 Eclipse CDT
- Install the latest 2.7.0 nightly - this will fail
- Try with PR build and the update should go through without any issues

These steps should be repeated for Espressif-IDE 2.6.0 and Embedded CDT 2022-09 and 06 versions

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site installation

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
