### PR TITLE
IEP-868: Fixing the export of global openocd path in preferences

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -24,9 +24,11 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.osgi.service.prefs.BackingStoreException;
 
 import com.espressif.idf.core.ExecutableFinder;
 import com.espressif.idf.core.IDFConstants;
@@ -614,5 +616,22 @@ public class IDFUtil
 		return Stream.of(getIDFPath(), "components", "nvs_flash", "nvs_partition_generator", "nvs_partition_gen.py")
 				.collect(Collectors.joining(String.valueOf(IPath.SEPARATOR)));
 
+	}
+	
+	/**
+	 * Update the openocd path in configurations
+	 */
+	public static void updateEspressifPrefPageOpenocdPath()
+	{
+		IEclipsePreferences newNode = DefaultScope.INSTANCE.getNode("com.espressif.idf.debug.gdbjtag.openocd"); //$NON-NLS-1$
+		newNode.put("install.folder", getOpenOCDLocation()); //$NON-NLS-1$
+		try
+		{
+			newNode.flush();
+		}
+		catch (BackingStoreException e)
+		{
+			Logger.log(e);
+		}
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -34,12 +34,15 @@ import org.eclipse.cdt.internal.core.envvar.EnvironmentVariableManager;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
+import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFConstants;
@@ -557,9 +560,24 @@ public class ToolsInstallationHandler extends Thread
 			configureToolChain();
 			configEnv();
 			copyOpenOcdRules();
+			updateEspressifPrefPageOpenocdPath();
 			return Boolean.TRUE;
 		}
 
+		private void updateEspressifPrefPageOpenocdPath()
+		{
+			IEclipsePreferences newNode = DefaultScope.INSTANCE.getNode("com.espressif.idf.debug.gdbjtag.openocd"); //$NON-NLS-1$
+			newNode.put("install.folder", IDFUtil.getOpenOCDLocation()); //$NON-NLS-1$
+			try
+			{
+				newNode.flush();
+			}
+			catch (BackingStoreException e)
+			{
+				Logger.log(e);
+			}
+		}
+		
 		private void configEnv()
 		{
 			// Enable IDF_COMPONENT_MANAGER by default

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -34,15 +34,12 @@ import org.eclipse.cdt.internal.core.envvar.EnvironmentVariableManager;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
-import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFConstants;
@@ -560,24 +557,10 @@ public class ToolsInstallationHandler extends Thread
 			configureToolChain();
 			configEnv();
 			copyOpenOcdRules();
-			updateEspressifPrefPageOpenocdPath();
+			IDFUtil.updateEspressifPrefPageOpenocdPath();
 			return Boolean.TRUE;
 		}
 
-		private void updateEspressifPrefPageOpenocdPath()
-		{
-			IEclipsePreferences newNode = DefaultScope.INSTANCE.getNode("com.espressif.idf.debug.gdbjtag.openocd"); //$NON-NLS-1$
-			newNode.put("install.folder", IDFUtil.getOpenOCDLocation()); //$NON-NLS-1$
-			try
-			{
-				newNode.flush();
-			}
-			catch (BackingStoreException e)
-			{
-				Logger.log(e);
-			}
-		}
-		
 		private void configEnv()
 		{
 			// Enable IDF_COMPONENT_MANAGER by default

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -26,8 +26,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
@@ -368,21 +366,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			}
 			else
 			{
-				updateEspressifPrefPageOpenocdPath();
-			}
-		}
-
-		private void updateEspressifPrefPageOpenocdPath()
-		{
-			IEclipsePreferences newNode = DefaultScope.INSTANCE.getNode("com.espressif.idf.debug.gdbjtag.openocd"); //$NON-NLS-1$
-			newNode.put("install.folder", IDFUtil.getOpenOCDLocation()); //$NON-NLS-1$
-			try
-			{
-				newNode.flush();
-			}
-			catch (BackingStoreException e)
-			{
-				Logger.log(e);
+				IDFUtil.updateEspressifPrefPageOpenocdPath();
 			}
 		}
 


### PR DESCRIPTION
## Description

Tools installation wizard was not exporting openocd path in configurations.

Fixes # ([IEP-868](https://jira.espressif.com:8443/browse/IEP-868))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Tested on windows by installing tools through wizard and then verifying variable in preferences
Espressif > OpenOCD Path.

Needs to be tested on other platforms.

**Test Configuration**:
* ESP-IDF Version: shouldn't matter
* OS (Windows,Linux and macOS): All


## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
