### PR TITLE
IEP-865: Error changing language due to case invalidation in file name

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
@@ -52,7 +52,7 @@ public class EclipseIniUtil
 	private void loadIniFilePath() throws Exception
 	{
 		URL url = new URL(
-				Platform.getInstallLocation().getURL() + System.getProperty("eclipse.launcher.name") + ".ini"); //$NON-NLS-1$ //$NON-NLS-2$
+				Platform.getInstallLocation().getURL() + System.getProperty("eclipse.launcher.name").toLowerCase() + ".ini"); //$NON-NLS-1$ //$NON-NLS-2$
 		ECLIPSE_INI_FILE = url.toString();
 	}
 


### PR DESCRIPTION
The default launcher name is upper case where as the file for properties is found to be always in the lower case. This cause issues in UNIX and LINUX based OS.

## Description

Simply changed the code to convert the launcher name property to lowercase regardless of OS because windows is case insensitive and UNIX and LINUX are not and this was probably only tested on Windows when the feature was created making it appear much later. 
Fixes # ([IEP-865](https://jira.espressif.com:8443/browse/IEP-865))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Change the language in the Espressif IDE to Chinese. Repeat this test on all platforms

**Test Configuration**:
* ESP-IDF Version: Doesn't matter
* OS (Windows,Linux and macOS): All

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
