### PR TITLE
IEP-852: Check for websocket dependency before starting serial monitor

### DIFF
--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
@@ -92,7 +92,7 @@ public class IDFMonitor
 	{
 		if(!dependenciesAreInstalled())
 		{
-			throw new Exception("Missing Dependencies"); //$NON-NLS-1$
+			throw new Exception("The WebSocket dependency is missing and cannot be installed automatically"); //$NON-NLS-1$
 		}
 		List<String> arguments = commandArgsWithSocketServer();
 		

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/handlers/SerialMonitorHandler.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/handlers/SerialMonitorHandler.java
@@ -1,7 +1,5 @@
 package com.espressif.idf.serial.monitor.handlers;
 
-import java.io.IOException;
-
 import org.eclipse.core.resources.IProject;
 
 import com.espressif.idf.core.logging.Logger;
@@ -38,7 +36,7 @@ public class SerialMonitorHandler
 		{
 			return monitor.start();
 		}
-		catch (IOException e)
+		catch (Exception e)
 		{
 			Logger.log(e);
 		}

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -48,7 +48,8 @@ Export-Package: com.espressif.idf.ui,
  com.espressif.idf.ui.dialogs,
  com.espressif.idf.ui.handlers,
  com.espressif.idf.ui.preferences,
- com.espressif.idf.ui.tracing
+ com.espressif.idf.ui.tracing,
+ com.espressif.idf.ui.update
 Bundle-ClassPath: .,
  lib/commonmark-0.16.1.jar,
  lib/ini4j-0.5.4.jar,


### PR DESCRIPTION
## Description

Verify and install websocket before launching idf monitor.
As we have added webscocket plugin dependency with the core dump debugging it was considered as a regression for customers as it's failed after update. 

Fixes # ([IEP-852](https://jira.espressif.com:8443/browse/IEP-852))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Remove the websocket dependency from the command line using the **_pyhton -m pip uninstall websocket_** using the python from the ESP after installing tools in IDE.
Run and Build any sample project and launch serial monitor. The serial monitor should work now as it checks and installs the dependency or will fail with an exception logged in file stating missing dependencies.

**Test Configuration**:
* ESP-IDF Version: Any
* OS (Windows,Linux and macOS): All

## Dependent components impacted by this PR:
- Serial Monitor
All the events linked to monitor including core dump and gdbstub debugging for the moment and normal working of the terminal should be verified as well.

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
