### PR TITLE
IEP-825: Fixing issues with tools installation wizard on MAC OS

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -60,13 +60,7 @@ public class ESPToolChainManager
 	 */
 	private static final String TOOLCHAIN_ATTR_ID = "ATTR_ID"; //$NON-NLS-1$
 	private String envValue;
-	
-	public ESPToolChainManager(String envValue)
-	{
-		this.envValue = envValue;
-	}
-	
-	// Default constructor kept for compatibility
+
 	public ESPToolChainManager()
 	{
 	}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ESPToolChainManager.java
@@ -59,6 +59,17 @@ public class ESPToolChainManager
 	 * Toolchain target property id.
 	 */
 	private static final String TOOLCHAIN_ATTR_ID = "ATTR_ID"; //$NON-NLS-1$
+	private String envValue;
+	
+	public ESPToolChainManager(String envValue)
+	{
+		this.envValue = envValue;
+	}
+	
+	// Default constructor kept for compatibility
+	public ESPToolChainManager()
+	{
+	}
 
 	/**
 	 * @param manager
@@ -85,7 +96,7 @@ public class ESPToolChainManager
 	{
 		Logger.log("Initializing toolchain..."); //$NON-NLS-1$
 		List<String> paths = new ArrayList<String>();
-		String idfToolsExportPath = getIdfToolsExportPath();
+		String idfToolsExportPath = StringUtil.isEmpty(envValue) ? getIdfToolsExportPath() : envValue;
 		if (idfToolsExportPath != null)
 		{
 			paths.add(idfToolsExportPath);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -29,9 +29,7 @@ import java.util.concurrent.Future;
 
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.cdt.core.build.IToolChainManager;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -563,6 +561,7 @@ public class ToolsInstallationHandler extends Thread
 			handleWebSocketClientInstall();
 			ToolChainUtil.configureToolChain();
 			configEnv();
+			handleWebSocketClientInstall();
 			copyOpenOcdRules();
 			IDFUtil.updateEspressifPrefPageOpenocdPath();
 			scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
@@ -592,18 +591,6 @@ public class ToolsInstallationHandler extends Thread
 
 			final Map<String, String> environment = new HashMap<>(System.getenv());
 			
-//			if (environment.containsKey("PATH"))
-//			{
-//				environment.put("PATH", idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.PATH).
-//						concat(File.pathSeparator).
-//						concat(environment.get("PATH")));
-//			}
-//			else if (environment.containsKey("Path"))
-//			{
-//				environment.put("Path",environment.get("Path").
-//						concat(File.pathSeparator).
-//						concat(idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.PATH)));
-//			}
 			StringBuilder paths = new StringBuilder();
 			
 			for (Path toolPath : listOfPathsToUpdate)
@@ -628,9 +615,6 @@ public class ToolsInstallationHandler extends Thread
 				environment.put(IDFEnvironmentVariables.PATH, paths.toString());
 			}
 			
-			
-//			environment.put(IDFEnvironmentVariables.IDF_PATH, idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_PATH));
-//			environment.putAll(idfEnvironmentVariables.getSystemEnvMap());
 			final ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
 			
 			try
@@ -698,17 +682,6 @@ public class ToolsInstallationHandler extends Thread
 			}
 			return value;
 		}
-		private void configureToolChain()
-		{
-			IToolChainManager tcManager = CCorePlugin.getService(IToolChainManager.class);
-			ICMakeToolChainManager cmakeTcManager = CCorePlugin.getService(ICMakeToolChainManager.class);
-			ESPToolChainManager toolchainManager = new ESPToolChainManager();
-			toolchainManager.removePrevInstalledToolchains(tcManager);
-			toolchainManager.initToolChain(tcManager, ESPToolChainProvider.ID);
-			toolchainManager.initCMakeToolChain(tcManager, cmakeTcManager);
-			toolchainManager.addToolchainBasedTargets(IDFCorePlugin.getService(ILaunchTargetManager.class));
-		}
-
 		private void copyOpenOcdRules()
 		{
 			if (Platform.getOS().equals(Platform.OS_LINUX)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationHandler.java
@@ -27,14 +27,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.osgi.util.NLS;
-import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJsonParser.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJsonParser.java
@@ -4,7 +4,9 @@
  *******************************************************************************/
 package com.espressif.idf.ui.tools;
 
+import java.io.BufferedReader;
 import java.io.FileReader;
+import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,6 +92,24 @@ public class ToolsJsonParser
 			currentOS = "win"; //$NON-NLS-1$
 		}
 		
