### PR TITLE
IEP-900 EBV feedback - automatically configure available ports for debugging

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
@@ -43,6 +43,7 @@ public class Messages extends NLS {
 	public static String NvsValidation_KeyValidationErr_1;
 	public static String NvsValidation_KeyValidationErr_2;
 	
+	public static String PortChecker_AttemptLimitExceededMsg;
 	public static String PortChecker_PortIsAvailable;
 	public static String PortChecker_PortNotAvailable;
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
@@ -43,6 +43,9 @@ public class Messages extends NLS {
 	public static String NvsValidation_KeyValidationErr_1;
 	public static String NvsValidation_KeyValidationErr_2;
 	
+	public static String PortChecker_PortIsAvailable;
+	public static String PortChecker_PortNotAvailable;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/PortChecker.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/PortChecker.java
@@ -16,6 +16,8 @@ import com.espressif.idf.core.logging.Logger;
  */
 public class PortChecker
 {
+	private static final int MAX_ATTEMPS = 20;
+
 	private PortChecker()
 	{
 	}
@@ -38,11 +40,20 @@ public class PortChecker
 	 */
 	public static int getAvailablePort(int port)
 	{
-		while (!isPortAvailable(port))
+		int attemptsCount = 0;
+		while (!isPortAvailable(port) && attemptsCount < MAX_ATTEMPS)
 		{
 			Logger.log(String.format(Messages.PortChecker_PortNotAvailable, port, port + 1));
 			port += 1;
+			attemptsCount += 1;
 		}
+
+		if (attemptsCount >= MAX_ATTEMPS)
+		{
+			Logger.log(Messages.PortChecker_AttemptLimitExceededMsg);
+			return port;
+		}
+
 		Logger.log(String.format(Messages.PortChecker_PortIsAvailable, port));
 		return port;
 	}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/PortChecker.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/PortChecker.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import java.net.Socket;
+
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * A helper class for checking the availability of ports for a socket connection.
+ * 
+ * @author Denys Almazov
+ *
+ */
+public class PortChecker
+{
+	private PortChecker()
+	{
+	}
+
+	public static boolean isPortAvailable(int port)
+	{
+		try (Socket ignored = new Socket("localhost", port)) //$NON-NLS-1$
+		{
+			return false;
+		}
+		catch (Exception e)
+		{
+			return true;
+		}
+	}
+
+	/**
+	 * checks the port for availability for the socket connection. If the port is not available, we get the next
+	 * available port
+	 */
+	public static int getAvailablePort(int port)
+	{
+		while (!isPortAvailable(port))
+		{
+			Logger.log(String.format(Messages.PortChecker_PortNotAvailable, port, port + 1));
+			port += 1;
+		}
+		Logger.log(String.format(Messages.PortChecker_PortIsAvailable, port));
+		return port;
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
@@ -28,3 +28,5 @@ NvsValidation_NumberValueValidationErr_2=%s is out of range for %s
 NvsValidation_EncodingValidationErr_1=Unsupported coding for type %s, expected on of %s. Instead got %s
 NvsValidation_KeyValidationErr_1=Key is required
 NvsValidation_KeyValidationErr_2=Maximum key length is 15 characters
+PortChecker_PortIsAvailable=Port %d is available
+PortChecker_PortNotAvailable=Port %d is not available, trying next port: %d

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
@@ -28,5 +28,6 @@ NvsValidation_NumberValueValidationErr_2=%s is out of range for %s
 NvsValidation_EncodingValidationErr_1=Unsupported coding for type %s, expected on of %s. Instead got %s
 NvsValidation_KeyValidationErr_1=Key is required
 NvsValidation_KeyValidationErr_2=Maximum key length is 15 characters
+PortChecker_AttemptLimitExceededMsg=The port selection attempt limit was exceeded. Returning last checked port
 PortChecker_PortIsAvailable=Port %d is available
 PortChecker_PortNotAvailable=Port %d is not available, trying next port: %d

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -29,6 +29,7 @@ import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.embedcdt.debug.gdbjtag.core.DebugUtils;
 
+import com.espressif.idf.core.util.PortChecker;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.launch.serial.util.ESPFlashUtil;
 
@@ -91,19 +92,26 @@ public class Configuration
 
 			lst.add(executable);
 
-			lst.add("-c");
-			lst.add("gdb_port "
-					+ Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
-							DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT)));
+			int port = PortChecker
+					.getAvailablePort(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
+							DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT));
 
-			lst.add("-c");
-			lst.add("telnet_port "
-					+ Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
-							DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT)));
+			lst.add("-c"); //$NON-NLS-1$
+			lst.add("gdb_port " + port); //$NON-NLS-1$
 
