### PR TITLE
IEP-840 & IEP-841: Fix for Build settings save and add build settings tab in new launch config

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -98,7 +98,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 {
 
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
-	protected static final String COMPONENTS = "components"; // $NON-NLS-1$
+	protected static final String COMPONENTS = "components"; //$NON-NLS-1$
 	private static final String ESP_IDF_COMPONENTS = "esp_idf_components"; //$NON-NLS-1$
 	public static final String CMAKE_GENERATOR = "cmake.generator"; //$NON-NLS-1$
 	public static final String CMAKE_ARGUMENTS = "cmake.arguments"; //$NON-NLS-1$

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/RecheckConfigsHelper.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/RecheckConfigsHelper.java
@@ -4,8 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.core.util;
 
-import java.util.Iterator;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
@@ -18,8 +17,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.osgi.service.prefs.Preferences;
 
-import com.espressif.idf.core.build.ESP32S2ToolChain;
-import com.espressif.idf.core.build.ESP32ToolChain;
+import com.espressif.idf.core.build.AbstractESPToolchain;
 import com.espressif.idf.core.logging.Logger;
 
 /**
@@ -33,22 +31,33 @@ import com.espressif.idf.core.logging.Logger;
 public class RecheckConfigsHelper
 {
 
+	private RecheckConfigsHelper()
+	{
+	}
+
 	public static void revalidateToolchain(IProject project)
 	{
 		Preferences settings;
 		try
 		{
-			settings = InstanceScope.INSTANCE.getNode(CCorePlugin.PLUGIN_ID).node("config").node(project.getName())
+			settings = InstanceScope.INSTANCE.getNode(CCorePlugin.PLUGIN_ID).node("config").node(project.getName()) //$NON-NLS-1$
 					.node(project.getActiveBuildConfig().getName());
 			IToolChainManager toolChainManager = CCorePlugin.getService(IToolChainManager.class);
-			IToolChain toolChain = getESPToolChain(toolChainManager);
-			settings.put(ICBuildConfiguration.TOOLCHAIN_TYPE,
-					Optional.ofNullable(toolChain).map(IToolChain::getTypeId).orElse("")); //$NON-NLS-1$
-			settings.put(ICBuildConfiguration.TOOLCHAIN_ID,
-					Optional.ofNullable(toolChain).map(IToolChain::getId).orElse("")); //$NON-NLS-1$
+			IToolChain anyEspToolChain = getESPToolChain(toolChainManager);
+			String typeId = settings.get(ICBuildConfiguration.TOOLCHAIN_TYPE, anyEspToolChain.getTypeId());
+			String toolchainId = settings.get(ICBuildConfiguration.TOOLCHAIN_ID, anyEspToolChain.getId());
+			IToolChain currentToolChain = toolChainManager.getToolChain(typeId, toolchainId);
+			if (!(currentToolChain instanceof AbstractESPToolchain))
+			{
+				currentToolChain = anyEspToolChain;
+			}
+			settings.put(ICBuildConfiguration.TOOLCHAIN_TYPE, currentToolChain.getTypeId());
+			settings.put(ICBuildConfiguration.TOOLCHAIN_ID, currentToolChain.getId());
 			recheckConfigs();
 		}
-		catch (CoreException e)
+		catch (
+				CoreException
+				| NoSuchElementException e)
 		{
 			Logger.log(e);
 		}
@@ -64,17 +73,9 @@ public class RecheckConfigsHelper
 
 	private static IToolChain getESPToolChain(IToolChainManager toolChainManager) throws CoreException
 	{
-		Iterator<IToolChain> iter = toolChainManager.getAllToolChains().iterator();
-		IToolChain toolChain = null;
-		while (iter.hasNext())
-		{
-			toolChain = iter.next();
-			if (toolChain instanceof ESP32ToolChain || toolChain instanceof ESP32S2ToolChain) // TODO: remove specific
-																								// conditions
-			{
-				return toolChain;
-			}
-		}
-		return toolChain;
+
+		return toolChainManager.getAllToolChains().stream().filter(AbstractESPToolchain.class::isInstance).findFirst()
+				.orElseThrow();
+
 	}
 }

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.model.CModelException;
@@ -227,15 +229,21 @@ public class CMakeMainTab2 extends GenericMainTab {
 	private IProject getSelectedProject() {
 		List<IProject> projectList = new ArrayList<>(1);
 		Display.getDefault().syncExec(new Runnable() {
-
 			@Override
 			public void run() {
 				IProject project = EclipseUtil.getSelectedProjectInExplorer();
-				projectList.add(project);
+				if (project != null)
+					projectList.add(project);
 			}
 		});
-		IProject project = projectList.get(0);
-		return project;
+		try {
+			ICProject[] projects = CoreModel.getDefault().getCModel().getCProjects();
+			projectList.addAll(Stream.of(projects).map(ICProject::getProject).collect(Collectors.toList()));
+		} catch (CModelException e) {
+			Logger.log(e);
+		}
+
+		return projectList.get(0);
 	}
 
 	protected void initializeCProject(IProject project, ILaunchConfigurationWorkingCopy config) {

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
@@ -15,17 +15,26 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial.ui.internal;
 
+import org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.launchbar.ui.internal.LaunchBarLaunchConfigDialog;
 
 public class SerialFlashLaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup {
 
+	@SuppressWarnings("restriction")
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new ILaunchConfigurationTab[] { new CMakeMainTab2(), new EnvironmentTab(), new CommonTab() });
+		if (dialog instanceof LaunchBarLaunchConfigDialog) {
+			setTabs(new ILaunchConfigurationTab[] { new CMakeMainTab2(), new EnvironmentTab(), new CommonTab() });
+		} else {
+			setTabs(new ILaunchConfigurationTab[] { new CoreBuildTab(), new CMakeMainTab2(), new EnvironmentTab(),
+					new CommonTab() });
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Description

As changes are relevant to the both tickets, this PR contains fixes for: 
- IEP-840: Build settings not getting saved to specific launch configuration 
- IEP-841: Add the Build Settings tab in the Launch configuration creation dialog

Explanation to the code changes: 
- In order to save and use build settings for each individual project launch configuration, we must avoid using the default build configuration, which is the same for all launch configurations. Instead, we need to create build configurations based on the launch configuration name or the project name as the default option.
- In addition, to avoid problems with a misconfigured build, we must ensure that the selected toolchain is extends from AbsractESPToolChain
- In order to be able to provide a Build Settings tab during the creation of a new launch configuration, we need to specify a project. We already do this in the Main tab, but the default setting can be empty. So this is changed - the default option is the selected project in the project explorer, and if it's not selected, we are providing the first found project as the default option.
- Selecting the default toolchain based on the current selected target

Fixes # ([IEP-841](https://jira.espressif.com:8443/browse/IEP-841))
Fixes # ([IEP-840](https://jira.espressif.com:8443/browse/IEP-840))
## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Before Testing: 
- Create a few projects on the master branch first, and then test them on that branch to make sure projects with the default build configuration work fine with new changes.

Test 1: 
- Create Project and make a different manipulation with it: Build, Change target, Edit launch configuration, Duplicate launch configuration, create new Launch configuration.

Test 2
- Change build settings for different launch configurations. For example, set different custom build folders and then make sure each launch configuration has its own build folder after build.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- ESP-IDF Project (Building Project)
- Launch Configurations
- Build Settings Tab (Launch Configuration)
- Main Tab (Launch Configuration)
- Creating Launch Configurations

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
