### PR TITLE
IEP-911: Changing the shell variable to default display shell

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
@@ -142,7 +142,7 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 			@Override
 			public void widgetSelected(SelectionEvent event)
 			{
-				FileDialog dlg = new FileDialog(shell);
+				FileDialog dlg = new FileDialog(Display.getDefault().getActiveShell());
 				dlg.setText(Messages.DirectorySelectionDialog_GitExecutableLocation);
 
 				String dir = dlg.open();
@@ -193,7 +193,7 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 				@Override
 				public void widgetSelected(SelectionEvent event)
 				{
-					FileDialog dlg = new FileDialog(shell);
+					FileDialog dlg = new FileDialog(Display.getDefault().getActiveShell());
 					dlg.setText(Messages.DirectorySelectionDialog_PyExecutableLocation);
 
 					String dir = dlg.open();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
@@ -105,7 +106,7 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 			@Override
 			public void widgetSelected(SelectionEvent event)
 			{
-				DirectoryDialog dlg = new DirectoryDialog(shell);
+				DirectoryDialog dlg = new DirectoryDialog(Display.getDefault().getActiveShell());
 				dlg.setFilterPath(text.getText());
 				dlg.setText(Messages.DirectorySelectionDialog_IDFDirLabel);
 				dlg.setMessage(Messages.DirectorySelectionDialog_SelectIDFDirMessage);


### PR DESCRIPTION
## Description

Changing the shell variable to default display shell as the active display and window can be different

Fixes # ([IEP-911](https://jira.espressif.com:8443/browse/IEP-911))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Use jira reference ticket to reproduce and test

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Verified on all platforms - Windows,Linux and macOS