+		if (currentOS.contains(Platform.OS_MACOSX))
+		{
+			Process p = Runtime.getRuntime().exec("uname -m"); //$NON-NLS-1$
+			InputStreamReader inputStreamReader = new InputStreamReader(p.getInputStream());
+			BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+			String output = bufferedReader.readLine();
+			if (!output.contains("arm64")) //$NON-NLS-1$
+			{
+				currentOS = "macos"; //$NON-NLS-1$
+			}
+			else 
+			{
+				currentOS = "macos-".concat(output); //$NON-NLS-1$
+				inputStreamReader.close();
+				bufferedReader.close();				
+			}
+		}
+		
 		for (int i = 0; i < jsonArray.size(); i++)
 		{
 			JsonObject jsonObject = jsonArray.get(i).getAsJsonObject();
@@ -106,7 +126,7 @@ public class ToolsJsonParser
 						JsonElement element = jsonObject.get(key);
 						if (element.isJsonArray())
 						{
-							List<String> list = getStringsListFromJsonArray(element.getAsJsonArray());
+							List<String> list = getStringsListFromJsonArray(element.getAsJsonArray().get(0).getAsJsonArray());
 							injectOverride(toolsVO, key, list);
 						}
 						else

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsUtility.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsUtility.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.text.DecimalFormat;
 import java.util.HashMap;
@@ -72,7 +73,7 @@ public class ToolsUtility
 				}
 			}
 		}
-
+		
 		return false;
 	}
 
@@ -150,10 +151,14 @@ public class ToolsUtility
 				if (archiveentry.isDirectory())
 				{
 					if (!Files.exists(pathEntryOutput))
-						Files.createDirectory(pathEntryOutput);
+						Files.createDirectories(pathEntryOutput);
 				}
 				else
-					Files.copy(tararchiveinputstream, pathEntryOutput);
+				{
+					Files.copy(tararchiveinputstream, pathEntryOutput, StandardCopyOption.REPLACE_EXISTING);
+					Runtime.getRuntime().exec("/bin/chmod 755 ".concat(pathEntryOutput.toString()));
+				}
+					
 			}
 
 			tararchiveinputstream.close();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/wizard/pages/ManageToolsInstallationWizardPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/wizard/pages/ManageToolsInstallationWizardPage.java
