### PR TITLE
IEP-886 Launch Configuration does not save custom build folder path

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/CmakeBuildException.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/CmakeBuildException.java
@@ -1,0 +1,11 @@
+package com.espressif.idf.core.build;
+
+public class CmakeBuildException extends Exception
+{
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 3025439276829588687L;
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -188,10 +188,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		String userArgs = getProperty(CMAKE_ARGUMENTS);
 		// Custom build directory
 		int buildDirIndex = userArgs.indexOf("-B"); //$NON-NLS-1$
-		if (buildDirIndex != -1)
-		{
-			this.customBuildDir = userArgs.replaceFirst("-B", StringUtil.EMPTY).stripLeading(); //$NON-NLS-1$
-		}
+		customBuildDir = buildDirIndex == -1 ? StringUtil.EMPTY
+				: userArgs.replaceFirst("-B", StringUtil.EMPTY).stripLeading(); //$NON-NLS-1$
 		try
 		{
 			getProject().setPersistentProperty(
@@ -202,7 +200,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			Logger.log(e);
 		}
 
-		return this.customBuildDir != null;
+		return !customBuildDir.isBlank();
 	}
 
 	@Override
@@ -335,7 +333,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 			String envStr = getProperty(CMAKE_ENV);
 			List<IEnvironmentVariable> envVars = new ArrayList<>();
-			if (envStr != null)
+			if (envStr != null && !envStr.isBlank())
 			{
 				List<String> envList = CMakeUtils.stripEnvVars(envStr);
 				for (String s : envList)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.eclipse.cdt.build.gcc.core.ClangToolChain;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
@@ -78,6 +79,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
@@ -91,12 +93,14 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.DfuCommandsUtil;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.ParitionSizeHandler;
+import com.espressif.idf.core.util.StringUtil;
 import com.google.gson.Gson;
 
 @SuppressWarnings(value = { "restriction" })
 public class IDFBuildConfiguration extends CBuildConfiguration
 {
 
+	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
 	protected static final String COMPONENTS = "components"; //$NON-NLS-1$
 	private static final String ESP_IDF_COMPONENTS = "esp_idf_components"; //$NON-NLS-1$
@@ -181,6 +185,23 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 	private boolean hasCustomBuild()
 	{
+		String userArgs = getProperty(CMAKE_ARGUMENTS);
+		// Custom build directory
+		int buildDirIndex = userArgs.indexOf("-B"); //$NON-NLS-1$
+		if (buildDirIndex != -1)
+		{
+			this.customBuildDir = userArgs.replaceFirst("-B", StringUtil.EMPTY).stripLeading(); //$NON-NLS-1$
+		}
+		try
+		{
+			getProject().setPersistentProperty(
+					new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY), customBuildDir);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
 		return this.customBuildDir != null;
 	}
 
@@ -210,6 +231,25 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		return getBuildOutput(binaries, outputPath);
 	}
 
+	@Override
+	public String getProperty(String name)
+	{
+		try
+		{
+			ILaunchConfiguration configuration = IDFCorePlugin.getService(ILaunchBarManager.class)
+					.getActiveLaunchConfiguration();
+			String property = configuration.getAttribute(name, StringUtil.EMPTY);
+			property = property.isBlank() ? getSettings().get(name, StringUtil.EMPTY) : property;
+			return property;
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
+		return super.getProperty(name);
+	}
+
 	private IBinary[] getBuildOutput(final IBinaryContainer binaries, final IPath outputPath) throws CoreException
 	{
 		return Arrays.stream(binaries.getBinaries()).filter(b -> b.isExecutable() && outputPath.isPrefixOf(b.getPath()))
@@ -234,247 +274,41 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			throws CoreException
 	{
 		IProject project = getProject();
-		ICMakeToolChainFile toolChainFile = getToolChainFile();
+		toolChainFile = getToolChainFile();
 
 		Instant start = Instant.now();
+		if (!checkLaunchTarget(console) || !checkSpacesSupport(project, console) || !checkToolChainFile(console))
+		{
+			return new IProject[0];
+		}
+
+		String generator = getProperty(CMAKE_GENERATOR);
+		generator = generator.isBlank() ? NINJA : generator;
+		project.deleteMarkers(ICModelMarker.C_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
+
+		ConsoleOutputStream infoStream = console.getInfoStream();
+		// create build directory
+		Path buildDir = getBuildDirectory();
+		if (!buildDir.toFile().exists())
+		{
+			buildDir.toFile().mkdir();
+		}
 
 		try
 		{
-			// Get launch target
-			ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
-			launchtarget = launchBarManager.getActiveLaunchTarget();
-			ILaunchMode activeLaunchMode = launchBarManager.getActiveLaunchMode();
-
-			// Allow build only through esp launch target in run mode
-			if (launchtarget != null && !launchtarget.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE)
-					&& activeLaunchMode != null && activeLaunchMode.getIdentifier().equals("run")) //$NON-NLS-1$
-			{
-				console.getErrorStream()
-						.write("No esp launch target found. Please create/select the correct 'Launch Target'"); //$NON-NLS-1$
-				return null;
-			}
-
-			// Check for spaces in the project path
-			if (!IDFUtil.checkIfIdfSupportsSpaces() && project.getLocation().toOSString().contains(" ")) //$NON-NLS-1$
-			{
-				console.getErrorStream()
-						.write("Project path can’t include space " + project.getLocation().toOSString()); //$NON-NLS-1$
-				return null;
-			}
-
-			String generator = getProperty(CMAKE_GENERATOR);
-			if (generator == null)
-			{
-				generator = "Ninja"; //$NON-NLS-1$
-			}
-
-			project.deleteMarkers(ICModelMarker.C_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
-
-			ConsoleOutputStream infoStream = console.getInfoStream();
-
-			// create build directory
-			Path buildDir = getBuildDirectory();
-			if (!buildDir.toFile().exists())
-			{
-				buildDir.toFile().mkdir();
-			}
-
 			infoStream.write(String.format(Messages.CMakeBuildConfiguration_BuildingIn, buildDir.toString()));
-
-			// Make sure we have a toolchain file if cross
-			if (toolChainFile == null && !isLocal())
-			{
-				ICMakeToolChainManager manager = IDFCorePlugin.getService(ICMakeToolChainManager.class);
-				toolChainFile = manager.getToolChainFileFor(getToolChain());
-
-				if (toolChainFile == null)
-				{
-					// error
-					console.getErrorStream()
-							.write(Messages.IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile);
-					return null;
-				}
-			}
-
 			boolean runCMake = cmakeListsModified;
 			if (!runCMake)
 			{
-				switch (generator)
-				{
-				case "Ninja": //$NON-NLS-1$
-					runCMake = !Files.exists(buildDir.resolve("build.ninja")); //$NON-NLS-1$
-					break;
-				default:
-					runCMake = !Files.exists(buildDir.resolve("CMakeFiles")); //$NON-NLS-1$
-				}
+				runCMake = generator.contentEquals(NINJA) ? !Files.exists(buildDir.resolve("build.ninja")) //$NON-NLS-1$
+						: !Files.exists(buildDir.resolve("CMakeFiles")); //$NON-NLS-1$
 			}
 
 			if (runCMake)
 			{
-				deleteCMakeErrorMarkers(project);
-
-				infoStream.write(String.format(Messages.CMakeBuildConfiguration_Configuring, buildDir));
-				// clean output to make sure there is no content
-				// incompatible with current settings (cmake config would fail)
-				cleanBuildDirectory(buildDir);
-
-				List<String> command = new ArrayList<>();
-
-				command.add("cmake"); //$NON-NLS-1$
-				command.add("-G"); //$NON-NLS-1$
-				command.add(generator);
-
-				if (toolChainFile != null)
-				{
-					command.add("-DCMAKE_TOOLCHAIN_FILE=" + toolChainFile.getPath().toString()); //$NON-NLS-1$
-				}
-
-				command.add("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"); //$NON-NLS-1$
-				if (isCCacheEnabled())
-				{
-					command.add("-DCCACHE_ENABLE=1"); //$NON-NLS-1$
-				}
-
-				if (launchtarget != null)
-				{
-					String idfTargetName = launchtarget.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
-							""); //$NON-NLS-1$
-					if (!idfTargetName.isEmpty())
-					{
-						command.add("-DIDF_TARGET=" + idfTargetName); //$NON-NLS-1$
-					}
-				}
-
-				if (getToolChain().getTypeId() == ClangToolChain.TYPE_ID)
-				{
-					command.add("-DIDF_TOOLCHAIN=clang"); //$NON-NLS-1$
-				}
-
-				String userArgs = getProperty(CMAKE_ARGUMENTS);
-				if (userArgs != null)
-				{
-					command.addAll(Arrays.asList(userArgs.trim().split("\\s+"))); //$NON-NLS-1$
-				}
-
-				// Custom build directory
-				int buildDirIndex = command.indexOf("-B"); //$NON-NLS-1$
-				if (buildDirIndex != -1)
-				{
-					this.customBuildDir = command.get(buildDirIndex + 1);
-				}
-				getProject().setPersistentProperty(
-						new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY), customBuildDir);
-
-				IContainer srcFolder = project;
-				command.add(new File(srcFolder.getLocationURI()).getAbsolutePath());
-
-				infoStream.write(String.join(" ", command) + '\n'); //$NON-NLS-1$
-
-				org.eclipse.core.runtime.Path workingDir = new org.eclipse.core.runtime.Path(
-						getBuildDirectory().toString());
-				// hook in cmake error parsing
-				IConsole errConsole = new CMakeConsoleWrapper(srcFolder, console);
-
-				// Set PYTHONUNBUFFERED to 1/TRUE to dump the messages back immediately without
-				// buffering
-				IEnvironmentVariable bufferEnvVar = new EnvironmentVariable("PYTHONUNBUFFERED", "1"); //$NON-NLS-1$ //$NON-NLS-2$
-
-				Process p = startBuildProcess(command, new IEnvironmentVariable[] { bufferEnvVar }, workingDir,
-						errConsole, monitor);
-				if (p == null)
-				{
-					console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
-					return null;
-				}
-
-				watchProcess(p, errConsole);
-				cmakeListsModified = false;
+				runCmakeCommand(console, monitor, project, generator, infoStream, buildDir);
 			}
-
-			try (ErrorParserManager epm = new ErrorParserManager(project, getBuildDirectoryURI(), this,
-					getToolChain().getErrorParserIds()))
-			{
-				epm.setOutputStream(console.getOutputStream());
-
-				List<String> command = new ArrayList<>();
-
-				String envStr = getProperty(CMAKE_ENV);
-				List<IEnvironmentVariable> envVars = new ArrayList<>();
-				if (envStr != null)
-				{
-					List<String> envList = CMakeUtils.stripEnvVars(envStr);
-					for (String s : envList)
-					{
-						int index = s.indexOf("="); //$NON-NLS-1$
-						if (index == -1)
-						{
-							envVars.add(new EnvironmentVariable(s));
-						}
-						else
-						{
-							envVars.add(new EnvironmentVariable(s.substring(0, index), s.substring(index + 1)));
-						}
-					}
-				}
-
-				String buildCommand = getProperty(BUILD_COMMAND);
-				if (buildCommand == null)
-				{
-					command.add("cmake"); //$NON-NLS-1$
-					command.add("--build"); //$NON-NLS-1$
-					command.add("."); //$NON-NLS-1$
-					if ("Ninja".equals(generator)) //$NON-NLS-1$
-					{
-						command.add("--"); //$NON-NLS-1$
-						command.add("-v"); //$NON-NLS-1$
-					}
-				}
-				else
-				{
-					command.addAll(Arrays.asList(buildCommand.split(" "))); //$NON-NLS-1$
-				}
-
-				infoStream.write(String.join(" ", command) + '\n'); //$NON-NLS-1$
-
-				org.eclipse.core.runtime.Path workingDir = new org.eclipse.core.runtime.Path(
-						getBuildDirectory().toString());
-				Process p = startBuildProcess(command, envVars.toArray(new IEnvironmentVariable[0]), workingDir,
-						console, monitor);
-				if (p == null)
-				{
-					console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
-					return null;
-				}
-
-				watchProcess(p, new IConsoleParser[] { epm });
-
-				final String isSkip = System.getProperty("skip.idf.components"); //$NON-NLS-1$
-				if (!Boolean.parseBoolean(isSkip))
-				{ // no property defined
-					linkBuildComponents(project, monitor);
-					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-				}
-
-				// parse compile_commands.json file
-				// built-ins detection output goes to the build console, if the user requested
-				// output
-
-				processCompileCommandsFile(console, monitor);
-				if (DfuCommandsUtil.isDfu() && DfuCommandsUtil.isDfuSupported(launchtarget))
-				{
-					watchProcess(DfuCommandsUtil.dfuBuild(project, infoStream, buildConfiguration, envVars), console);
-				}
-				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-
-				infoStream.write(String.format(Messages.CMakeBuildConfiguration_BuildingComplete, epm.getErrorCount(),
-						epm.getWarningCount(), buildDir.toString()));
-
-				Instant finish = Instant.now();
-				long timeElapsed = Duration.between(start, finish).toMillis();
-				ParitionSizeHandler paritionSizeHandler = new ParitionSizeHandler(project, infoStream, console);
-				paritionSizeHandler.startCheckingSize();
-				infoStream.write(MessageFormat.format("Total time taken to build the project: {0} ms", timeElapsed)); //$NON-NLS-1$
-			}
+			runCmakeBuildCommand(console, monitor, project, start, generator, infoStream, buildDir);
 
 			// This is specifically added to trigger the indexing since in Windows OS it
 			// doesn't seem to happen!
@@ -486,6 +320,239 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			throw new CoreException(IDFCorePlugin
 					.errorStatus(String.format(Messages.CMakeBuildConfiguration_Building, project.getName()), e));
 		}
+	}
+
+	private void runCmakeBuildCommand(IConsole console, IProgressMonitor monitor, IProject project, Instant start,
+			String generator, ConsoleOutputStream infoStream, Path buildDir)
+			throws CoreException, IOException, CmakeBuildException
+	{
+		try (ErrorParserManager epm = new ErrorParserManager(project, getBuildDirectoryURI(), this,
+				getToolChain().getErrorParserIds()))
+		{
+			epm.setOutputStream(console.getOutputStream());
+
+			List<String> command = new ArrayList<>();
+
+			String envStr = getProperty(CMAKE_ENV);
+			List<IEnvironmentVariable> envVars = new ArrayList<>();
+			if (envStr != null)
+			{
+				List<String> envList = CMakeUtils.stripEnvVars(envStr);
+				for (String s : envList)
+				{
+					int index = s.indexOf("="); //$NON-NLS-1$
+					if (index == -1)
+					{
+						envVars.add(new EnvironmentVariable(s));
+					}
+					else
+					{
+						envVars.add(new EnvironmentVariable(s.substring(0, index), s.substring(index + 1)));
+					}
+				}
+			}
+
+			String buildCommand = getProperty(BUILD_COMMAND);
+			if (buildCommand.isBlank())
+			{
+				command.add("cmake"); //$NON-NLS-1$
+				command.add("--build"); //$NON-NLS-1$
+				command.add("."); //$NON-NLS-1$
+				if (NINJA.equals(generator)) // $NON-NLS-1$
+				{
+					command.add("--"); //$NON-NLS-1$
+					command.add("-v"); //$NON-NLS-1$
+				}
+			}
+			else
+			{
+				command.addAll(Arrays.asList(buildCommand.split(" "))); //$NON-NLS-1$
+			}
+
+			infoStream.write(String.join(" ", command) + '\n'); //$NON-NLS-1$
+
+			org.eclipse.core.runtime.Path workingDir = new org.eclipse.core.runtime.Path(
+					getBuildDirectory().toString());
+			Process p = startBuildProcess(command, envVars.toArray(new IEnvironmentVariable[0]), workingDir, console,
+					monitor);
+			if (p == null)
+			{
+				console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
+				throw new CmakeBuildException();
+			}
+
+			watchProcess(p, new IConsoleParser[] { epm });
+
+			final String isSkip = System.getProperty("skip.idf.components"); //$NON-NLS-1$
+			if (!Boolean.parseBoolean(isSkip))
+			{ // no property defined
+				linkBuildComponents();
+				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+			}
+
+			// parse compile_commands.json file
+			// built-ins detection output goes to the build console, if the user requested
+			// output
+
+			processCompileCommandsFile(console, monitor);
+			if (DfuCommandsUtil.isDfu() && DfuCommandsUtil.isDfuSupported(launchtarget))
+			{
+				watchProcess(DfuCommandsUtil.dfuBuild(project, infoStream, buildConfiguration, envVars), console);
+			}
+			project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+
+			infoStream.write(String.format(Messages.CMakeBuildConfiguration_BuildingComplete, epm.getErrorCount(),
+					epm.getWarningCount(), buildDir.toString()));
+
+			Instant finish = Instant.now();
+			long timeElapsed = Duration.between(start, finish).toMillis();
+			ParitionSizeHandler paritionSizeHandler = new ParitionSizeHandler(project, infoStream, console);
+			paritionSizeHandler.startCheckingSize();
+			infoStream.write(MessageFormat.format("Total time taken to build the project: {0} ms", timeElapsed)); //$NON-NLS-1$
+		}
+	}
+
+	private void runCmakeCommand(IConsole console, IProgressMonitor monitor, IProject project, String generator,
+			ConsoleOutputStream infoStream, Path buildDir) throws CoreException, IOException, CmakeBuildException
+	{
+		deleteCMakeErrorMarkers(project);
+
+		infoStream.write(String.format(Messages.CMakeBuildConfiguration_Configuring, buildDir));
+		// clean output to make sure there is no content
+		// incompatible with current settings (cmake config would fail)
+		cleanBuildDirectory(buildDir);
+
+		List<String> command = new ArrayList<>();
+
+		command.add("cmake"); //$NON-NLS-1$
+		command.add("-G"); //$NON-NLS-1$
+		command.add(generator);
+
+		if (toolChainFile != null)
+		{
+			command.add("-DCMAKE_TOOLCHAIN_FILE=" + toolChainFile.getPath().toString()); //$NON-NLS-1$
+		}
+
+		command.add("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"); //$NON-NLS-1$
+		if (isCCacheEnabled())
+		{
+			command.add("-DCCACHE_ENABLE=1"); //$NON-NLS-1$
+		}
+
+		if (launchtarget != null)
+		{
+			String idfTargetName = launchtarget.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
+					StringUtil.EMPTY);
+			if (!idfTargetName.isEmpty())
+			{
+				command.add("-DIDF_TARGET=" + idfTargetName); //$NON-NLS-1$
+			}
+		}
+
+		if (Objects.equals(getToolChain().getTypeId(), ClangToolChain.TYPE_ID))
+		{
+			command.add("-DIDF_TOOLCHAIN=clang"); //$NON-NLS-1$
+		}
+
+		String userArgs = getProperty(CMAKE_ARGUMENTS);
+		if (userArgs != null)
+		{
+			command.addAll(Arrays.asList(userArgs.trim().split("\\s+"))); //$NON-NLS-1$
+		}
+		IContainer srcFolder = project;
+		command.add(new File(srcFolder.getLocationURI()).getAbsolutePath());
+
+		infoStream.write(String.join(" ", command) + '\n'); //$NON-NLS-1$
+
+		org.eclipse.core.runtime.Path workingDir = new org.eclipse.core.runtime.Path(getBuildDirectory().toString());
+		// hook in cmake error parsing
+		IConsole errConsole = new CMakeConsoleWrapper(srcFolder, console);
+
+		// Set PYTHONUNBUFFERED to 1/TRUE to dump the messages back immediately without
+		// buffering
+		IEnvironmentVariable bufferEnvVar = new EnvironmentVariable("PYTHONUNBUFFERED", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		Process p = startBuildProcess(command, new IEnvironmentVariable[] { bufferEnvVar }, workingDir, errConsole,
+				monitor);
+		if (p == null)
+		{
+			console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
+			throw new CmakeBuildException();
+		}
+
+		watchProcess(p, errConsole);
+		cmakeListsModified = false;
+	}
+
+	private boolean checkToolChainFile(IConsole console)
+	{
+		try
+		{
+			if (toolChainFile == null && !isLocal())
+			{
+				ICMakeToolChainManager manager = IDFCorePlugin.getService(ICMakeToolChainManager.class);
+				toolChainFile = manager.getToolChainFileFor(getToolChain());
+				if (toolChainFile == null)
+				{
+					console.getErrorStream()
+							.write(Messages.IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile);
+					return false;
+				}
+			}
+		}
+		catch (
+				IOException
+				| CoreException e)
+		{
+			Logger.log(e);
+		}
+		return true;
+	}
+
+	private boolean checkSpacesSupport(IProject project, IConsole console)
+	{
+		if (!IDFUtil.checkIfIdfSupportsSpaces() && project.getLocation().toOSString().contains(" ")) //$NON-NLS-1$
+		{
+			try
+			{
+				console.getErrorStream()
+						.write("Project path can’t include space " + project.getLocation().toOSString()); //$NON-NLS-1$
+			}
+			catch (
+					IOException
+					| CoreException e)
+			{
+				Logger.log(e);
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private boolean checkLaunchTarget(IConsole console)
+	{
+		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+		try
+		{
+			launchtarget = launchBarManager.getActiveLaunchTarget();
+			ILaunchMode activeLaunchMode = launchBarManager.getActiveLaunchMode();
+			// Allow build only through esp launch target in run mode
+			if (launchtarget != null && !launchtarget.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE)
+					&& activeLaunchMode != null && activeLaunchMode.getIdentifier().equals("run")) //$NON-NLS-1$
+			{
+				console.getErrorStream()
+						.write("No esp launch target found. Please create/select the correct 'Launch Target'"); //$NON-NLS-1$
+				return false;
+			}
+		}
+		catch (
+				CoreException
+				| IOException e)
+		{
+			Logger.log(e);
+		}
+
+		return true;
 	}
 
 	private boolean isCCacheEnabled()
@@ -510,7 +577,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			}
 			catch (Exception e)
 			{
-				e.printStackTrace();
+				Logger.log(e);
 			}
 		}
 	}
@@ -526,7 +593,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	 * @param project
 	 * @throws Exception
 	 */
-	protected void linkBuildComponents(IProject project, IProgressMonitor monitor) throws Exception
+	protected void linkBuildComponents() throws CoreException
 	{
 		final IPath jsonIPath = getBuildContainerPath()
 				.append(new org.eclipse.core.runtime.Path(COMPILE_COMMANDS_JSON));
@@ -548,11 +615,11 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
 				if (file == null)
 				{
-					createLinkForSourceFileOnly(path.toOSString(), project, folder, monitor);
+					createLinkForSourceFileOnly(path.toOSString(), folder);
 				}
 			}
 		}
-		catch (Exception e)
+		catch (IOException e)
 		{
 			Logger.log(e);
 		}
@@ -597,8 +664,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		}
 	}
 
