### PR TITLE
IEP-917 Build, Indexer, or the UI can stuck after close and reopen the project/restarting eclipse

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
@@ -92,7 +91,6 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 
 			if (toolChain != null)
 			{
-				config = createBuildConfigBasedOnProjectName(config);
 				return new IDFBuildConfiguration(config, name, toolChain);
 			}
 			else
@@ -100,11 +98,6 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 				// No valid combinations
 				return null;
 			}
-		}
-		if (config.getName().equals(ID + '/' + ICBuildConfiguration.DEFAULT_NAME))
-		{
-			name = configName == null ? config.getProject().getName() : configName;
-			config = configManager.createBuildConfiguration(this, config.getProject(), name, null);
 		}
 		IDFBuildConfiguration cmakeConfig = new IDFBuildConfiguration(config, name);
 		ICMakeToolChainFile tcFile = cmakeConfig.getToolChainFile();
@@ -125,14 +118,9 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		}
 	}
 
-	private IBuildConfiguration createBuildConfigBasedOnProjectName(IBuildConfiguration config) throws CoreException
-	{
-		return configManager.createBuildConfiguration(this, config.getProject(), config.getProject().getName(), null);
-	}
-
 	@Override
-	public ICBuildConfiguration createBuildConfiguration(IProject project, IToolChain toolChain, String launchMode,
-			IProgressMonitor monitor) throws CoreException
+	public synchronized ICBuildConfiguration createBuildConfiguration(IProject project, IToolChain toolChain,
+			String launchMode, IProgressMonitor monitor) throws CoreException
 	{
 		// get matching toolchain file if any
 		Map<String, String> properties = new HashMap<>();
@@ -158,7 +146,7 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		}
 
 		// Let's generate build artifacts directly under the build folder so that CLI and eclipse IDF will be in sync
-		String name = configName == null ? ICBuildConfiguration.DEFAULT_NAME : configName;
+		String name = ICBuildConfiguration.DEFAULT_NAME;
 		IBuildConfiguration buildConfig;
 		if (configManager.hasConfiguration(this, project, name))
 		{
@@ -173,11 +161,6 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		CBuildConfiguration cmakeConfig = new IDFBuildConfiguration(buildConfig, name, toolChain, file, launchMode);
 		configManager.addBuildConfiguration(buildConfig, cmakeConfig);
 		return cmakeConfig;
-	}
-
-	public void setNameBasedOnLaunchConfiguration(ILaunchConfiguration configuration)
-	{
-		configName = configuration.getName();
 	}
 
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -39,7 +39,6 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 
 	private ICMakeToolChainManager manager = CCorePlugin.getService(ICMakeToolChainManager.class);
 	private ICBuildConfigurationManager configManager = CCorePlugin.getService(ICBuildConfigurationManager.class);
-	private String configName;
 
 	@Override
 	public String getId()
@@ -119,8 +118,8 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 	}
 
 	@Override
