### PR TITLE
IEP-906 Changing the OpenOCD path does not modify the OpenOCD scripts path

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
@@ -14,6 +14,9 @@
 
 package com.espressif.idf.debug.gdbjtag.openocd.ui.preferences;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
@@ -23,22 +26,23 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
+import com.espressif.idf.core.IDFEnvironmentVariables;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.PersistentPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.Messages;
 
-
 /**
- * This class represents a preference page that is contributed to the
- * Preferences dialog. By subclassing <samp>FieldEditorPreferencePage</samp>, we
- * can use the field support built into JFace that allows us to create a page
+ * This class represents a preference page that is contributed to the Preferences dialog. By subclassing
+ * <samp>FieldEditorPreferencePage</samp>, we can use the field support built into JFace that allows us to create a page
  * that is small and knows how to save, restore and apply itself.
  * <p>
- * This page uses special filed editors, that get the default values from the
- * preferences store, but the values are from the variables store.
+ * This page uses special filed editors, that get the default values from the preferences store, but the values are from
+ * the variables store.
  */
-public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage
+{
 
 	// ------------------------------------------------------------------------
 
@@ -51,10 +55,12 @@ public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkben
 
 	// ------------------------------------------------------------------------
 
-	public GlobalMcuPage() {
+	public GlobalMcuPage()
+	{
 		super(GRID);
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.GlobalMcuPage()");
 		}
 
@@ -71,20 +77,22 @@ public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkben
 
 	// Contributed by IWorkbenchPreferencePage
 	@Override
-	public void init(IWorkbench workbench) {
+	public void init(IWorkbench workbench)
+	{
 
-		if (Activator.getInstance().isDebugging()) {
+		if (Activator.getInstance().isDebugging())
+		{
 			System.out.println("openocd.GlobalMcuPage.init()");
 		}
 	}
 
 	/**
-	 * Creates the field editors. Field editors are abstractions of the common GUI
-	 * blocks needed to manipulate various types of preferences. Each field editor
-	 * knows how to save and restore itself.
+	 * Creates the field editors. Field editors are abstractions of the common GUI blocks needed to manipulate various
+	 * types of preferences. Each field editor knows how to save and restore itself.
 	 */
 	@Override
-	protected void createFieldEditors() {
+	protected void createFieldEditors()
+	{
 
 		FieldEditor executable = new StringFieldEditor(PersistentPreferences.EXECUTABLE_NAME,
 				Messages.McuPage_executable_label, getFieldEditorParent());
@@ -97,6 +105,20 @@ public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkben
 		FieldEditor folder = new XpackDirectoryNotStrictFieldEditor(xpackNames, PersistentPreferences.INSTALL_FOLDER,
 				Messages.McuPage_executable_folder, getFieldEditorParent(), isStrict);
 		addField(folder);
+	}
+
+	@Override
+	public boolean performOk()
+	{
+		boolean result = super.performOk();
+		String openOcdPath = fPersistentPreferences.getInstallFolder(StringUtil.EMPTY);
+		Path path = Paths.get(openOcdPath);
+		if (!openOcdPath.isBlank())
+		{
+			path = path.getParent().resolve("share").resolve("openocd").resolve("scripts"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		}
+		new IDFEnvironmentVariables().addEnvVariable(IDFEnvironmentVariables.OPENOCD_SCRIPTS, path.toString());
+		return result;
 	}
 
 	// ------------------------------------------------------------------------

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
@@ -111,13 +111,14 @@ public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkben
 	public boolean performOk()
 	{
 		boolean result = super.performOk();
-		String openOcdPath = fPersistentPreferences.getInstallFolder(StringUtil.EMPTY);
-		Path path = Paths.get(openOcdPath);
-		if (!openOcdPath.isBlank())
+		Path updatedPath = Paths.get(fPersistentPreferences.getInstallFolder(StringUtil.EMPTY)).getParent();
+		if (updatedPath != null)
 		{
-			path = path.getParent().resolve("share").resolve("openocd").resolve("scripts"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			updatedPath = updatedPath.resolve("share").resolve("openocd").resolve("scripts"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new IDFEnvironmentVariables().addEnvVariable(IDFEnvironmentVariables.OPENOCD_SCRIPTS,
+					updatedPath.toString());
 		}
-		new IDFEnvironmentVariables().addEnvVariable(IDFEnvironmentVariables.OPENOCD_SCRIPTS, path.toString());
+
 		return result;
 	}
 


### PR DESCRIPTION
## Description

We must ensure that the user can modify the OpenOCD path through the page we offer in Workspace preferences. Additionally, we need to override not only the OpenOCD.exe path but also the OpenOCD scripts path

Fixes # ([IEP-906](https://jira.espressif.com:8443/browse/IEP-906))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- create a debug configuration
- go to preferences -> Environment -> edit OPENOCD_SCRIPTS variable to non-existing path -> close and apply
- open the debug configuration ->  JTAG flash UI elements are missing now, because we are getting wrong scripts path
- go to preferences -> Espressif -> Global OpenOCD path -> browse openocd bin folder -> apply and close
- open the debug configuration -> now jtag flash UI elements are there.
- go to preferences -> Environment -> OPENOCD_SCRIPTS variable is correct again

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- debug configuration
- Espressif preferences -> Global openocd path page
- Environment -> OPENOCD_SCRIPTS variable

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