-	private void createLinkForSourceFileOnly(String sourceFile, IProject project, IFolder folder,
-			IProgressMonitor monitor) throws Exception
+	private void createLinkForSourceFileOnly(String sourceFile, IFolder folder) throws CoreException
 	{
 		String sourceFileToSplit = sourceFile;
 		if (sourceFile.contains(getIdfToolsPath()))
@@ -660,7 +726,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			String cleanCommand = getProperty(CLEAN_COMMAND);
 			if (cleanCommand == null)
 			{
-				if (generator == null || generator.equals("Ninja")) //$NON-NLS-1$
+				if (generator == null || generator.equals(NINJA)) // $NON-NLS-1$
 				{
 					command.add("ninja"); //$NON-NLS-1$
 					command.add("clean"); //$NON-NLS-1$
@@ -835,29 +901,21 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			return true;
 		}
 
-		if (delta.getKind() == ICElementDelta.CHANGED)
+		if (delta.getKind() == ICElementDelta.CHANGED && ((delta.getFlags() & ICElementDelta.F_CONTENT) != 0))
 		{
 			// check for modified CMakeLists.txt file
-			if (0 != (delta.getFlags() & ICElementDelta.F_CONTENT))
+			IResourceDelta[] resourceDeltas = delta.getResourceDeltas();
+			if (resourceDeltas != null)
 			{
-				IResourceDelta[] resourceDeltas = delta.getResourceDeltas();
-				if (resourceDeltas != null)
-				{
-					for (IResourceDelta resourceDelta : resourceDeltas)
-					{
-						IResource resource = resourceDelta.getResource();
-						if (resource.getType() == IResource.FILE
-								&& !resource.getFullPath().toOSString().contains(IDFConstants.BUILD_FOLDER))
-						{
-							String name = resource.getName();
-							if (name.equals("CMakeLists.txt") || name.endsWith(".cmake")) //$NON-NLS-1$ //$NON-NLS-2$
-							{
-								cmakeListsModified = true;
-								return false; // stop processing
-							}
-						}
-					}
-				}
+				cmakeListsModified = Stream.of(resourceDeltas).map(t -> t.getResource())
+						.filter(t -> t.getType() == IResource.FILE
+								&& !t.getFullPath().toOSString().contains(IDFConstants.BUILD_FOLDER))
+						.map(t -> t.getName()).anyMatch(t -> t.equals("CMakeLists.txt") || t.endsWith(".cmake")); //$NON-NLS-1$ //$NON-NLS-2$
+
+			}
+			if (cmakeListsModified)
+			{
+				return false;
 			}
 		}
 
@@ -979,7 +1037,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 			IPath projectPath = getComponentsPath().append(relativePath);
 			IResource resourcePath = project.findMember(projectPath);
-			if (resourcePath != null && resourcePath instanceof IFile)
+			if (resourcePath instanceof IFile)
 			{
 				return (IFile) resourcePath;
 			}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -453,7 +453,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		}
 
 		String userArgs = getProperty(CMAKE_ARGUMENTS);
-		if (userArgs != null)
+		if (userArgs != null && !userArgs.isBlank())
 		{
 			command.addAll(Arrays.asList(userArgs.trim().split("\\s+"))); //$NON-NLS-1$
 		}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/StringUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/StringUtil.java
@@ -10,7 +10,11 @@ package com.espressif.idf.core.util;
  */
 public class StringUtil
 {
-	public static String EMPTY = ""; //$NON-NLS-1$
+	private StringUtil()
+	{
+	}
+
+	public static final String EMPTY = ""; //$NON-NLS-1$
 
 	public static final String LINE_SEPARATOR = System.getProperty("line.separator"); //$NON-NLS-1$
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -111,9 +111,18 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 	@Override
 	public void launchDescriptorRemoved(ILaunchDescriptor descriptor) throws CoreException {
 		IProject project = descriptor.getAdapter(IProject.class);
-		if (project != null) {
-			configs.remove(project);
+		if (project == null) {
+			return;
 		}
+		Map<String, ILaunchConfiguration> projectConfigs = configs.get(project);
+		if (projectConfigs != null) {
+			for (ILaunchConfiguration config : projectConfigs.values()) {
+				if (config.contentsEqual(((IDFProjectLaunchDescriptor) descriptor).getConfiguration())) {
+					config.delete();
+				}
+			}
+		}
+
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -69,8 +69,7 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		if (project != null && !project.isOpen()) {
 			return true;
 		}
-		if (ownsLaunchConfiguration(configuration)) {
-
+		if (configuration.exists()) {
 			Map<String, ILaunchConfiguration> projectConfigs = configs.get(project);
 			if (projectConfigs == null) {
 				projectConfigs = new HashMap<>();
@@ -78,9 +77,9 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 			}
 
 			projectConfigs.put(configuration.getName(), configuration);
-			return true;
 		}
-		return false;
+
+		return ownsLaunchConfiguration(configuration);
 	}
 
 	@Override
@@ -116,11 +115,7 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		}
 		Map<String, ILaunchConfiguration> projectConfigs = configs.get(project);
 		if (projectConfigs != null) {
-			for (ILaunchConfiguration config : projectConfigs.values()) {
-				if (config.contentsEqual(((IDFProjectLaunchDescriptor) descriptor).getConfiguration())) {
-					config.delete();
-				}
-			}
+			projectConfigs.remove(descriptor.getName());
 		}
 
 	}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -247,8 +247,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		if (!configManager.hasConfiguration(configurationProvider, project, configuration.getName())) {
 			configurationProvider.setNameBasedOnLaunchConfiguration(configuration);
 		}
-		IBuildConfiguration buildConfig = project
-				.getBuildConfig(IDFBuildConfigurationProvider.ID + '/' + configuration.getName());
+		IBuildConfiguration buildConfig = project.getActiveBuildConfig();
 
 		IProjectDescription desc = project.getDescription();
 		desc.setActiveBuildConfig(IDFBuildConfigurationProvider.ID + '/' + configuration.getName());

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -150,7 +150,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 	}
 
 	private void chooseProject() {
-		ICProject projects[];
+		ICProject[] projects;
 		try {
 			projects = CoreModel.getDefault().getCModel().getCProjects();
 			ILabelProvider labelProvider = new CElementLabelProvider();
@@ -306,11 +306,15 @@ public class CMakeMainTab2 extends GenericMainTab {
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		super.performApply(configuration);
-		if (!isJtagFlashAvailable) {
-			return;
-		}
 		try {
 			ILaunchConfigurationWorkingCopy wc = configuration.getWorkingCopy();
+			if (selectedProject != null) {
+				initializeCProject(selectedProject, wc);
+			}
+			if (!isJtagFlashAvailable) {
+				wc.doSave();
+				return;
+			}
 			wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText());
 			wc.setAttribute(IDFLaunchConstants.JTAG_FLASH_VOLTAGE, fFlashVoltage.getText());
 			wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, fTarget.getText());
@@ -324,10 +328,6 @@ public class CMakeMainTab2 extends GenericMainTab {
 			} else {
 				wc.setAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS, argumentField.getText());
 				wc.setAttribute(IDFLaunchConstants.ATTR_JTAG_FLASH_ARGUMENTS, argumentsForJtagFlash);
-			}
-
-			if (selectedProject != null) {
-				wc.setMappedResources(new IResource[] { selectedProject });
 			}
 
 			wc.doSave();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -26,6 +26,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.swt.SWT;
@@ -191,7 +192,7 @@ public class CMakeBuildTab2 extends CommonBuildTab
 		IDFBuildConfigurationProvider provider = new IDFBuildConfigurationProvider();
 		provider.setNameBasedOnLaunchConfiguration(configuration);
 		provider.createBuildConfiguration(project, getBuildConfiguration() == null ? getDefaultMatchingToolChain()
-				: getBuildConfiguration().getToolChain(), "run", null); //$NON-NLS-1$
+				: getBuildConfiguration().getToolChain(), ILaunchManager.RUN_MODE, null);
 	}
 
 	private IToolChain getDefaultMatchingToolChain()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -183,19 +183,15 @@ public class CMakeBuildTab2 extends CommonBuildTab
 			Logger.log(e);
 		}
 
