### PR TITLE
Fix: Building project hangs

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -1085,10 +1085,10 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 					if (str.length() > 0)
 					{
 						String[] split = str.split("/"); //$NON-NLS-1$
-						int y = Integer.parseInt(split[1].strip());
-						if (!isProgressSet && monitor != null)
+						if (!isProgressSet && monitor != null && split.length > 1)
 						{
 							isProgressSet = true;
+							int y = Integer.parseInt(split[1].strip());
 							monitor.beginTask("Building", y); //$NON-NLS-1$
 						}
 


### PR DESCRIPTION
## Description

The project build is getting stuck when there is a plain message which has [] tags but there is no actual file processing mentioned.

Fixes # ([IEP-921](https://jira.espressif.com:8443/browse/IEP-921))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Add #Warning message somewhere in your _main.c file and build a project. The build gets stuck when the warning message is on the build console.

**Test Configuration**:
* ESP-IDF Version:master
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- Build

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
