### PR TITLE
IEP-878: Fixing the git warning

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/preferences/GlobalMcuPage.java
@@ -111,7 +111,7 @@ public class GlobalMcuPage extends FieldEditorPreferencePage implements IWorkben
 	public boolean performOk()
 	{
 		boolean result = super.performOk();
-		Path updatedPath = Paths.get(fPersistentPreferences.getInstallFolder(StringUtil.EMPTY)).getParent();
+		Path updatedPath = Paths.get(fPersistentPreferences.getInstallFolder()).getParent();
 		if (updatedPath != null)
 		{
 			updatedPath = updatedPath.resolve("share").resolve("openocd").resolve("scripts"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ListInstalledToolsHandler.java
@@ -13,6 +13,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
@@ -77,7 +78,11 @@ public class ListInstalledToolsHandler extends AbstractToolsHandler
 	{
 		List<String> arguments = new ArrayList<String>();
 		arguments.add(IDFConstants.TOOLS_LIST_CMD);
-
+		if (StringUtil.isEmpty(gitExecutablePath))
+		{
+			gitExecutablePath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.GIT_PATH);
+		}
+		
 		runCommand(arguments, console);
 	}
 


### PR DESCRIPTION
## Description

I have fixed the git warning issue and possibly this will also fix the git spawn error. Further also reverted to a deprecated method for support with older cdt for PersistentPreferences class

Fixes # ([IEP-878](https://jira.espressif.com:8443/browse/IEP-878))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Using windows sandbox install tools and then click on product information in the Espressif menu there should be no git not found warning now

**Test Configuration**:
* ESP-IDF Version: all
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
