### PR TITLE
IEP-898:Opening a serial monitor during debug session makes the idf_monitor to reset the board

### DIFF
--- a/bundles/com.espressif.idf.serial.monitor/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.serial.monitor/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  com.espressif.idf.ui,
  org.eclipse.ui.console;bundle-version="3.9.0",
  org.eclipse.ui,
- org.eclipse.embedcdt.ui
+ org.eclipse.embedcdt.ui,
+ org.eclipse.embedcdt.debug.gdbjtag.core
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.espressif.idf.serial.monitor
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -58,7 +60,7 @@ public class IDFMonitor
 			args.add("--print_filter"); //$NON-NLS-1$
 			args.add(filterOptions);
 		}
-		if (isDebuggerRunning(project))
+		if (isDebuggerRunning(project) && isNoResetFlagSupported())
 		{
 			args.add("--no-reset"); //$NON-NLS-1$
 		}
@@ -119,6 +121,14 @@ public class IDFMonitor
 			Logger.log(e);
 		}
 		return false;
+	}
+
+	private boolean isNoResetFlagSupported()
+	{
+		String version = IDFUtil.getEspIdfVersion();
+		Pattern p = Pattern.compile("([0-9][.][0-9])"); //$NON-NLS-1$
+		Matcher m = p.matcher(version);
+		return m.find() && Double.parseDouble(m.group(0)) >= 5.0;
 	}
 
 	protected ILaunchManager getLaunchManager()


### PR DESCRIPTION
## Description

Opening a serial monitor during debug session makes the idf_monitor reset the board. To avoid this problem, will pass the --no-reset flag to the idf_monitor if there is any active debug session running for the project.

Fixes # ([IEP-898](https://jira.espressif.com:8443/browse/IEP-898))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

To reproduce the problem:
- Launch OpenOCD debugging
- Launch esp-idf serial monitor
- Observe the debugging console, and you will find that the "Debug controller was reset" was due to idf_monitor was resetting the board.

```
Info : [esp32.cpu0] Debug controller was reset.
Info : [esp32.cpu0] Core was reset.
Info : [esp32.cpu0] Target halted, PC=0x40007BA1, debug_reason=00000000
Info : [esp32.cpu0] Reset cause (1) - (Power on reset)
Error: [esp32.cpu1] Unexpected OCD_ID = 00000000
Error: [esp32.cpu1] Unexpected OCD_ID = 00000000
Error: [esp32.cpu1] Unexpected OCD_ID = 00000000
Info : [esp32.cpu0] Debug controller was reset.
Info : [esp32.cpu0] Core was reset.
Info : [esp32.cpu0] Target halted, PC=0x40079BEC, debug_reason=00000000
Info : [esp32.cpu0] Reset cause (16) - (RTC WDT core and rtc reset)
Error: [esp32.cpu1] Unexpected OCD_ID = 00000000
Info : [esp32.cpu1] Debug controller was reset.
Info : [esp32.cpu1] Core was reset.
Info : [esp32.cpu1] Target halted, PC=0x400844DE, debug_reason=00000000
Info : [esp32.cpu1] Reset cause (14) - (CPU1 reset by CPU0)

```

Now verify the same behavior with the PR build, you don't find `reset` console messages.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- OpenOCD Debugging
- ESP-IDF Serial Monitor

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
