### PR TITLE
IEP-873: Fix the "Restore defaults" button in the Debugger Tab

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -1220,18 +1220,14 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			fDoGdbServerAllocateTelnetConsole
 					.setSelection(DefaultPreferences.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE_DEFAULT);
 
+			fFlashVoltage.select(0);
+			fTarget.select(0);
+			fTarget.notifyListeners(SWT.Selection, null);
 		}
 
 		// GDB Client Setup
 		{
 			fDoStartGdbClient.setSelection(DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);
-
-			// Set Xtensa toolchain path
-			String clientExecutablePath = getGdbClientExecutable(fConfiguration);
-			if (clientExecutablePath != null)
-			{
-				fGdbClientExecutable.setText(clientExecutablePath);
-			}
 
 			// Other options
 			fGdbClientOtherOptions.setText(DefaultPreferences.GDB_CLIENT_OTHER_OPTIONS_DEFAULT);
@@ -1589,6 +1585,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 			configuration.setAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE,
 					DefaultPreferences.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE_DEFAULT);
+
 		}
 
 		// GDB client setup


### PR DESCRIPTION
## Description

Fix the "Restore defaults" button in the Debugger Tab. The defaults values are:
esp32 target, default flash voltage, the xtensa toolchain, config options according to the esp32 target and board 

Fixes # ([IEP-873](https://jira.espressif.com:8443/browse/IEP-873))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1
- Create a new debug configuration
- Manually change the values in the fields all over the Debugger tab
- click Restore Defaults, and make sure everything is reset to the default

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Debugger Tab

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
