### PR TITLE
IEP-879 Offline installer release 2.8.1 - after installation the "Launch Target Bar" is empty.

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ToolChainUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ToolChainUtil.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.IToolChainManager;
+import org.eclipse.launchbar.core.target.ILaunchTargetManager;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.build.ESPToolChainManager;
+import com.espressif.idf.core.build.ESPToolChainProvider;
+
+/**
+ * The util class to configure the toolchains after tools installation
+ * 
+ * @author Denys Almazov
+ *
+ */
+public class ToolChainUtil
+{
+
+	private ToolChainUtil()
+	{
+	}
+
+	/**
+	 * Configure the file in the preferences and initialize the launch bar with available targets
+	 */
+	public static void configureToolChain()
+	{
+		IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
+		ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
+
+		ESPToolChainManager toolchainManager = new ESPToolChainManager();
+		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
+		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
+		toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -12,10 +12,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.text.MessageFormat;
 
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.cmake.core.internal.Activator;
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -33,13 +30,12 @@ import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
-import com.espressif.idf.core.build.ESPToolChainManager;
-import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.build.Messages;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.ResourceChangeListener;
 import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.core.util.ToolChainUtil;
 import com.espressif.idf.ui.dialogs.MessageLinkDialog;
 import com.espressif.idf.ui.update.ExportIDFTools;
 import com.espressif.idf.ui.update.InstallToolsHandler;
@@ -113,8 +109,7 @@ public class InitializeToolsStartup implements IStartup
 			IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
 			Display.getDefault().syncExec(() -> {
 				Shell shell = new Shell(Display.getDefault());
-				MessageBox messageBox = new MessageBox(shell,
-						SWT.ICON_WARNING | SWT.YES | SWT.NO);
+				MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.YES | SWT.NO);
 				messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
 				messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage,
 						newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
@@ -134,7 +129,7 @@ public class InitializeToolsStartup implements IStartup
 
 					return;
 				}
-			});		
+			});
 		}
 
 		// read esp-idf.json file
@@ -162,7 +157,7 @@ public class InitializeToolsStartup implements IStartup
 					exportIDFTools.runToolsExport(pythonExecutablePath, gitExecutablePath, null, null);
 
 					// Configure toolchains
-					configureToolChain();
+					ToolChainUtil.configureToolChain();
 
 					Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 					scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
@@ -246,18 +241,5 @@ public class InitializeToolsStartup implements IStartup
 	private boolean isInstallerConfigSet()
 	{
 		return getPreferences().getBoolean(IS_INSTALLER_CONFIG_SET, false);
-	}
-
-	/**
-	 * Configure the toolchain and toolchain file in the preferences
-	 */
-	protected void configureToolChain()
-	{
-		IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
-		ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
-
-		ESPToolChainManager toolchainManager = new ESPToolChainManager();
-		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
-		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -27,15 +27,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.cdt.internal.core.envvar.EnvironmentVariableManager;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
@@ -46,11 +42,10 @@ import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
-import com.espressif.idf.core.build.ESPToolChainManager;
-import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.core.util.ToolChainUtil;
 import com.espressif.idf.ui.UIPlugin;
 import com.espressif.idf.ui.tools.vo.ToolsVO;
 import com.espressif.idf.ui.tools.vo.VersionsVO;
@@ -554,7 +549,7 @@ public class ToolsInstallationHandler extends Thread
 			runPythonEnvCommand();
 			runToolsExport(idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.GIT_PATH));
 			handleWebSocketClientInstall();
-			configureToolChain();
+			ToolChainUtil.configureToolChain();
 			configEnv();
 			copyOpenOcdRules();
 			IDFUtil.updateEspressifPrefPageOpenocdPath();
@@ -695,17 +690,6 @@ public class ToolsInstallationHandler extends Thread
 					envMap.put("Path", path2); //$NON-NLS-1$
 				}
 			}
-		}
-
-		private void configureToolChain()
-		{
-			IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
-			ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
-
-			ESPToolChainManager toolchainManager = new ESPToolChainManager();
-			toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
-			toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
-			toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
 		}
 
 		private void copyOpenOcdRules()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -16,9 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -27,7 +24,6 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
