### PR TITLE
IEP-701: Changes to handle the change in idf in esp_idf.json config file

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -26,6 +26,9 @@ public class Messages extends NLS
 	public static String IncreasePartitionSizeTitle;
 	public static String IncreasePartitionSizeMessage;
 
+	public static String ToolsInitializationDifferentPathMessageBoxMessage;
+	public static String ToolsInitializationDifferentPathMessageBoxTitle;
+	
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -17,3 +17,5 @@ CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource.
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
 IncreasePartitionSizeTitle=Low Application Partition Size
 IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
+ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file
+ToolsInitializationDifferentPathMessageBoxMessage=A different IDF path was found in the startup configuration file do you want to install the tools in this path or keep the older path\nNew Path: {0}\nOld Path: {1}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -21,7 +21,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.ui.IStartup;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -58,7 +60,9 @@ public class InitializeToolsStartup implements IStartup
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
-
+	
+	private String newIdfPath;
+	
 	@Override
 	public void earlyStartup()
 	{
@@ -85,23 +89,50 @@ public class InitializeToolsStartup implements IStartup
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener());
 		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 		launchBarManager.addListener(new LaunchBarListener());
-		if (isInstallerConfigSet())
-		{
-			Logger.log("Ignoring esp_idf.json settings as it was configured earilier.");
-			return;
-		}
-
+		
 		// Get the location of the eclipse root directory
 		Location installLocation = Platform.getInstallLocation();
 		URL url = installLocation.getURL();
 		Logger.log("Eclipse Install location::" + url);
-
-		// Check the esp-idf.json
 		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
 		if (!idf_json_file.exists())
 		{
 			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: '{0}'", url.getPath()));
 			return;
+		}
+		else if (isInstallerConfigSet())
+		{
+			checkForUpdatedVersion(idf_json_file);
+			if (isInstallerConfigSet())
+			{
+				Logger.log("Ignoring esp_idf.json settings as it was configured earilier and idf_path is similar.");
+				return;		
+			}
+			else 
+			{
+				IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
+				MessageBox messageBox = new MessageBox(Display.getDefault().getActiveShell(),
+						SWT.ICON_WARNING | SWT.YES | SWT.NO);
+				messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
+				messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage, newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
+				int response = messageBox.open();
+				if (response == SWT.NO)
+				{
+					Preferences prefs = getPreferences();
+					prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
+					try
+					{
+						prefs.flush();
+					}
+					catch (BackingStoreException e)
+					{
+						Logger.log(e);
+					}
+					
+					return;
+				}
+				
+			}
 		}
 
 		// read esp-idf.json file
@@ -118,7 +149,7 @@ public class InitializeToolsStartup implements IStartup
 				JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
 				String idfPath = (String) selectedIDFInfo.get(IDF_PATH);
 				String pythonExecutablePath = (String) selectedIDFInfo.get(PYTHON_PATH);
-
+				
 				// Add IDF_PATH to the eclipse CDT build environment variables
 				IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
 				idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_PATH, idfPath);
@@ -163,6 +194,44 @@ public class InitializeToolsStartup implements IStartup
 		{
 			Logger.log(e);
 		}
+	}
+
+	private void checkForUpdatedVersion(File idf_json_file)
+	{
+		// read esp-idf.json file
+		JSONParser parser = new JSONParser();
+		try
+		{
+			JSONObject jsonObj = (JSONObject) parser.parse(new FileReader(idf_json_file));
+			String idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
+			JSONObject list = (JSONObject) jsonObj.get(IDF_INSTALLED_LIST_KEY);
+			if (list != null)
+			{
+				// selected esp-idf version information
+				JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
+				String idfPath = (String) selectedIDFInfo.get(IDF_PATH);
+				IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
+				if (idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH).equals(idfPath)) return;
+				newIdfPath = idfPath;
+				Preferences prefs = getPreferences();
+				prefs.putBoolean(IS_INSTALLER_CONFIG_SET, false);
+				try
+				{
+					prefs.flush();
+				}
+				catch (BackingStoreException e)
+				{
+					Logger.log(e);
+				}				
+			}
+		}
+		catch (
+				IOException
+				| ParseException e)
+		{
+			Logger.log(e);
+		}
+
 	}
 
 	private Preferences getPreferences()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -24,6 +24,7 @@ import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IStartup;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -110,27 +111,30 @@ public class InitializeToolsStartup implements IStartup
 			}
 
 			IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
-			MessageBox messageBox = new MessageBox(Display.getDefault().getActiveShell(),
-					SWT.ICON_WARNING | SWT.YES | SWT.NO);
-			messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
-			messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage,
-					newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
-			int response = messageBox.open();
-			if (response == SWT.NO)
-			{
-				Preferences prefs = getPreferences();
-				prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
-				try
+			Display.getDefault().syncExec(() -> {
+				Shell shell = new Shell(Display.getDefault());
+				MessageBox messageBox = new MessageBox(shell,
+						SWT.ICON_WARNING | SWT.YES | SWT.NO);
+				messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
+				messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage,
+						newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
+				int response = messageBox.open();
+				if (response == SWT.NO)
 				{
-					prefs.flush();
-				}
-				catch (BackingStoreException e)
-				{
-					Logger.log(e);
-				}
+					Preferences prefs = getPreferences();
+					prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
+					try
+					{
+						prefs.flush();
+					}
+					catch (BackingStoreException e)
+					{
+						Logger.log(e);
+					}
 
-				return;
-			}
+					return;
+				}
+			});		
 		}
 
 		// read esp-idf.json file


### PR DESCRIPTION
## Description
Changes to handle the change in idf in esp_idf.json config file

Fixes # ([IEP-701](https://jira.espressif.com:8443/browse/IEP-701))

## Type of change

Please delete options that are not relevant.
- Bug fix (can be a breaking change)

## How has this been tested?
To test we need to have this tested with installer or some existing espressif ide installation.
- Need to change the idf path in config file
- It should work fine without any changes
- First initialization should be okay

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):
* 
## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS

## For QA 
(@AndriiFilippov)
Use the esp_idf.json file usually found when installing the ide via installer. Try running the IDE and then changing version and IDF_PATH in the json configuration file that's what the installer is doing when used again just to change the version. You should get a message when launching the IDE next time that the version is changed and if yes is pressed the IDE should change the version to the one in the json configuration. 
**Note: Please wait for the tools to complete installation before doing anything in IDE, currently we dont have any progress indicator for that (WIP)**
