### PR TITLE
IEP-869: Default gdb client path is wrong for the new project

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -110,7 +110,7 @@ public class IDFUtil
 				+ IDFConstants.IDF_SIZE_SCRIPT;
 		return new File(idf_py_script);
 	}
-	
+
 	/**
 	 * @return tools.json file for tools to install
 	 */
@@ -363,7 +363,7 @@ public class IDFUtil
 							String[] tuples = file.getName().split("-"); //$NON-NLS-1$
 							if (projectEspTarget == null) // If no IDF_TARGET
 							{
-								return path;
+								return null;
 							}
 							else if (tuples[1].equals(projectEspTarget) || tuples[0].equals(projectEspTarget))
 							{
@@ -442,7 +442,7 @@ public class IDFUtil
 				+ IDFConstants.ESP_TOOL_SCRIPT;
 		return new File(esp_tool_script);
 	}
-	
+
 	public static File getEspCoreDumpScriptFile()
 	{
 		String idf_path = getIDFPath();
@@ -450,7 +450,7 @@ public class IDFUtil
 				+ IDFConstants.ESP_CORE_DUMP_FOLDER + IPath.SEPARATOR + IDFConstants.ESP_CORE_DUMP_SCRIPT;
 		return new File(esp_tool_script);
 	}
-	
+
 	public static String getEspIdfVersion()
 	{
 		if (IDFUtil.getIDFPath() != null && IDFUtil.getIDFPythonEnvPath() != null)
@@ -580,7 +580,7 @@ public class IDFUtil
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Project .elf file path
 	 * 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -1125,9 +1125,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 						configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_CLIENT, booleanDefault));
 
 				// Executable
-				stringDefault = fPersistentPreferences.getGdbClientExecutable();
 				String gdbCommandAttr = configuration.getAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
-						stringDefault);
+						fGdbClientExecutable.getText());
 				fGdbClientExecutable.setText(gdbCommandAttr);
 
 				// Other options
@@ -1461,7 +1460,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 			stringValue = fGdbClientExecutable.getText().trim();
 			configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME, stringValue); // DSF
-			fPersistentPreferences.putGdbClientExecutable(stringValue);
 
 			stringValue = fGdbClientOtherOptions.getText().trim();
 			configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS, stringValue);
@@ -1595,9 +1593,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 		// GDB client setup
 		{
-			defaultString = getGdbClientExecutable(configuration);
-			configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME, defaultString);
-
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_REMOTE_TARGET,
 					DefaultPreferences.USE_REMOTE_TARGET_DEFAULT);
 


### PR DESCRIPTION
## Description

We used the same default gdb client executable for all configurations. This was causing incorrect defaults for new projects. 
Instead of providing a default value from the persistence preference, we are getting the default value based on the selected target, or providing the saved value after the debug configuration is already created

Fixes # ([IEP-869](https://jira.espressif.com:8443/browse/IEP-869))

## Type of change
Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Test 1:
- create a new project
- select some target 
- create a new debug configuration for this project
- the default target and the default gdb client executable must be correct
Test 2:
- repeat test 1, but with a different target
Test 3:
- try to run a debug

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows, Linux, and macOS):

## Dependent components impacted by this PR:
- Debug configuration

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows, Linux and macOS