@@ -488,7 +488,7 @@ public class ManageToolsInstallationWizardPage extends WizardPage implements ITo
 					{
 						if (ToolsPlatformMapping.isSupported(key))
 						{
-							alwaysInstall |= versionsVO.getStatus().equalsIgnoreCase(RECOMMENDED);
+							alwaysInstall = versionsVO.getStatus().equalsIgnoreCase(RECOMMENDED);
 							isInstalled = ToolsUtility.isToolInstalled(toolsVO.getName(), versionsVO.getName());
 							toolsVO.setInstalled(isInstalled);
 							versionsVO.getVersionOsMap().get(key).setSelected(alwaysInstall);
@@ -521,7 +521,7 @@ public class ManageToolsInstallationWizardPage extends WizardPage implements ITo
 			mainItem.setData(toolsVO);
 			Image installedImage = isInstalled ? UIPlugin.getImage(GREEN) : UIPlugin.getImage(WHITE);
 			mainItem.setImage(2, installedImage);
-			mainItem.setExpanded(alwaysInstall);
+			mainItem.setExpanded(true);
 
 			if (!platformAvailable)
 			{
@@ -848,11 +848,19 @@ public class ManageToolsInstallationWizardPage extends WizardPage implements ITo
 			{
 				String key = item.getText(0);
 				VersionsVO versionsVO = (VersionsVO) item.getData();
-				VersionDetailsVO versionDetailsVO = versionsVO.getVersionOsMap().get(key);
-				if (versionDetailsVO != null)
+				
+				for(String os : versionsVO.getVersionOsMap().keySet())
 				{
-					versionDetailsVO.setSelected(checked);	
+					if (ToolsPlatformMapping.isSupported(os))
+					{
+						VersionDetailsVO versionDetailsVO = versionsVO.getVersionOsMap().get(os);
+						if (versionDetailsVO != null)
+						{
+							versionDetailsVO.setSelected(checked);	
+						}
+					}	
 				}
+				
 			}
 			TreeItem[] items = item.getItems();
 			for (int i = 0; i < items.length; i++)

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -3,149 +3,117 @@
 <target name="com.espressif.idf.target" sequenceNumber="25">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.25/"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.help.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/" />
+			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.rcp.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.help.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.pde.feature.group" version="0.0.0" />
 
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2022-09"/>
-			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/releases/2022-09" />
+			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818"/>
-			<unit id="javax.activation" version="1.2.2.v20201119-1642"/>
-			<unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818"/>
-			<unit id="javax.xml.stream" version="0.0.0"/>
-			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
-			<unit id="org.antlr.runtime" version="0.0.0"/>
-			<unit id="org.apache.commons.compress" version="0.0.0"/>
-			<unit id="org.apache.log4j" version="0.0.0"/>
-			<unit id="org.assertj" version="0.0.0"/>
-			<unit id="org.freemarker" version="0.0.0"/>
-			<unit id="org.hamcrest" version="0.0.0"/>
-			<unit id="org.hamcrest.core" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.junit.jupiter.api" version="0.0.0"/>
-			<unit id="org.mockito" version="0.0.0"/>
-			<unit id="org.slf4j.impl.log4j12" version="0.0.0"/>
-			<unit id="org.yaml.snakeyaml" version="0.0.0"/>
-			<unit id="com.sun.jna" version="5.6.0.v20200716-0148"/>
-			<unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
+			<unit id="com.google.gson" version="0.0.0" />
+			<unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818" />
+			<unit id="javax.activation" version="1.2.2.v20201119-1642" />
+			<unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818" />
+			<unit id="javax.xml.stream" version="0.0.0" />
+			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0" />
+			<unit id="org.antlr.runtime" version="0.0.0" />
+			<unit id="org.apache.commons.compress" version="0.0.0" />
+			<unit id="org.apache.log4j" version="0.0.0" />
+			<unit id="org.assertj" version="0.0.0" />
+			<unit id="org.freemarker" version="0.0.0" />
+			<unit id="org.hamcrest" version="0.0.0" />
+			<unit id="org.hamcrest.core" version="0.0.0" />
+			<unit id="org.junit" version="0.0.0" />
+			<unit id="org.junit.jupiter.api" version="0.0.0" />
+			<unit id="org.mockito" version="0.0.0" />
+			<unit id="org.slf4j.impl.log4j12" version="0.0.0" />
+			<unit id="org.yaml.snakeyaml" version="0.0.0" />
+			<unit id="com.sun.jna" version="5.6.0.v20200716-0148" />
+			<unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/"/>
+			<unit id="org.eclipse.lsp4e" version="0.0.0" />
+			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
-			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/"/>
+			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0" />
+			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/egit/updates-5.13/"/>
+			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/egit/updates-5.13/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository"/>
+			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.apache.batik.xml" version="0.0.0"/>
-			<unit id="org.apache.batik.dom" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
+			<unit id="org.apache.batik.xml" version="0.0.0" />
+			<unit id="org.apache.batik.dom" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/releases/3.10/"/>
+			<repository location="https://download.eclipse.org/mylyn/releases/3.10/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
+			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tm4e/releases/0.4.1/"/>
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tm4e/releases/0.4.1/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/nebula/releases/latest"/>
-			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/nebula/releases/latest" />
+			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/embed-cdt/updates/v6/"/>
+			<repository location="https://download.eclipse.org/embed-cdt/updates/v6/" />
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.feature.group" version="" />
+			<unit id="org.eclipse.embedcdt.packs.feature.group" version="" />
 			
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/embed-cdt/releases/6.3.0/p2"/>
-			<unit id="org.eclipse.embedcdt.codered.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.codered.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.jlink.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.jlink.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.pyocd.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.pyocd.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.qemu.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.qemu.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.doc.user.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.doc.user.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.managedbuild.cross.arm.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.managedbuild.cross.arm.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.managedbuild.cross.riscv.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.managedbuild.cross.riscv.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.packs.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.ad.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.ad.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.cortexm.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.cortexm.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.freescale.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.freescale.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.sifive.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.sifive.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.stm.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.stm.source.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.xpack.feature.group" version="6.3.0.202208180721"/>
-			<unit id="org.eclipse.embedcdt.templates.xpack.source.feature.group" version="6.3.0.202208180721"/>
 		</location>
 	</locations>
 </target>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -3,117 +3,149 @@
 <target name="com.espressif.idf.target" sequenceNumber="25">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.25/" />
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.rcp.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.help.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/"/>
+			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.p2.extras.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.help.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2022-09" />
-			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/releases/2022-09"/>
+			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.launchbar.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="0.0.0" />
-			<unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818" />
-			<unit id="javax.activation" version="1.2.2.v20201119-1642" />
-			<unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818" />
-			<unit id="javax.xml.stream" version="0.0.0" />
-			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0" />
-			<unit id="org.antlr.runtime" version="0.0.0" />
-			<unit id="org.apache.commons.compress" version="0.0.0" />
-			<unit id="org.apache.log4j" version="0.0.0" />
-			<unit id="org.assertj" version="0.0.0" />
-			<unit id="org.freemarker" version="0.0.0" />
-			<unit id="org.hamcrest" version="0.0.0" />
-			<unit id="org.hamcrest.core" version="0.0.0" />
-			<unit id="org.junit" version="0.0.0" />
-			<unit id="org.junit.jupiter.api" version="0.0.0" />
-			<unit id="org.mockito" version="0.0.0" />
-			<unit id="org.slf4j.impl.log4j12" version="0.0.0" />
-			<unit id="org.yaml.snakeyaml" version="0.0.0" />
-			<unit id="com.sun.jna" version="5.6.0.v20200716-0148" />
-			<unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209" />
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/" />
+			<unit id="com.google.gson" version="0.0.0"/>
+			<unit id="com.sun.xml.bind" version="2.3.3.v20201118-1818"/>
+			<unit id="javax.activation" version="1.2.2.v20201119-1642"/>
+			<unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818"/>
+			<unit id="javax.xml.stream" version="0.0.0"/>
+			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
+			<unit id="org.antlr.runtime" version="0.0.0"/>
+			<unit id="org.apache.commons.compress" version="0.0.0"/>
+			<unit id="org.apache.log4j" version="0.0.0"/>
+			<unit id="org.assertj" version="0.0.0"/>
+			<unit id="org.freemarker" version="0.0.0"/>
+			<unit id="org.hamcrest" version="0.0.0"/>
+			<unit id="org.hamcrest.core" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+			<unit id="org.junit.jupiter.api" version="0.0.0"/>
+			<unit id="org.mockito" version="0.0.0"/>
+			<unit id="org.slf4j.impl.log4j12" version="0.0.0"/>
+			<unit id="org.yaml.snakeyaml" version="0.0.0"/>
+			<unit id="com.sun.jna" version="5.6.0.v20200716-0148"/>
+			<unit id="com.sun.jna.platform" version="5.6.0.v20200722-0209"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.lsp4e" version="0.0.0" />
-			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/" />
+			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.7/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0" />
-			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/" />
+			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
+			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/egit/updates-5.13/" />
+			<unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/egit/updates-5.13/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository" />
+			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.apache.batik.xml" version="0.0.0" />
-			<unit id="org.apache.batik.dom" version="0.0.0" />
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository" />
+			<unit id="org.apache.batik.xml" version="0.0.0"/>
+			<unit id="org.apache.batik.dom" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/" />
+			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/" />
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/releases/3.10/" />
+			<repository location="https://download.eclipse.org/mylyn/releases/3.10/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/" />
+			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
-			<repository location="https://download.eclipse.org/tm4e/releases/0.4.1/" />
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tm4e/releases/0.4.1/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/nebula/releases/latest" />
-			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0" />
+			<repository location="http://download.eclipse.org/nebula/releases/latest"/>
+			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/embed-cdt/updates/v6/" />
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="" />
-			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="" />
-			<unit id="org.eclipse.embedcdt.feature.group" version="" />
-			<unit id="org.eclipse.embedcdt.packs.feature.group" version="" />
+			<repository location="https://download.eclipse.org/embed-cdt/updates/v6/"/>
 			
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/embed-cdt/releases/6.3.0/p2"/>
+			<unit id="org.eclipse.embedcdt.codered.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.codered.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.jlink.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.jlink.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.pyocd.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.pyocd.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.qemu.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.qemu.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.debug.gdbjtag.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.doc.user.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.doc.user.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.managedbuild.cross.arm.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.managedbuild.cross.arm.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.managedbuild.cross.riscv.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.managedbuild.cross.riscv.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.packs.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.ad.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.ad.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.cortexm.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.cortexm.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.freescale.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.freescale.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.sifive.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.sifive.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.stm.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.stm.source.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.xpack.feature.group" version="6.3.0.202208180721"/>
+			<unit id="org.eclipse.embedcdt.templates.xpack.source.feature.group" version="6.3.0.202208180721"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
## Description

There were some issues in tools installation wizard particularly on Mac os due to some java functions not working because of limited permissions there while extraction of the files from a gz archive

Fixes # ([IEP-825](https://jira.espressif.com:8443/browse/IEP-825))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

This change requires that tools installation wizard to be tested on Mac os and after that we need to verify this on other platforms as well. If any issues found for those they will be taken in their respective tickets 

**Test Configuration**:
* ESP-IDF Version: **All**
* OS (Windows,Linux and macOS): **All**

## Dependent components impacted by this PR:

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
