### PR TITLE
IEP-870: Missing gdb executable for esp32c2 target

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -33,7 +33,9 @@ import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
+import com.espressif.idf.core.build.ESP32C2ToolChain;
 import com.espressif.idf.core.build.ESP32C3ToolChain;
+import com.espressif.idf.core.build.ESP32H2ToolChain;
 import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
 
@@ -43,6 +45,11 @@ import com.espressif.idf.core.logging.Logger;
  */
 public class IDFUtil
 {
+
+	private IDFUtil()
+	{
+	}
+
 	private static Boolean idfSupportsSpaces;
 
 	/**
@@ -331,9 +338,9 @@ public class IDFUtil
 
 	public static String getXtensaToolchainExecutablePathByTarget(String projectEspTarget)
 	{
-
 		Pattern gdb_pattern = ESPToolChainProvider.GDB_PATTERN; // default
-		if (!StringUtil.isEmpty(projectEspTarget) && projectEspTarget.equals(ESP32C3ToolChain.OS))
+		if (!StringUtil.isEmpty(projectEspTarget) && (projectEspTarget.equals(ESP32C3ToolChain.OS)
+				|| projectEspTarget.equals(ESP32C2ToolChain.OS) || projectEspTarget.equals(ESP32H2ToolChain.OS)))
 		{
 			gdb_pattern = ESPToolChainProvider.GDB_PATTERN_ESP32C3;
 			projectEspTarget = ESP32C3ToolChain.ARCH;


### PR DESCRIPTION
## Description

Fixes # ([IEP-870](https://jira.espressif.com:8443/browse/IEP-870))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
- in the debug configuration select esp32c2 target -> select esp32c2 board


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Debug configuration

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
