### PR TITLE
IEP-814: Fix error for Illegal Thread State exception causing monitor issues

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
@@ -156,7 +156,11 @@ public class SerialPortHandler
 		};
 
 		thread.start();
-		serverMessageHandler.start();
+		if (!serverMessageHandler.isAlive())
+		{
+			serverMessageHandler.start();
+		}
+
 		isOpen = true;
 
 		serialConnector.control.setState(TerminalState.CONNECTED);


### PR DESCRIPTION
Fix error for Illegal Thread State exception causing monitor issues

## Description

The thread for handling the socket server messages gave IllegalThreadState exception as while flashing the thread was already running and after resume call for the serial port handler the exception was thrown which caused the processes to become orphan and they were showing themselves detach from the eclipse but were running in the background holding the serial port.
Just needed to add a check to see if the thread was alive or not.

Fixes # ([IEP-814](https://jira.espressif.com:8443/browse/IEP-814))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- Flash a project with the monitor running and connected to that project, after flashing the monitor should resume automatically and user must not need to connect again
- Disconnect and reconnect the monitor after flashing.
- Disconnect monitor and flash project and then reconnect monitor

**Test Configuration**:
* OS (Windows):

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
