### PR TITLE
IEP-815: openocd path in the Espressif preferences page requires the eclipse restart to update a value

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -26,6 +26,8 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
@@ -328,6 +330,24 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			if (event.getResult().getSeverity() == IStatus.ERROR)
 			{
 				restoreOldVars();
+			}
+			else
+			{
+				updateEspressifPrefPageOpenocdPath();
+			}
+		}
+
+		private void updateEspressifPrefPageOpenocdPath()
+		{
+			IEclipsePreferences newNode = DefaultScope.INSTANCE.getNode("com.espressif.idf.debug.gdbjtag.openocd"); //$NON-NLS-1$
+			newNode.put("install.folder", IDFUtil.getOpenOCDLocation()); //$NON-NLS-1$
+			try
+			{
+				newNode.flush();
+			}
+			catch (BackingStoreException e)
+			{
+				Logger.log(e);
 			}
 		}
 


### PR DESCRIPTION
## Description

Updating the default value for openocd path immediately after tools installation.

Fixes # ([IEP-815](https://jira.espressif.com:8443/browse/IEP-815))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1: 
- Make sure, that openocd can be updated (the latest version is not yet installed). To do it: 
Go to Preferences -> Espressif -> Global OpenOCD Path
<img width="1144" alt="Screenshot 2022-12-06 at 13 52 35" src="https://user-images.githubusercontent.com/24419842/205904955-1f79c03f-bbca-4d64-921d-634a0e128871.png">

- Now install tools from the latest esp-idf master. After the installation the Global OpenOCD Path should be updated:
<img width="1135" alt="Screenshot 2022-12-06 at 13 56 38" src="https://user-images.githubusercontent.com/24419842/205905806-0891fdf7-617d-465c-9070-32443f668932.png">
Test 2: 
- Create a debug configuration and check if Actual executable value is updated accordingly. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Espressif Preference Page 
- Debugger Tab

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