-
 	}
 
-	private void createBuildConfiguration(ILaunchConfiguration configuration)
-			throws CoreException
+	private void createBuildConfiguration(ILaunchConfiguration configuration) throws CoreException
 	{
 		IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
 		IDFBuildConfigurationProvider provider = new IDFBuildConfigurationProvider();
 		provider.setNameBasedOnLaunchConfiguration(configuration);
-		provider.createBuildConfiguration(project,
-				getBuildConfiguration() == null ? getDefaultMatchingToolChain()
-						: getBuildConfiguration().getToolChain(),
-				IDFCorePlugin.getService(ILaunchBarManager.class).getActiveLaunchMode().getIdentifier(), null);
+		provider.createBuildConfiguration(project, getBuildConfiguration() == null ? getDefaultMatchingToolChain()
+				: getBuildConfiguration().getToolChain(), "run", null); //$NON-NLS-1$
 	}
 
 	private IToolChain getDefaultMatchingToolChain()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
-import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
 import org.eclipse.cdt.core.build.ICBuildConfigurationProvider;
 import org.eclipse.cdt.core.build.IToolChain;
@@ -187,17 +186,16 @@ public class CMakeBuildTab2 extends CommonBuildTab
 
 	}
 
-	private ICBuildConfiguration getBuildConfiguration(ILaunchConfiguration configuration, IProject project)
+	private void createBuildConfiguration(ILaunchConfiguration configuration)
 			throws CoreException
 	{
-		ICBuildConfiguration buildConfig = null;
+		IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
 		IDFBuildConfigurationProvider provider = new IDFBuildConfigurationProvider();
 		provider.setNameBasedOnLaunchConfiguration(configuration);
-		buildConfig = provider.createBuildConfiguration(project,
+		provider.createBuildConfiguration(project,
 				getBuildConfiguration() == null ? getDefaultMatchingToolChain()
 						: getBuildConfiguration().getToolChain(),
 				IDFCorePlugin.getService(ILaunchBarManager.class).getActiveLaunchMode().getIdentifier(), null);
-		return buildConfig;
 	}
 
 	private IToolChain getDefaultMatchingToolChain()
@@ -275,6 +273,15 @@ public class CMakeBuildTab2 extends CommonBuildTab
 		else
 		{
 			configuration.removeAttribute(CMakeBuildConfiguration.CLEAN_COMMAND);
+		}
+
+		try
+		{
+			createBuildConfiguration(configuration);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
 		}
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -48,7 +48,8 @@ import com.espressif.idf.core.util.RecheckConfigsHelper;
 import com.espressif.idf.core.util.StringUtil;
 
 @SuppressWarnings("restriction")
-public class CMakeBuildTab2 extends CommonBuildTab {
+public class CMakeBuildTab2 extends CommonBuildTab
+{
 
 	private static final String UNIX_MAKEFILES = "Unix Makefiles";
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
@@ -58,17 +59,18 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 	private Text buildCommandText;
 	private Text cleanCommandText;
 
-
 	private static IToolChainManager tcManager = LaunchUIPlugin.getService(IToolChainManager.class);
 	private static ICBuildConfigurationManager bcManager = LaunchUIPlugin.getService(ICBuildConfigurationManager.class);
-	
+
 	@Override
-	protected String getBuildConfigProviderId() {
+	protected String getBuildConfigProviderId()
+	{
 		return IDFBuildConfigurationProvider.ID;
 	}
 
 	@Override
-	public void createControl(Composite parent) {
+	public void createControl(Composite parent)
+	{
 		Composite comp = new Composite(parent, SWT.NONE);
 		comp.setLayout(new GridLayout());
 		setControl(comp);
@@ -89,18 +91,22 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 
 		unixGenButton = new Button(genComp, SWT.RADIO);
 		unixGenButton.setText(Messages.CMakeBuildTab2_UnixMakeFiles);
-		unixGenButton.addSelectionListener(new SelectionAdapter() {
+		unixGenButton.addSelectionListener(new SelectionAdapter()
+		{
 			@Override
-			public void widgetSelected(SelectionEvent e) {
+			public void widgetSelected(SelectionEvent e)
+			{
 				updateLaunchConfigurationDialog();
 			}
 		});
 
 		ninjaGenButton = new Button(genComp, SWT.RADIO);
 		ninjaGenButton.setText(Messages.CMakeBuildTab2_Ninja);
-		ninjaGenButton.addSelectionListener(new SelectionAdapter() {
+		ninjaGenButton.addSelectionListener(new SelectionAdapter()
+		{
 			@Override
-			public void widgetSelected(SelectionEvent e) {
+			public void widgetSelected(SelectionEvent e)
+			{
 				updateLaunchConfigurationDialog();
 			}
 		});
@@ -128,7 +134,8 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 	}
 
 	@Override
-	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
+	{
 		ICBuildConfiguration buildConfig = null;
 		try
 		{
@@ -146,7 +153,8 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 	}
 
 	@Override
-	public void initializeFrom(ILaunchConfiguration configuration) {
+	public void initializeFrom(ILaunchConfiguration configuration)
+	{
 
 		super.initializeFrom(configuration);
 		ICBuildConfiguration buildConfig = null;
@@ -166,23 +174,32 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 		updateGeneratorButtons(generator);
 
 		String cmakeArgs = buildConfig.getProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
-		if (cmakeArgs != null) {
+		if (cmakeArgs != null)
+		{
 			cmakeArgsText.setText(cmakeArgs);
-		} else {
+		}
+		else
+		{
 			cmakeArgsText.setText(StringUtil.EMPTY);
 		}
 
 		String buildCommand = buildConfig.getProperty(CMakeBuildConfiguration.BUILD_COMMAND);
-		if (buildCommand != null) {
+		if (buildCommand != null)
+		{
 			buildCommandText.setText(buildCommand);
-		} else {
+		}
+		else
+		{
 			buildCommandText.setText(StringUtil.EMPTY);
 		}
 
 		String cleanCommand = buildConfig.getProperty(CMakeBuildConfiguration.CLEAN_COMMAND);
-		if (cleanCommand != null) {
+		if (cleanCommand != null)
+		{
 			cleanCommandText.setText(buildCommand != null ? buildCommand : StringUtil.EMPTY);
-		} else {
+		}
+		else
+		{
 			cleanCommandText.setText(StringUtil.EMPTY);
 		}
 	}
@@ -193,11 +210,10 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 		ICBuildConfiguration buildConfig = null;
 		IDFBuildConfigurationProvider provider = new IDFBuildConfigurationProvider();
 		provider.setNameBasedOnLaunchConfiguration(configuration);
-		buildConfig = provider
-				.createBuildConfiguration(project,
-						getBuildConfiguration() == null ? getDefaultMatchingToolChain()
-								: getBuildConfiguration().getToolChain(),
-						IDFCorePlugin.getService(ILaunchBarManager.class).getActiveLaunchMode().getIdentifier(), null);
+		buildConfig = provider.createBuildConfiguration(project,
+				getBuildConfiguration() == null ? getDefaultMatchingToolChain()
+						: getBuildConfiguration().getToolChain(),
+				IDFCorePlugin.getService(ILaunchBarManager.class).getActiveLaunchMode().getIdentifier(), null);
 		return buildConfig;
 	}
 
@@ -217,17 +233,22 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 
 		return toolchainsCollection.stream().findFirst().orElseThrow();
 	}
-	private void updateGeneratorButtons(String generator) {
-		if (generator == null || generator.equals(NINJA))
+
+	private void updateGeneratorButtons(String generator)
+	{
+		if (generator == null || generator.equals(NINJA) || generator.isBlank())
 		{
 			ninjaGenButton.setSelection(true);
-		} else {
+		}
+		else
+		{
 			unixGenButton.setSelection(true);
 		}
 	}
 
 	@Override
-	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+	public void performApply(ILaunchConfigurationWorkingCopy configuration)
+	{
 		super.performApply(configuration);
 
 		ICBuildConfiguration buildConfig = null;
@@ -247,32 +268,41 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 				ninjaGenButton.getSelection() ? NINJA : UNIX_MAKEFILES);
 
 		String cmakeArgs = cmakeArgsText.getText().trim();
-		if (!cmakeArgs.isEmpty()) {
+		if (!cmakeArgs.isEmpty())
+		{
 			buildConfig.setProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS, cmakeArgs);
-		} else {
+		}
+		else
+		{
 			buildConfig.removeProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
 		}
 
 		String buildCommand = buildCommandText.getText().trim();
-		if (!buildCommand.isEmpty()) {
+		if (!buildCommand.isEmpty())
+		{
 			buildConfig.setProperty(CMakeBuildConfiguration.BUILD_COMMAND, buildCommand);
-		} else {
+		}
+		else
+		{
 			buildConfig.removeProperty(CMakeBuildConfiguration.BUILD_COMMAND);
 		}
 
 		String cleanCommand = cleanCommandText.getText().trim();
-		if (!cleanCommand.isEmpty()) {
+		if (!cleanCommand.isEmpty())
+		{
 			buildConfig.setProperty(CMakeBuildConfiguration.CLEAN_COMMAND, cleanCommand);
-		} else {
+		}
+		else
+		{
 			buildConfig.removeProperty(CMakeBuildConfiguration.CLEAN_COMMAND);
 		}
 	}
 
 	@Override
-	protected void saveProperties(Map<String, String> properties) {
+	protected void saveProperties(Map<String, String> properties)
+	{
 		super.saveProperties(properties);
-		properties.put(CMakeBuildConfiguration.CMAKE_GENERATOR,
-				ninjaGenButton.getSelection() ? NINJA : UNIX_MAKEFILES);
+		properties.put(CMakeBuildConfiguration.CMAKE_GENERATOR, ninjaGenButton.getSelection() ? NINJA : UNIX_MAKEFILES);
 
 		properties.put(CMakeBuildConfiguration.CMAKE_ARGUMENTS, cmakeArgsText.getText().trim());
 		properties.put(CMakeBuildConfiguration.BUILD_COMMAND, buildCommandText.getText().trim());
@@ -280,41 +310,53 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 	}
 
 	@Override
-	protected void restoreProperties(Map<String, String> properties) {
+	protected void restoreProperties(Map<String, String> properties)
+	{
 		super.restoreProperties(properties);
 
 		String gen = properties.get(CMakeBuildConfiguration.CMAKE_GENERATOR);
-		if (gen != null) {
-			switch (gen) {
-			case NINJA:
-				ninjaGenButton.setSelection(true);
-				unixGenButton.setSelection(false);
-				break;
+		if (gen != null)
+		{
+			switch (gen)
+			{
 			case UNIX_MAKEFILES:
 				ninjaGenButton.setSelection(false);
 				unixGenButton.setSelection(true);
+				break;
+			default:
+				ninjaGenButton.setSelection(true);
+				unixGenButton.setSelection(false);
 				break;
 			}
 		}
 
 		String cmakeArgs = properties.get(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
-		if (cmakeArgs != null) {
+		if (cmakeArgs != null)
+		{
 			cmakeArgsText.setText(cmakeArgs);
-		} else {
+		}
+		else
+		{
 			cmakeArgsText.setText(StringUtil.EMPTY);
 		}
 
 		String buildCmd = properties.get(CMakeBuildConfiguration.BUILD_COMMAND);
-		if (buildCmd != null) {
+		if (buildCmd != null)
+		{
 			buildCommandText.setText(buildCmd);
-		} else {
+		}
+		else
+		{
 			buildCommandText.setText(StringUtil.EMPTY);
 		}
 
 		String cleanCmd = properties.get(CMakeBuildConfiguration.CLEAN_COMMAND);
-		if (cleanCmd != null) {
+		if (cleanCmd != null)
+		{
 			cleanCommandText.setText(cleanCmd);
-		} else {
+		}
+		else
+		{
 			cleanCommandText.setText(StringUtil.EMPTY);
 		}
 	}
@@ -335,7 +377,8 @@ public class CMakeBuildTab2 extends CommonBuildTab {
 	}
 
 	@Override
-	public String getName() {
+	public String getName()
+	{
 		return "CMake"; //$NON-NLS-1$
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -51,7 +51,7 @@ import com.espressif.idf.core.util.StringUtil;
 public class CMakeBuildTab2 extends CommonBuildTab
 {
 
-	private static final String UNIX_MAKEFILES = "Unix Makefiles";
+	private static final String UNIX_MAKEFILES = "Unix Makefiles"; //$NON-NLS-1$
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	private Button unixGenButton;
 	private Button ninjaGenButton;
@@ -136,20 +136,17 @@ public class CMakeBuildTab2 extends CommonBuildTab
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
 	{
-		ICBuildConfiguration buildConfig = null;
 		try
 		{
 			IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
 			RecheckConfigsHelper.revalidateToolchain(project);
-			buildConfig = getBuildConfiguration(configuration, project);
-
 		}
 		catch (CoreException e)
 		{
 			Logger.log(e);
 		}
 
-		buildConfig.setProperty(CMakeBuildConfiguration.CMAKE_GENERATOR, NINJA);
+		configuration.setAttribute(CMakeBuildConfiguration.CMAKE_GENERATOR, NINJA);
 	}
 
 	@Override
@@ -157,12 +154,29 @@ public class CMakeBuildTab2 extends CommonBuildTab
 	{
 
 		super.initializeFrom(configuration);
-		ICBuildConfiguration buildConfig = null;
 		try
 		{
 			IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
 			RecheckConfigsHelper.revalidateToolchain(project);
-			buildConfig = getBuildConfiguration(configuration, project);
+
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		try
+		{
+			String generator = configuration.getAttribute(CMakeBuildConfiguration.CMAKE_GENERATOR, StringUtil.EMPTY);
+			updateGeneratorButtons(generator);
+
+			String cmakeArgs = configuration.getAttribute(CMakeBuildConfiguration.CMAKE_ARGUMENTS, StringUtil.EMPTY);
+			cmakeArgsText.setText(cmakeArgs);
+
+			String buildCommand = configuration.getAttribute(CMakeBuildConfiguration.BUILD_COMMAND, StringUtil.EMPTY);
+			buildCommandText.setText(buildCommand);
+
+			String cleanCommand = configuration.getAttribute(CMakeBuildConfiguration.CLEAN_COMMAND, StringUtil.EMPTY);
+			cleanCommandText.setText(cleanCommand);
 
 		}
 		catch (CoreException e)
@@ -170,38 +184,7 @@ public class CMakeBuildTab2 extends CommonBuildTab
 			Logger.log(e);
 		}
 
-		String generator = buildConfig.getProperty(CMakeBuildConfiguration.CMAKE_GENERATOR);
-		updateGeneratorButtons(generator);
 
-		String cmakeArgs = buildConfig.getProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
-		if (cmakeArgs != null)
-		{
-			cmakeArgsText.setText(cmakeArgs);
-		}
-		else
-		{
-			cmakeArgsText.setText(StringUtil.EMPTY);
-		}
-
-		String buildCommand = buildConfig.getProperty(CMakeBuildConfiguration.BUILD_COMMAND);
-		if (buildCommand != null)
-		{
-			buildCommandText.setText(buildCommand);
-		}
-		else
-		{
-			buildCommandText.setText(StringUtil.EMPTY);
-		}
-
-		String cleanCommand = buildConfig.getProperty(CMakeBuildConfiguration.CLEAN_COMMAND);
-		if (cleanCommand != null)
-		{
-			cleanCommandText.setText(buildCommand != null ? buildCommand : StringUtil.EMPTY);
-		}
-		else
-		{
-			cleanCommandText.setText(StringUtil.EMPTY);
-		}
 	}
 
 	private ICBuildConfiguration getBuildConfiguration(ILaunchConfiguration configuration, IProject project)
@@ -251,50 +234,47 @@ public class CMakeBuildTab2 extends CommonBuildTab
 	{
 		super.performApply(configuration);
 
-		ICBuildConfiguration buildConfig = null;
 		try
 		{
 			IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
 			RecheckConfigsHelper.revalidateToolchain(project);
-			buildConfig = getBuildConfiguration(configuration, project);
-
 		}
 		catch (CoreException e)
 		{
 			Logger.log(e);
 		}
 
-		buildConfig.setProperty(CMakeBuildConfiguration.CMAKE_GENERATOR,
+		configuration.setAttribute(CMakeBuildConfiguration.CMAKE_GENERATOR,
 				ninjaGenButton.getSelection() ? NINJA : UNIX_MAKEFILES);
 
 		String cmakeArgs = cmakeArgsText.getText().trim();
 		if (!cmakeArgs.isEmpty())
 		{
-			buildConfig.setProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS, cmakeArgs);
+			configuration.setAttribute(CMakeBuildConfiguration.CMAKE_ARGUMENTS, cmakeArgs);
 		}
 		else
 		{
-			buildConfig.removeProperty(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
+			configuration.removeAttribute(CMakeBuildConfiguration.CMAKE_ARGUMENTS);
 		}
 
 		String buildCommand = buildCommandText.getText().trim();
 		if (!buildCommand.isEmpty())
 		{
-			buildConfig.setProperty(CMakeBuildConfiguration.BUILD_COMMAND, buildCommand);
+			configuration.setAttribute(CMakeBuildConfiguration.BUILD_COMMAND, buildCommand);
 		}
 		else
 		{
-			buildConfig.removeProperty(CMakeBuildConfiguration.BUILD_COMMAND);
+			configuration.removeAttribute(CMakeBuildConfiguration.BUILD_COMMAND);
 		}
 
 		String cleanCommand = cleanCommandText.getText().trim();
 		if (!cleanCommand.isEmpty())
 		{
-			buildConfig.setProperty(CMakeBuildConfiguration.CLEAN_COMMAND, cleanCommand);
+			configuration.setAttribute(CMakeBuildConfiguration.CLEAN_COMMAND, cleanCommand);
 		}
 		else
 		{
-			buildConfig.removeProperty(CMakeBuildConfiguration.CLEAN_COMMAND);
+			configuration.removeAttribute(CMakeBuildConfiguration.CLEAN_COMMAND);
 		}
 	}
 


### PR DESCRIPTION
## Description

Launch configuration was not able to restore the custom build folder after closing and reopening the project. As figured out the Instance Scope preference are cleaned up after the closing of the project, so as a solution I decided to move to store preferences in the launch configuration. It also makes code cleaner and allows us to export the launch configuration with all preferences which are set up there.

Also, as part of PR was some related refactoring of the IDFBuildConfiguration class. The goal of the refactoring was to reduce the complexity of the code. After the refactoring, the build command always picks up the last selected build folder (Previously, it required the restart of the eclipse or editing the cmake file)

Was found and fixed the typo: we were using buildCommand instead of cleanCommand for the cleanCommandTxt.

One last thing, during testing, I found and fixed the root of the issue with the launch configuration, due to which, sometimes the launch configuration could not pick up the selected project and the selected project was always the default after reopening the launch configuration.


Fixes # ([IEP-886](https://jira.espressif.com:8443/browse/IEP-886))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1:
- add a custom build folder, close-reopen the project -> make sure that the custom build folder hasn't changed 
Test 2:
- make sure that the refactoring didn't break the current functionality related to the build, indexer, and other related components. We need to do as many tests as possible by comparing behavior on the master and on this branch 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build command
- Launch configuration (Build Tab, Main tab)
- custom build folder

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
