### PR TITLE
IEP-890: Show IDF Tools installation status

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InputStreamConsoleThread.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InputStreamConsoleThread.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.eclipse.ui.console.MessageConsoleStream;
+
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * @author Kondal Kolipaka
+ *
+ */
+public class InputStreamConsoleThread extends Thread
+{
+	private InputStream input;
+	private MessageConsoleStream console;
+
+	public InputStreamConsoleThread(InputStream inputStream, MessageConsoleStream console)
+	{
+		if (inputStream == null)
+		{
+			throw new IllegalArgumentException("The InputStream cannot be null!"); //$NON-NLS-1$
+		}
+		this.input = inputStream;
+		this.console = console;
+	}
+
+	@Override
+	public void run()
+	{
+		InputStreamReader streamReader = null;
+		try
+		{
+			streamReader = new InputStreamReader(input, "UTF-8"); //$NON-NLS-1$
+			BufferedReader br = new BufferedReader(streamReader);
+			String line = null;
+			while ((line = br.readLine()) != null)
+			{
+				console.println(line);
+			}
+		}
+		catch (IOException e)
+		{
+			Logger.log(e);
+		} finally
+		{
+			if (streamReader != null)
+			{
+				try
+				{
+					streamReader.close();
+				}
+				catch (Exception e)
+				{
+				}
+			}
+		}
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/InstallToolsHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.ui.console.MessageConsoleStream;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
@@ -70,7 +71,7 @@ public class InstallToolsHandler extends AbstractToolsHandler
 
 				monitor.worked(1);
 				monitor.setTaskName(Messages.InstallToolsHandler_InstallingPythonMsg);
-				status = handleToolsInstallPython();
+				status = handleToolsInstallPython(console);
 				if (status.getSeverity() == IStatus.ERROR)
 				{
 					return status;
@@ -203,16 +204,16 @@ public class InstallToolsHandler extends AbstractToolsHandler
 
 		console.println(Messages.InstallToolsHandler_InstallingToolsMsg);
 		console.println(Messages.InstallToolsHandler_ItWilltakeTimeMsg);
-		return runCommand(arguments);
+		return runCommand(arguments, console);
 	}
 
-	protected IStatus handleToolsInstallPython()
+	protected IStatus handleToolsInstallPython(MessageConsoleStream console)
 	{
 		List<String> arguments;
 		// idf_tools.py install-python-env
 		arguments = new ArrayList<String>();
 		arguments.add(IDFConstants.TOOLS_INSTALL_PYTHON_CMD);
-		return runCommand(arguments);
+		return runCommand(arguments, console);
 	}
 
 	public IStatus handleWebSocketClientInstall()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
@@ -78,7 +78,7 @@ public class ListInstalledToolsHandler extends AbstractToolsHandler
 		List<String> arguments = new ArrayList<String>();
 		arguments.add(IDFConstants.TOOLS_LIST_CMD);
 
-		runCommand(arguments);
+		runCommand(arguments, console);
 	}
 
 }


### PR DESCRIPTION
## Description

Instead of dumping all the installation output after the process is complete, will read the current state of progress and show it in the console.

https://user-images.githubusercontent.com/8463287/220529540-6fce4bd5-2669-4e04-bf67-6f06b2118afb.mov

Fixes # ([IEP-890](https://jira.espressif.com:8443/browse/IEP-890))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

 - Espressif Menu > ESP-IDF Tools Manager > Install Tools 
 - Observe that console will be updated with the current state instead of dumping everything after it's done.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Install Tools

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
