### PR TITLE
CI Build fix: Tag IEP builds with Eclipse 2022-09 target

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -3,7 +3,7 @@
 <target name="com.espressif.idf.target" sequenceNumber="25">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/eclipse/updates/latest" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/" />
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.rcp.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0" />
@@ -19,7 +19,7 @@
 
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/latest" />
+			<repository location="https://download.eclipse.org/releases/2022-09" />
 			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
@@ -55,7 +55,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
-			<repository location="https://download.eclipse.org/lsp4e/releases/latest/" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0" />
@@ -64,7 +64,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/egit/updates" />
+			<repository location="https://download.eclipse.org/egit/updates-5.13/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0" />
@@ -88,10 +88,10 @@
 			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/mylyn/releases/latest" />
+			<repository location="https://download.eclipse.org/mylyn/releases/3.10/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />


### PR DESCRIPTION
## Description

CI Build fix: Tag IEP builds with Eclipse 2022-09 target

Fixes # ([IEP-838](https://jira.espressif.com:8443/browse/IEP-838))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Build has to go through and should be able to install the update site generated with espressif-ide v2.7.0

## Dependent components impacted by this PR:

- Update site

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
