### PR TITLE
IEP-816: GH #640: Not opening Aplication Size Analysis on esp-idf 5.0

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -193,7 +193,7 @@ public class IDFSizeDataManager
 		IEnvironmentVariable idfVersionEnv = new IDFEnvironmentVariables()
 				.getEnv(IDFEnvironmentVariables.ESP_IDF_VERSION);
 		String idfVersion = idfVersionEnv != null ? idfVersionEnv.getValue() : null;
-		if (idfVersion != null && Double.parseDouble(idfVersion) >= 5.0)
+		if (idfVersion != null && Double.parseDouble(idfVersion) >= 5.1)
 		{
 			arguments.add("--format"); //$NON-NLS-1$
 			arguments.add("json"); //$NON-NLS-1$


### PR DESCRIPTION
## Description

`idf_size <map_file> --format json` instead of `--json` was added in the 5.1 version, not 5.0 as was thought previously. This caused the application size analysis to crash
Fixes # ([IEP-816](https://jira.espressif.com:8443/browse/IEP-816))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1:
- install tools with esp-idf 5.0 -> create project -> build -> open application size analysis 

Test 2: 
- install tools with esp-idf higher or lower than 5.0 -> create project -> build -> open application size analysis. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Application Size analysis editor

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
