### PR TITLE
GH #629: Low application partition size turn off notification

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
@@ -32,7 +32,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.osgi.service.prefs.BackingStoreException;
 
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.Messages;
 
 public class MessageLinkDialog extends MessageDialog
@@ -84,11 +86,18 @@ public class MessageLinkDialog extends MessageDialog
 		Button checkBox = new Button(parent, SWT.CHECK);
 		checkBox.addSelectionListener(new SelectionListener()
 		{
-
 			@Override
 			public void widgetSelected(SelectionEvent e)
 			{
 				preferences.putBoolean(DO_NOT_SHOW_MSG, checkBox.getSelection());
+				try
+				{
+					preferences.flush();
+				}
+				catch (BackingStoreException e1)
+				{
+					Logger.log(e1);
+				}
 			}
 
 			@Override

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/MessageLinkDialog.java
@@ -90,14 +90,6 @@ public class MessageLinkDialog extends MessageDialog
 			public void widgetSelected(SelectionEvent e)
 			{
 				preferences.putBoolean(DO_NOT_SHOW_MSG, checkBox.getSelection());
-				try
-				{
-					preferences.flush();
-				}
-				catch (BackingStoreException e1)
-				{
-					Logger.log(e1);
-				}
 			}
 
 			@Override
@@ -119,6 +111,19 @@ public class MessageLinkDialog extends MessageDialog
 		}
 	}
 
+	@Override
+	protected void buttonPressed(int buttonId)
+	{
+		try
+		{
+			preferences.flush();
+		}
+		catch (BackingStoreException e1)
+		{
+			Logger.log(e1);
+		}
+		super.buttonPressed(buttonId);
+	}
 	public static boolean open(int kind, Shell parent, String title, String message, int style)
 	{
 		MessageLinkDialog dialog = new MessageLinkDialog(parent, title, null, message, kind, 0,


### PR DESCRIPTION
## Description

com.espressif.idf.core.prefs file was not persisted after restarting Eclipse. Added flashing the preferences to save the file

Fixes # ([IEP-807](https://jira.espressif.com:8443/browse/IEP-807))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- Test A


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
