### PR TITLE
IEP-864 Clean commands do not work with custom build directories

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/ProjectCleanCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/ProjectCleanCommandHandler.java
@@ -12,9 +12,11 @@ import java.util.Map;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.EclipseUtil;
 import com.espressif.idf.ui.update.AbstractToolsHandler;
@@ -35,6 +37,16 @@ public class ProjectCleanCommandHandler extends AbstractToolsHandler
 		List<String> commands = new ArrayList<>();
 		commands.add(IDFUtil.getIDFPythonEnvPath());
 		commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+		commands.add("-B"); //$NON-NLS-1$
+		try
+		{
+			commands.add(IDFUtil.getBuildDir(selectedProject));
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
 		commands.add("clean"); //$NON-NLS-1$
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
 		console.println(commands.toString());

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/ProjectFullCleanCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/ProjectFullCleanCommandHandler.java
@@ -12,9 +12,11 @@ import java.util.Map;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.EclipseUtil;
 import com.espressif.idf.ui.update.AbstractToolsHandler;
@@ -41,6 +43,15 @@ public class ProjectFullCleanCommandHandler extends AbstractToolsHandler
 		List<String> commands = new ArrayList<>();
 		commands.add(IDFUtil.getIDFPythonEnvPath());
 		commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+		commands.add("-B"); //$NON-NLS-1$
+		try
+		{
+			commands.add(IDFUtil.getBuildDir(selectedProject));
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
 		commands.add("fullclean"); //$NON-NLS-1$
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
 		console.println(commands.toString());

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/PythonCleanCommandHandler.java
@@ -12,9 +12,11 @@ import java.util.Map;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.EclipseUtil;
 import com.espressif.idf.ui.update.AbstractToolsHandler;
@@ -35,6 +37,15 @@ public class PythonCleanCommandHandler extends AbstractToolsHandler
 		List<String> commands = new ArrayList<>();
 		commands.add(IDFUtil.getIDFPythonEnvPath());
 		commands.add(IDFUtil.getIDFPythonScriptFile().getAbsolutePath());
+		commands.add("-B"); //$NON-NLS-1$
+		try
+		{
+			commands.add(IDFUtil.getBuildDir(selectedProject));
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
 		commands.add("python-clean"); //$NON-NLS-1$
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
 		console.println(commands.toString());


### PR DESCRIPTION
## Description

passed the build folder path `-B folder_path` to the clean commands to support the custom build folder

Fixes # ([IEP-864](https://jira.espressif.com:8443/browse/IEP-864))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Test 1:
- Create a new project
- Build
- Try clean commands on it (Project clean, FullClean and Python clean)

Test 2:
- Repeat test 2, but on the custom build folder

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Clean commands
- Custom build folder

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
