### PR TITLE
IEP-867 The number format exception for some python versions

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -125,9 +125,9 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 				Logger.log("No Python installations found in the system."); //$NON-NLS-1$
 			}
 
-			pythonExecutablenPath = pythonVersions.entrySet().stream()
-					.filter(e -> new Version(e.getKey()).compareTo(new Version("3.6")) >= 0).map(Entry::getValue) //$NON-NLS-1$
-					.findAny().orElseGet(IDFUtil::getPythonExecutable);
+			pythonExecutablenPath = pythonVersions.entrySet().stream().filter(
+					e -> new Version(e.getKey().replaceAll("-.+", StringUtil.EMPTY)).compareTo(new Version("3.6")) >= 0) //$NON-NLS-1$ //$NON-NLS-2$
+					.map(Entry::getValue).findAny().orElseGet(IDFUtil::getPythonExecutable);
 
 		}
 		else

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -24,6 +24,7 @@ import com.espressif.idf.core.ExecutableFinder;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
+import com.espressif.idf.core.Version;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.PyWinRegistryReader;
@@ -123,9 +124,10 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 			{
 				Logger.log("No Python installations found in the system."); //$NON-NLS-1$
 			}
+
 			pythonExecutablenPath = pythonVersions.entrySet().stream()
-					.filter(e -> Double.parseDouble(e.getKey()) >= 3.6).map(Entry::getValue).findAny()
-					.orElseGet(IDFUtil::getPythonExecutable);
+					.filter(e -> new Version(e.getKey()).compareTo(new Version("3.6")) >= 0).map(Entry::getValue) //$NON-NLS-1$
+					.findAny().orElseGet(IDFUtil::getPythonExecutable);
 
 		}
 		else


### PR DESCRIPTION
## Description

Some python versions can be added to registry "3.7-32" so it causes java.lang.NumberFormatException:
Fixes # ([IEP-867](https://jira.espressif.com:8443/browse/IEP-867))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1:
- install tools, and check installed tools with different python versions. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Install Tools command
- List installed tools command

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