-	public synchronized ICBuildConfiguration createBuildConfiguration(IProject project, IToolChain toolChain,
-			String launchMode, IProgressMonitor monitor) throws CoreException
+	public ICBuildConfiguration createBuildConfiguration(IProject project, IToolChain toolChain, String launchMode,
+			IProgressMonitor monitor) throws CoreException
 	{
 		// get matching toolchain file if any
 		Map<String, String> properties = new HashMap<>();

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
@@ -19,19 +19,21 @@ import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.RecheckConfigsHelper;
 
-public class ResourceChangeListener implements IResourceChangeListener 
+public class ResourceChangeListener implements IResourceChangeListener
 {
-	
+
 	@Override
 	public void resourceChanged(IResourceChangeEvent event)
 	{
-		if (event == null || event.getDelta() == null) {
+		if (event == null || event.getDelta() == null)
+		{
 			return;
 		}
-		
+
 		try
 		{
-			event.getDelta().accept(new IResourceDeltaVisitor() {
+			event.getDelta().accept(new IResourceDeltaVisitor()
+			{
 				@Override
 				public boolean visit(final IResourceDelta delta) throws CoreException
 				{
@@ -45,8 +47,8 @@ public class ResourceChangeListener implements IResourceChangeListener
 					{
 						cleanupBuildFolder(resource);
 					}
-					boolean isProjectRenamed = resource.getType() == IResource.PROJECT
-							&& kind == IResourceDelta.ADDED && ((flags & IResourceDelta.MOVED_FROM) != 0);
+					boolean isProjectRenamed = resource.getType() == IResource.PROJECT && kind == IResourceDelta.ADDED
+							&& ((flags & IResourceDelta.MOVED_FROM) != 0);
 
 					boolean isProjectOpenedOrCopied = resource.getType() == IResource.PROJECT
 							&& ((flags & IResourceDelta.OPEN) != 0);
@@ -54,7 +56,7 @@ public class ResourceChangeListener implements IResourceChangeListener
 					if (isProjectOpenedOrCopied || isProjectRenamed)
 					{
 						IProject project = (IProject) resource;
-						if (project.isOpen()) 
+						if (project.isOpen())
 						{
 							RecheckConfigsHelper.revalidateToolchain(project);
 						}
@@ -63,14 +65,15 @@ public class ResourceChangeListener implements IResourceChangeListener
 				}
 
 			});
-				
-		} catch (CoreException e)
+
+		}
+		catch (CoreException e)
 		{
 			Logger.log(e);
 		}
-		
+
 	}
-	
+
 	private void updateLaunchBar(IResource resource, int kind, int flags) throws CoreException
 	{
 		if (resource instanceof IProject)
@@ -113,10 +116,10 @@ public class ResourceChangeListener implements IResourceChangeListener
 	{
 
 		IProject project = (IProject) resource;
-		File buildLocation = new File(project.getLocation() + "/"+ IDFConstants.BUILD_FOLDER); //$NON-NLS-1$
+		File buildLocation = new File(project.getLocation() + "/" + IDFConstants.BUILD_FOLDER); //$NON-NLS-1$
 		deleteDirectory(buildLocation);
 	}
-	
+
 	private boolean deleteDirectory(File directoryToBeDeleted)
 	{
 		File[] allContents = directoryToBeDeleted.listFiles();
@@ -130,5 +133,3 @@ public class ResourceChangeListener implements IResourceChangeListener
 		return directoryToBeDeleted.delete();
 	}
 }
-
-

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -23,17 +23,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
 import org.eclipse.cdt.debug.core.CDebugCorePlugin;
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigDelegate;
 import org.eclipse.cdt.debug.core.launch.NullProcess;
 import org.eclipse.cdt.debug.internal.core.Messages;
 import org.eclipse.cdt.serial.SerialPort;
-import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -54,8 +50,6 @@ import org.eclipse.launchbar.ui.target.ILaunchTargetUIManager;
 import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFEnvironmentVariables;
-import com.espressif.idf.core.build.IDFBuildConfiguration;
-import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.DfuCommandsUtil;
@@ -238,21 +232,8 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 	public boolean buildForLaunch(ILaunchConfiguration configuration, String mode, ILaunchTarget target,
 			IProgressMonitor monitor) throws CoreException {
 
-		ICBuildConfigurationManager configManager = CCorePlugin.getService(ICBuildConfigurationManager.class);
 		IProject project = getProject(configuration);
-		IDFBuildConfigurationProvider configurationProvider = new IDFBuildConfigurationProvider();
-		if (!configManager.hasConfiguration(configurationProvider, project, configuration.getName())) {
-			configurationProvider.setNameBasedOnLaunchConfiguration(configuration);
-		}
-		IBuildConfiguration buildConfig = project.getActiveBuildConfig();
-
-		IProjectDescription desc = project.getDescription();
-		desc.setActiveBuildConfig(IDFBuildConfigurationProvider.ID + '/' + configuration.getName());
-		project.setDescription(desc, monitor);
-		((IDFBuildConfiguration) new IDFBuildConfigurationProvider().getCBuildConfiguration(buildConfig,
-				configuration.getName())).setLaunchTarget(target);
 		RecheckConfigsHelper.revalidateToolchain(project);
-
 		return superBuildForLaunch(configuration, mode, monitor);
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/CMakeBuildTab2.java
@@ -10,23 +10,15 @@
  *******************************************************************************/
 package com.espressif.idf.ui.dialogs;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
-import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
-import org.eclipse.cdt.core.build.ICBuildConfigurationProvider;
-import org.eclipse.cdt.core.build.IToolChain;
-import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.cdt.debug.core.launch.CoreBuildLaunchConfigDelegate;
-import org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin;
 import org.eclipse.cdt.launch.ui.corebuild.CommonBuildTab;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.swt.SWT;
@@ -58,9 +50,6 @@ public class CMakeBuildTab2 extends CommonBuildTab
 	private Text cmakeArgsText;
 	private Text buildCommandText;
 	private Text cleanCommandText;
-
-	private static IToolChainManager tcManager = LaunchUIPlugin.getService(IToolChainManager.class);
-	private static ICBuildConfigurationManager bcManager = LaunchUIPlugin.getService(ICBuildConfigurationManager.class);
 
 	@Override
 	protected String getBuildConfigProviderId()
@@ -186,32 +175,6 @@ public class CMakeBuildTab2 extends CommonBuildTab
 
 	}
 
-	private void createBuildConfiguration(ILaunchConfiguration configuration) throws CoreException
-	{
-		IProject project = CoreBuildLaunchConfigDelegate.getProject(configuration);
-		IDFBuildConfigurationProvider provider = new IDFBuildConfigurationProvider();
-		provider.setNameBasedOnLaunchConfiguration(configuration);
-		provider.createBuildConfiguration(project, getBuildConfiguration() == null ? getDefaultMatchingToolChain()
-				: getBuildConfiguration().getToolChain(), ILaunchManager.RUN_MODE, null);
-	}
-
-	private IToolChain getDefaultMatchingToolChain()
-	{
-		ICBuildConfigurationProvider bcProvider = bcManager.getProvider(getBuildConfigProviderId());
-		Collection<IToolChain> toolchainsCollection = Collections.emptyList();
-		try
-		{
-			toolchainsCollection = bcProvider
-					.getSupportedToolchains(tcManager.getToolChainsMatching(getLaunchTarget().getAttributes()));
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
-		}
-
-		return toolchainsCollection.stream().findFirst().orElseThrow();
-	}
-
 	private void updateGeneratorButtons(String generator)
 	{
 		if (generator == null || generator.equals(NINJA) || generator.isBlank())
@@ -272,14 +235,6 @@ public class CMakeBuildTab2 extends CommonBuildTab
 			configuration.removeAttribute(CMakeBuildConfiguration.CLEAN_COMMAND);
 		}
 
-		try
-		{
-			createBuildConfiguration(configuration);
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
## Description

To avoid the deadlock issue, I removed the code that created a build configuration using the launch configuration name in the IDFBuildConfigurationProvider's getBuildConfig method. As we store build settings in the working copies of the launch configuration, it is unnecessary to create these build configs anymore, so removing these changes also improved the code's cleanliness and maintainability.

Fixes # ([IEP-917](https://jira.espressif.com:8443/browse/IEP-917))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How has this been tested?

We need to test items in epic https://jira.espressif.com:8443/browse/IEP-839, to make sure that removing changes didn't break something 

also, it's necessary to test if deadlocks are gone: 
Test 1:
- create a project, build a project
- close and reopen -> searching binaries should no stuck at this point
Test 2:
- close and reopen, build again
Test 3:
- build project
- restart eclipse
- build again
Test 4:
- build project
- restart eclipse 
- close/reopen/build
Test 5:
- build project
- close project
- restart eclipse
- reopen/build
**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows, Linux and macOS
