### PR TITLE
IEP-831: Set remotetimeout to 20 sec for GDB Client

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -133,5 +133,11 @@
           name="%command.name">
       </command>
  </extension>
+ <extension
+       point="org.eclipse.ui.startup">
+    <startup
+          class="com.espressif.idf.debug.gdbjtag.openocd.OpenOCDPluginStartup">
+    </startup>
+ </extension>
 
 </plugin>

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/preferences.ini
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/preferences.ini
@@ -80,7 +80,7 @@ gdb.server.executable=${openocd_path}/${openocd_executable}
 gdb.server.other=-s ${openocd_path}/share/openocd/scripts -f interface/ftdi/esp32_devkitj_v1.cfg -f board/esp32-wrover-kit-1.8v.cfg
 
 # Client defaults
-gdb.client.commands=set mem inaccessible-by-default off
+gdb.client.commands=set mem inaccessible-by-default off \nset remotetimeout 20
 gdb.client.executable=${cross_prefix}gdb${cross_suffix}
 gdb.client.other=
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/OpenOCDPluginStartup.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/OpenOCDPluginStartup.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.debug.gdbjtag.openocd;
+
+import org.eclipse.ui.IStartup;
+
+import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferenceInitializer;
+
+/**
+ * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
+ *
+ */
+public class OpenOCDPluginStartup implements IStartup
+{
+
+	@Override
+	public void earlyStartup()
+	{
+		new DefaultPreferenceInitializer().initializeDefaultPreferences();
+	}
+
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferenceInitializer.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferenceInitializer.java
@@ -61,6 +61,9 @@ public class DefaultPreferenceInitializer extends AbstractPreferenceInitializer 
 
 		fDefaultPreferences.putBoolean(PersistentPreferences.TAB_MAIN_CHECK_PROGRAM,
 				DefaultPreferences.TAB_MAIN_CHECK_PROGRAM_DEFAULT);
+		
+		//reset
+		fPersistentPreferences.putGdbClientCommands(DefaultPreferences.GDB_CLIENT_OTHER_COMMANDS_DEFAULT);
 
 		// When the 'ilg.gnumcueclipse.managedbuild.cross' node is completely
 		// added to /default, a NodeChangeEvent is raised.

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
@@ -79,7 +79,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	// ------------------------------------------------------------------------
 
 	// Debugger commands
-	public static final String GDB_CLIENT_OTHER_COMMANDS_DEFAULT = "set mem inaccessible-by-default off\n";
+	public static final String GDB_CLIENT_OTHER_COMMANDS_DEFAULT = "set mem inaccessible-by-default off\nset remotetimeout 20";
 	public static final String DO_FIRST_RESET_COMMAND = "monitor reset ";
 	public static final String HALT_COMMAND = "monitor halt";
 	public static final String ENABLE_SEMIHOSTING_COMMAND = "monitor arm semihosting enable";


### PR DESCRIPTION
## Description

The [default timeout limit ](https://sourceware.org/gdb/onlinedocs/gdb/Remote-Configuration.html)to wait for the remote target to respond is 2 seconds else GDB Client will be thrown an exception to the user.

As per the client reports, this seems to be a problem where they have to increase the timeout to 20 seconds to make it work.

Fixes # ([IEP-831](https://jira.espressif.com:8443/browse/IEP-831))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
1. Create a new workspace 
2. Create a new debug configuration and navigate to the Debugger tab
3. See if you're able to see a new command option in the GDB client with "set remotetimeout 20"
4. Make sure debugging is working


Test 2:
1. Go to your existing workspace
2. Create a new debug configuration and navigate to the Debugger tab
3. See if you're able to see a new command option in the GDB client with "set remotetimeout 20"
4. Make sure debugging is working


**Test Configuration**:
* ESP-IDF Version: v5.0
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- OpenOCD Debugging

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