-			lst.add("-c");
-			lst.add("tcl_port " + configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
-					DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT));
+			port = PortChecker
+					.getAvailablePort(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
+							DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT));
+
+			lst.add("-c"); //$NON-NLS-1$
+			lst.add("telnet_port " + port); //$NON-NLS-1$
+
+			port = PortChecker.getAvailablePort(
+					Integer.parseInt(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+							DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT)));
+
+			lst.add("-c"); //$NON-NLS-1$
+			lst.add("tcl_port " + port); //$NON-NLS-1$
 
 			String other = configuration
 					.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -25,24 +25,27 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.ILaunchConfiguration;
-
-import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
-import com.espressif.idf.launch.serial.util.ESPFlashUtil;
-
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.embedcdt.debug.gdbjtag.core.DebugUtils;
 
+import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
+import com.espressif.idf.launch.serial.util.ESPFlashUtil;
+
 @SuppressWarnings("restriction")
-public class Configuration {
+public class Configuration
+{
 
 	// ------------------------------------------------------------------------
 
-	public static String getGdbServerCommand(ILaunchConfiguration configuration, String executable) {
+	public static String getGdbServerCommand(ILaunchConfiguration configuration, String executable)
+	{
 
-		try {
+		try
+		{
 
-			if (executable == null) {
+			if (executable == null)
+			{
 				if (!configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_SERVER,
 						DefaultPreferences.DO_START_GDB_SERVER_DEFAULT))
 					return null;
@@ -54,7 +57,9 @@ public class Configuration {
 
 			executable = resolveAll(executable, configuration);
 
-		} catch (CoreException e) {
+		}
+		catch (CoreException e)
+		{
 			Activator.log(e);
 			return null;
 		}
@@ -62,17 +67,20 @@ public class Configuration {
 		return executable;
 	}
 
-	public static String getGdbServerCommandLine(ILaunchConfiguration configuration) {
+	public static String getGdbServerCommandLine(ILaunchConfiguration configuration)
+	{
 
 		String cmdLineArray[] = getGdbServerCommandLineArray(configuration);
 		return StringUtils.join(cmdLineArray, " ");
 	}
 
-	public static String[] getGdbServerCommandLineArray(ILaunchConfiguration configuration) {
+	public static String[] getGdbServerCommandLineArray(ILaunchConfiguration configuration)
+	{
 
-		List<String> lst = new ArrayList<String>();
+		List<String> lst = new ArrayList<>();
 
-		try {
+		try
+		{
 			if (!configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_SERVER,
 					DefaultPreferences.DO_START_GDB_SERVER_DEFAULT))
 				return null;
@@ -102,7 +110,8 @@ public class Configuration {
 					.trim();
 			other = resolveAll(other, configuration);
 
-			if (other != null && !other.isEmpty()) {
+			if (other != null && !other.isEmpty())
+			{
 				lst.addAll(StringUtils.splitCommandLineOptions(other));
 			}
 
@@ -110,12 +119,15 @@ public class Configuration {
 			{
 				lst.add(ESPFlashUtil.getEspJtagFlashCommand(configuration));
 			}
-			
-			if (isVerboseOutputEnabled(configuration)) {
+
+			if (isVerboseOutputEnabled(configuration))
+			{
 				lst.add("-d3"); //$NON-NLS-1$
 			}
 
-		} catch (CoreException e) {
+		}
+		catch (CoreException e)
+		{
 			Activator.log(e);
 			return null;
 		}
@@ -128,17 +140,20 @@ public class Configuration {
 		return lst.toArray(new String[0]);
 	}
 
-	private static boolean isVerboseOutputEnabled(ILaunchConfiguration configuration) throws CoreException {
+	private static boolean isVerboseOutputEnabled(ILaunchConfiguration configuration) throws CoreException
+	{
 		return configuration.getAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, false);
 	}
 
-	public static String getGdbServerCommandName(ILaunchConfiguration config) {
+	public static String getGdbServerCommandName(ILaunchConfiguration config)
+	{
 
 		String fullCommand = getGdbServerCommand(config, null);
 		return StringUtils.extractNameFromPath(fullCommand);
 	}
 
-	public static String getGdbServerOtherConfig(ILaunchConfiguration config) throws CoreException {
+	public static String getGdbServerOtherConfig(ILaunchConfiguration config) throws CoreException
+	{
 
 		return config
 				.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
@@ -147,11 +162,14 @@ public class Configuration {
 
 	// ------------------------------------------------------------------------
 
-	public static String getGdbClientCommand(ILaunchConfiguration configuration, String executable) {
+	public static String getGdbClientCommand(ILaunchConfiguration configuration, String executable)
+	{
 
-		try {
+		try
+		{
 
-			if (executable == null) {
+			if (executable == null)
+			{
 				String defaultGdbCommand = Platform.getPreferencesService().getString(GdbPlugin.PLUGIN_ID,
 						IGdbDebugPreferenceConstants.PREF_DEFAULT_GDB_COMMAND,
 						IGDBLaunchConfigurationConstants.DEBUGGER_DEBUG_NAME_DEFAULT, null);
@@ -162,7 +180,9 @@ public class Configuration {
 
 			executable = resolveAll(executable, configuration);
 
-		} catch (CoreException e) {
+		}
+		catch (CoreException e)
+		{
 			Activator.log(e);
 			return null;
 		}
@@ -174,7 +194,9 @@ public class Configuration {
 	{
 		return configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, false);
 	}
-	public static String[] getGdbClientCommandLineArray(ILaunchConfiguration configuration) {
+
+	public static String[] getGdbClientCommandLineArray(ILaunchConfiguration configuration)
+	{
 
 		List<String> lst = new ArrayList<String>();
 
@@ -193,70 +215,84 @@ public class Configuration {
 		lst.add("--nx");
 
 		String other;
-		try {
+		try
+		{
 			other = configuration.getAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
 					DefaultPreferences.GDB_CLIENT_OTHER_OPTIONS_DEFAULT).trim();
 
 			other = DebugUtils.resolveAll(other, configuration.getAttributes());
 
-			if (!other.isEmpty()) {
+			if (!other.isEmpty())
+			{
 				lst.addAll(StringUtils.splitCommandLineOptions(other));
 			}
-		} catch (CoreException e) {
+		}
+		catch (CoreException e)
+		{
 			Activator.log(e);
 		}
 
 		return lst.toArray(new String[0]);
 	}
 
-	public static String getGdbClientCommandLine(ILaunchConfiguration configuration) {
+	public static String getGdbClientCommandLine(ILaunchConfiguration configuration)
+	{
 
 		String cmdLineArray[] = getGdbClientCommandLineArray(configuration);
 		return StringUtils.join(cmdLineArray, " ");
 	}
 
-	public static String getGdbClientCommandName(ILaunchConfiguration config) {
+	public static String getGdbClientCommandName(ILaunchConfiguration config)
+	{
 
 		String fullCommand = getGdbClientCommand(config, null);
 		return StringUtils.extractNameFromPath(fullCommand);
 	}
 
-	public static String resolveAll(String str, ILaunchConfiguration configuration) throws CoreException {
+	public static String resolveAll(String str, ILaunchConfiguration configuration) throws CoreException
+	{
 		String value = str;
 		value = value.trim();
 		if (value.length() == 0)
 			return null;
 
-		if (value.indexOf("${") >= 0) {
+		if (value.indexOf("${") >= 0)
+		{
 			IProject project = EclipseUtils.getProjectByLaunchConfiguration(configuration);
-			if (project != null) {
+			if (project != null)
+			{
 				value = DynamicVariableResolver.resolveAll(value, project);
 			}
 		}
 
-		if (value.indexOf("${") >= 0) {
+		if (value.indexOf("${") >= 0)
+		{
 			// If more macros to process.
 			value = DebugUtils.resolveAll(value, configuration.getAttributes());
 
 			ICConfigurationDescription buildConfig = EclipseUtils.getBuildConfigDescription(configuration);
-			if (buildConfig != null) {
+			if (buildConfig != null)
+			{
 				value = DebugUtils.resolveAll(value, buildConfig);
 			}
 		}
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.resolveAll(\"" + str + "\") = \"" + value + "\"");
 		}
 		return value;
 	}
 	// ------------------------------------------------------------------------
 
-	public static boolean getDoStartGdbServer(ILaunchConfiguration config) throws CoreException {
+	public static boolean getDoStartGdbServer(ILaunchConfiguration config) throws CoreException
+	{
 
 		return config.getAttribute(ConfigurationAttributes.DO_START_GDB_SERVER,
 				DefaultPreferences.DO_START_GDB_SERVER_DEFAULT);
 	}
 
-	public static boolean getDoAddServerConsole(ILaunchConfiguration config) throws CoreException {
+	public static boolean getDoAddServerConsole(ILaunchConfiguration config) throws CoreException
+	{
 
 		return getDoStartGdbServer(config)
 				&& config.getAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_CONSOLE,
@@ -265,7 +301,8 @@ public class Configuration {
 
 	// ------------------------------------------------------------------------
 
-	public static boolean getDoStartGdbClient(ILaunchConfiguration config) throws CoreException {
+	public static boolean getDoStartGdbClient(ILaunchConfiguration config) throws CoreException
+	{
 
 		return config.getAttribute(ConfigurationAttributes.DO_START_GDB_CLIENT,
 				DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
@@ -39,6 +39,7 @@ import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.core.model.ISourceLocator;
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.GnuMcuLaunch;
 
+import com.espressif.idf.core.util.PortChecker;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
@@ -143,6 +144,11 @@ public class Launch extends GnuMcuLaunch
 			config.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
 					fDefaultPreferences.getGdbClientExecutable());
 		}
+
+		PortChecker.getAvailablePort(null);
+		int availableRemotePort = PortChecker.getAvailablePort(config.getAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
+				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT));
+		config.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, availableRemotePort);
 	}
 
 	// ------------------------------------------------------------------------

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
@@ -145,7 +145,6 @@ public class Launch extends GnuMcuLaunch
 					fDefaultPreferences.getGdbClientExecutable());
 		}
 
-		PortChecker.getAvailablePort(null);
 		int availableRemotePort = PortChecker.getAvailablePort(config.getAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
 				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT));
 		config.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, availableRemotePort);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
@@ -45,7 +45,8 @@ import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 
 @SuppressWarnings("restriction")
-public class Launch extends GnuMcuLaunch {
+public class Launch extends GnuMcuLaunch
+{
 
 	// ------------------------------------------------------------------------
 
@@ -56,11 +57,13 @@ public class Launch extends GnuMcuLaunch {
 
 	// ------------------------------------------------------------------------
 
-	public Launch(ILaunchConfiguration launchConfiguration, String mode, ISourceLocator locator) {
+	public Launch(ILaunchConfiguration launchConfiguration, String mode, ISourceLocator locator)
+	{
 
 		super(launchConfiguration, mode, locator);
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.Launch.launch(" + launchConfiguration.getName() + "," + mode + ") " + this);
 		}
 
@@ -72,17 +75,21 @@ public class Launch extends GnuMcuLaunch {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void initialize() {
+	public void initialize()
+	{
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.Launch.initialize() " + this);
 		}
 
 		super.initialize();
 
-		Runnable initRunnable = new DsfRunnable() {
+		Runnable initRunnable = new DsfRunnable()
+		{
 			@Override
-			public void run() {
+			public void run()
+			{
 				fTracker = new DsfServicesTracker(GdbPlugin.getBundleContext(), fSession.getId());
 				// fSession.addServiceEventListener(GdbLaunch.this, null);
 
@@ -92,36 +99,46 @@ public class Launch extends GnuMcuLaunch {
 		};
 
 		// Invoke the execution code and block waiting for the result.
-		try {
+		try
+		{
 			fExecutor.submit(initRunnable).get();
-		} catch (InterruptedException e) {
+		}
+		catch (InterruptedException e)
+		{
 			new Status(IStatus.ERROR, Activator.PLUGIN_ID, IDsfStatusConstants.INTERNAL_ERROR,
 					"Error initializing launch", e); //$NON-NLS-1$
-		} catch (ExecutionException e) {
+		}
+		catch (ExecutionException e)
+		{
 			new Status(IStatus.ERROR, Activator.PLUGIN_ID, IDsfStatusConstants.INTERNAL_ERROR,
 					"Error initializing launch", e); //$NON-NLS-1$
 		}
 	}
 
 	@Override
-	protected void provideDefaults(ILaunchConfigurationWorkingCopy config) throws CoreException {
+	protected void provideDefaults(ILaunchConfigurationWorkingCopy config) throws CoreException
+	{
 
 		super.provideDefaults(config);
 
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS)) {
-			config.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
+		if (!config.hasAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS))
+		{
+			config.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost"); //$NON-NLS-1$
 		}
 
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID)) {
+		if (!config.hasAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID))
+		{
 			config.setAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID, ConfigurationAttributes.JTAG_DEVICE);
 		}
 
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER)) {
+		if (!config.hasAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER))
+		{
 			config.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
 					DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
 		}
 
-		if (!config.hasAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME)) {
+		if (!config.hasAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME))
+		{
 			DefaultPreferences fDefaultPreferences = Activator.getInstance().getDefaultPreferences();
 			config.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
 					fDefaultPreferences.getGdbClientExecutable());
@@ -130,16 +147,19 @@ public class Launch extends GnuMcuLaunch {
 
 	// ------------------------------------------------------------------------
 
-	public void initializeServerConsole(IProgressMonitor monitor) throws CoreException {
+	public void initializeServerConsole(IProgressMonitor monitor) throws CoreException
+	{
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.Launch.initializeServerConsole()");
 		}
 
 		IProcess newProcess;
 		boolean doAddServerConsole = Configuration.getDoAddServerConsole(fConfig);
 
-		if (doAddServerConsole) {
+		if (doAddServerConsole)
+		{
 
 			// Add the GDB server process to the launch tree
 			newProcess = addServerProcess(Configuration.getGdbServerCommandName(fConfig));
@@ -149,9 +169,11 @@ public class Launch extends GnuMcuLaunch {
 		}
 	}
 
-	public void initializeConsoles(IProgressMonitor monitor) throws CoreException {
+	public void initializeConsoles(IProgressMonitor monitor) throws CoreException
+	{
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.Launch.initializeConsoles()");
 		}
 
@@ -165,15 +187,20 @@ public class Launch extends GnuMcuLaunch {
 		}
 	}
 
-	public IProcess addServerProcess(String label) throws CoreException {
+	public IProcess addServerProcess(String label) throws CoreException
+	{
 		IProcess newProcess = null;
-		try {
+		try
+		{
 			// Add the server process object to the launch.
-			Process serverProc = getDsfExecutor().submit(new Callable<Process>() {
+			Process serverProc = getDsfExecutor().submit(new Callable<Process>()
+			{
 				@Override
-				public Process call() throws CoreException {
-					GdbServerBackend backend = (GdbServerBackend) fTracker.getService(GdbServerBackend.class);
-					if (backend != null) {
+				public Process call() throws CoreException
+				{
+					GdbServerBackend backend = fTracker.getService(GdbServerBackend.class);
+					if (backend != null)
+					{
 						return backend.getServerProcess();
 					}
 					return null;
@@ -185,15 +212,22 @@ public class Launch extends GnuMcuLaunch {
 			// First set attribute to specify we want to create the gdb process.
 			// Bug 210366
 			Map<String, String> attributes = new HashMap<String, String>();
-			if (serverProc != null) {
+			if (serverProc != null)
+			{
 				newProcess = DebugPlugin.newProcess(this, serverProc, label, attributes);
 			}
-		} catch (InterruptedException e) {
+		}
+		catch (InterruptedException e)
+		{
 			throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0,
 					"Interrupted while waiting for get process callable.", e)); //$NON-NLS-1$
-		} catch (ExecutionException e) {
+		}
+		catch (ExecutionException e)
+		{
 			throw (CoreException) e.getCause();
-		} catch (RejectedExecutionException e) {
+		}
+		catch (RejectedExecutionException e)
+		{
 			throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0,
 					"Debugger shut down before launch was completed.", e)); //$NON-NLS-1$
 		}


### PR DESCRIPTION
## Description

Checking the availability of ports for debugging. If it's not, we get the next available ports.
Fixes # ([IEP-900](https://jira.espressif.com:8443/browse/IEP-900))

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Test 1:
To test it, I created a simple socket server that occupies the port:
```
public class Server {
    public static void main(String[] args) throws IOException {
        int port = 3333;
        ServerSocket serverSocket = new ServerSocket(port);
        System.out.println("Server is listening on port " + port);

        while (true) {
            Socket socket = serverSocket.accept();
            System.out.println("New client connected");
            socket.close();
            System.out.println("Client disconnected");
        }
    }
}

```

Then, try to debug with the default debug settings. In the openocd log, you will see that for gdb connection port 3334 is used instead of 3333, because port 3333 is occupied by a custom server. 

Repeat this test for other ports.
- Test 2: 
instead of starting a custom server, we can check which ports are already in use on our PC and then set that port in the debug configuration. Since the given port is in use, we should see a different port in the openocd log.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Debug

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
