### PR TITLE
IEP-893: Add plugin nightly update site to the product repo

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -92,7 +92,7 @@
       <repository location="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/" enabled="false" />
       <repository location="http://download.eclipse.org/releases/latest/" enabled="false" />
       <repository location="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/" enabled="true" />
-      <repository location="http://https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/" enabled="false" />
+      <repository location="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/" enabled="false" />
    </repositories>
 
    <preferencesInfo>

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -92,6 +92,7 @@
       <repository location="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/" enabled="false" />
       <repository location="http://download.eclipse.org/releases/latest/" enabled="false" />
       <repository location="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/" enabled="true" />
+      <repository location="http://https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/" enabled="false" />
    </repositories>
 
    <preferencesInfo>


### PR DESCRIPTION
## Description

Add plugin nightly update site to the product repo

Fixes # ([IEP-893](https://jira.espressif.com:8443/browse/IEP-893))

## Type of change
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Go to Help > Install New Software 
- Click on the Manage button
- Check the nightly update site from the list 
- Now nightly update site will appear in the work-with drop-down list
- Choose nightly from the list and you will be able to install IEP nightly build
- Once it's enabled, you should be able to get nightly builds directly using `Help >Check for updates ` also

<img width="995" alt="Screenshot 2023-03-09 at 6 16 24 PM" src="https://user-images.githubusercontent.com/8463287/224027216-db49adf1-a61d-42b6-9012-0528bc1461d2.png">


**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

-Update site

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
