### PR TITLE
IEP-817: More informative notification on target change

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -5,6 +5,7 @@
 package com.espressif.idf.ui;
 
 import java.io.File;
+import java.text.MessageFormat;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
@@ -97,7 +98,10 @@ public class LaunchBarListener implements ILaunchBarListener
 							String targetForJtagFlash = activeConfig.getWorkingCopy().getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
 							if (!newTarget.equals(targetForJtagFlash)) 
 							{
-								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(), Messages.LaunchBarListener_TargetChanged_Title, Messages.LaunchBarListener_TargetDontMatch_Msg);
+								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(),
+										Messages.LaunchBarListener_TargetChanged_Title,
+										MessageFormat.format(Messages.LaunchBarListener_TargetDontMatch_Msg, newTarget,
+												targetForJtagFlash, activeConfig.getName()));
 								if (isYes) {
 									ILaunchBarUIManager uiManager = UIPlugin.getService(ILaunchBarUIManager.class);
 									uiManager.openConfigurationEditor(launchBarManager.getActiveLaunchDescriptor());
@@ -112,7 +116,8 @@ public class LaunchBarListener implements ILaunchBarListener
 
 							boolean isDelete = MessageDialog.openQuestion(EclipseUtil.getShell(),
 									Messages.LaunchBarListener_TargetChanged_Title,
-									Messages.LaunchBarListener_TargetChanged_Msg);
+									MessageFormat.format(Messages.LaunchBarListener_TargetChanged_Msg,
+											project.getName(), currentTarget, newTarget));
 							if (isDelete)
 							{
 								IWorkspaceRunnable runnable = new IWorkspaceRunnable()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
@@ -1,3 +1,3 @@
-LaunchBarListener_TargetChanged_Msg=IDF launch target has changed for the project. Do you want to delete the `build` folder for the project?
+LaunchBarListener_TargetChanged_Msg=Current target for the project {0} has changed from {1} to {2} in the launchbar, do you would like to delete the "build" folder for the project?
 LaunchBarListener_TargetChanged_Title=IDF Launch Target Changed
-LaunchBarListener_TargetDontMatch_Msg=The selected target doesn't match the target for the JTAG flashing. Do you want to change the selected board in the configuration?
+LaunchBarListener_TargetDontMatch_Msg=The selected target {0} doesn''t match the target {1} for the JTAG flashing in {2}. Do you want to change the selected board in the configuration?

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
@@ -1,3 +1,3 @@
-LaunchBarListener_TargetChanged_Msg=Current target for the project {0} has changed from {1} to {2} in the launchbar, do you would like to delete the "build" folder for the project?
+LaunchBarListener_TargetChanged_Msg=Current target for the project {0} has changed from {1} to {2} in the launchbar, would you like to delete the "build" folder for the project?
 LaunchBarListener_TargetChanged_Title=IDF Launch Target Changed
 LaunchBarListener_TargetDontMatch_Msg=The selected target {0} doesn''t match the target {1} for the JTAG flashing in {2}. Do you want to change the selected board in the configuration?


### PR DESCRIPTION
## Description
Fixes # ([IEP-817](https://jira.espressif.com:8443/browse/IEP-817))

## Type of change
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Test 1:
- Build project with esp32 target, after build, change the target for something else.

Test 2:
- Edit the launch configuration and select Flashing via jtag  or create a debug configuration -> select esp32 board. Close the dialog and change the target via target bar.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch bar listener

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