@@ -38,11 +34,10 @@ import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
-import com.espressif.idf.core.build.ESPToolChainManager;
-import com.espressif.idf.core.build.ESPToolChainProvider;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.core.util.ToolChainUtil;
 import com.espressif.idf.ui.UIPlugin;
 
 /**
@@ -55,8 +50,6 @@ public class InstallToolsHandler extends AbstractToolsHandler
 {
 
 	public static final String INSTALL_TOOLS_FLAG = "INSTALL_TOOLS_FLAG"; //$NON-NLS-1$
-	private IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
-	private ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
 
 	@Override
 	protected void execute()
@@ -97,7 +90,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 				console.println(Messages.InstallToolsHandler_ConfiguredBuildEnvVarMsg);
 
 				monitor.setTaskName(Messages.InstallToolsHandler_AutoConfigureToolchain);
-				configureToolChain();
+				ToolChainUtil.configureToolChain();
 				monitor.worked(1);
 
 				configEnv();
@@ -201,18 +194,6 @@ public class InstallToolsHandler extends AbstractToolsHandler
 		}
 	}
 
-	/**
-	 * Configure the toolchain and toolchain file in the preferences
-	 */
-	protected void configureToolChain()
-	{
-		ESPToolChainManager toolchainManager = new ESPToolChainManager();
-		toolchainManager.removePrevInstalledToolchains(tcManager);
-		toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
-		toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
-		toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
-	}
-
 	protected IStatus handleToolsInstall()
 	{
 		// idf_tools.py install all
@@ -275,7 +256,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 						IDFCorePlugin.errorStatus("Unable to get the process status.", null)); //$NON-NLS-1$
 				if (errorConsoleStream != null)
 				{
-					errorConsoleStream.println("Unable to get the process status.");	
+					errorConsoleStream.println("Unable to get the process status.");
 				}
 				return IDFCorePlugin.errorStatus("Unable to get the process status.", null); //$NON-NLS-1$
 			}
@@ -285,12 +266,12 @@ public class InstallToolsHandler extends AbstractToolsHandler
 			{
 				return IDFCorePlugin.okStatus("websocket-client already installed", null); //$NON-NLS-1$
 			}
-			
+
 			// websocket client not installed so installing it now.
 			arguments.remove(arguments.size() - 1);
 			arguments.add("install"); //$NON-NLS-1$
 			arguments.add(websocketClient);
-			
+
 			status = processRunner.runInBackground(arguments, org.eclipse.core.runtime.Path.ROOT, environment);
 			if (status == null)
 			{
@@ -298,16 +279,16 @@ public class InstallToolsHandler extends AbstractToolsHandler
 						IDFCorePlugin.errorStatus("Unable to get the process status.", null)); //$NON-NLS-1$
 				if (errorConsoleStream != null)
 				{
-					errorConsoleStream.println("Unable to get the process status.");	
+					errorConsoleStream.println("Unable to get the process status.");
 				}
 				return IDFCorePlugin.errorStatus("Unable to get the process status.", null); //$NON-NLS-1$
 			}
-			
+
 			if (console != null)
 			{
 				console.println(status.getMessage());
 			}
-			
+
 			return status;
 		}
 		catch (Exception e1)


### PR DESCRIPTION
## Description

we are configuring toolchains in three different places: install tools, install tools wizard, and initialiazeToolsStartup class (for the offline installer). PR contains the refactoring - moving the same methods to a separate class which also adds the necessary line to the initializeToolsStartup class, which fixes the problem. 

Fixes # ([IEP-879](https://jira.espressif.com:8443/browse/IEP-879))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Test 1:
- clear workspace, install tools -> Launch bar should contain launch targets after tools installation

Test 2:
- repeat Test 1 but install tools with the Tools Installation wizard

Test 3:
- after installing the Espressif IDE by the offline installer, the launch target bar should be initialized out of the box

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Install Tools command
- Tools installation wizard
- Espressif IDE from the offline installer 
- Launch Bar
- Build/Debug/Toolchains

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
