### PR TITLE
IEP-896: Fix 'org.eclipse.ui.commands' parsing issues

### DIFF
--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -504,17 +504,14 @@
     <extension
          point="org.eclipse.ui.commands">
       <command
-            categoryId="com.espressif.commands.category"
             id="com.espressif.commands.cleanCommand"
             name="%command.name.5">
       </command>
       <command
-            categoryId="com.espressif.commands.category"
             id="com.espressif.commands.fullcleanCommand"
             name="%command.name.11">
       </command>
       <command
-            categoryId="com.espressif.commands.category"
             id="com.espressif.commands.pythoncleanCommand"
             name="%command.name.12">
       </command>
@@ -523,12 +520,10 @@
             name="%command.name.delete">
       </command>
       <command
-            categoryId="com.espressif.commands.category"
             id="com.espressif.idf.ui.partitionTableEditorCommand"
             name="%command.name.PartitionTableEditor">
       </command>
       <command
-            categoryId="com.espressif.commands.category"
             id="com.espressif.idf.ui.nvsEditorCommand"
             name="%command.name.nvsTableEditor">
       </command>


### PR DESCRIPTION
## Description

Fix 'org.eclipse.ui.commands' parsing issues

```
!ENTRY org.eclipse.ui 2 0 2023-02-28 19:28:57.542
!MESSAGE Warnings while parsing the commands from the 'org.eclipse.ui.commands' and 'org.eclipse.ui.actionDefinitions' extension points.
!SUBENTRY 1 org.eclipse.ui 2 0 2023-02-28 19:28:57.542
!MESSAGE Commands should really have a category: plug-in='com.espressif.idf.ui', id='com.espressif.commands.cleanCommand', categoryId='com.espressif.commands.category'


```

Fixes # ([IEP-896](https://jira.espressif.com:8443/browse/IEP-896))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Launch Espressif-IDE
- Go to Error log
- Look for  'org.eclipse.ui.commands' parsing issues mentioned in ([IEP-896](https://jira.espressif.com:8443/browse/IEP-896)) and there shouldn't be anything on this.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- ESP-IDF project menu list

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
