### PR TITLE
Fix for 'Animation Start' has encountered a problem 

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -18,7 +18,7 @@
       </programArgs>
       <vmArgsLin>-Xms256m -Xmx2048m  -Dosgi.requiredJavaVersion=11 -Dosgi.instance.area.default=@user.home/espressif-workspace
       </vmArgsLin>
-      <vmArgsMac>-Xms256m -Xmx2048m  -Xdock:icon=../com.espressif.idf.product/laucher/espressif.icns -XstartOnFirstThread -Dosgi.requiredJavaVersion=11 -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.instance.area.default=@user.home/espressif-workspace
+      <vmArgsMac>-Xms256m -Xmx2048m  -Xdock:icon=../Resources/espressif.icns -XstartOnFirstThread -Dosgi.requiredJavaVersion=11 -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.instance.area.default=@user.home/espressif-workspace
       </vmArgsMac>
       <vmArgsWin>-Xms256m -Xmx2048m   -Dosgi.requiredJavaVersion=11 -Dosgi.instance.area.default=@user.home/espressif-workspace
       </vmArgsWin>


### PR DESCRIPTION
## Description

Fix espressif.icns path issue in macOS

Fixes # ([IEP-894](https://jira.espressif.com:8443/browse/IEP-894))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
In macOS, after launching the workbench we shouldn't see `'Animation Start' has encountered a problem` popup

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- Espressif IDE workbench startup

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
