### PR TITLE
IEP-908: Adding the code to support the default workspace directory

### DIFF
--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -24,7 +24,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench,
  org.eclipse.core.commands,
  org.eclipse.jface,
- org.apache.commons.logging;bundle-version="1.2.0"
+ org.apache.commons.logging;bundle-version="1.2.0",
+ org.eclipse.ui.ide,
+ org.eclipse.ui.ide.application,
+ org.eclipse.osgi
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -257,4 +257,13 @@ config-only component and an interface library is created instead."
            name="KCONFIG_PROJBUILD">
      </property>
   </extension>
+  <extension
+        id="org.eclipse.ui.ide.workbench"
+        point="org.eclipse.core.runtime.applications">
+     <application>
+        <run
+              class="com.espressif.idf.core.InitializeEclipseStartup">
+        </run>
+     </application>
+  </extension>
 </plugin>

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/InitializeEclipseStartup.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/InitializeEclipseStartup.java
@@ -1,0 +1,403 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2020, 2023 IBM Corporation and others and Espressif Systems (Shanghai) PTE LTD.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Helmut J. Haigermoser -  Bug 359838 - The "Workspace Unavailable" error
+ *     Lars Vogel <Lars.Vogel@gmail.com> - Bug 422954
+ *     Christian Georgi (SAP) - Bug 423882 - Warn user if workspace is newer than IDE
+ *     Andrey Loskutov <loskutov@gmx.de> - Bug 427393, 455162
+ *     Patrik Suzzi <psuzzi@gmail.com> - Bug 514355
+ *******************************************************************************/
+package com.espressif.idf.core;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
+import org.eclipse.ui.internal.Workbench;
+import org.eclipse.ui.internal.ide.ChooseWorkspaceData;
+import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
+import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
+import org.eclipse.ui.internal.ide.StatusUtil;
+import org.eclipse.ui.internal.ide.application.IDEApplication;
+import org.osgi.framework.Bundle;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.EspIdfJsonParser;
+
+/**
+ * This is the first class that the application will start 
+ * We can utilize it to configure workspace and default params as well
+ * The class is derived from internal IDEApplication class and is overriden 
+ * in areas where its required a lot of code is reused until a better alternative is found
+ * @author Ali Azam Rana
+ *
+ */
+@SuppressWarnings("restriction")
+public class InitializeEclipseStartup extends IDEApplication
+{
+	// Use the branding plug-in of the platform feature since this is most likely
+	// to change on an update of the IDE.
+	private static final String WORKSPACE_CHECK_REFERENCE_BUNDLE_NAME = "org.eclipse.platform"; //$NON-NLS-1$
+	private static final org.osgi.framework.Version WORKSPACE_CHECK_REFERENCE_BUNDLE_VERSION;
+	static
+	{
+		Bundle bundle = Platform.getBundle(WORKSPACE_CHECK_REFERENCE_BUNDLE_NAME);
+		WORKSPACE_CHECK_REFERENCE_BUNDLE_VERSION = bundle != null ? bundle.getVersion() : null/* not installed */;
+	}
+	private static final String WORKSPACE_CHECK_REFERENCE_BUNDLE_NAME_LEGACY = "org.eclipse.core.runtime"; //$NON-NLS-1$
+	private static final String WORKSPACE_CHECK_LEGACY_VERSION_INCREMENTED = "2"; //$NON-NLS-1$ legacy version=1
+	/**
+	 * A special return code that will be recognized by the PDE launcher and used to show an error dialog if the
+	 * workspace is locked.
+	 */
+	private static final Integer EXIT_WORKSPACE_LOCKED = Integer.valueOf(15);
+	/**
+	 * Return value when the user wants to retry loading the current workspace
+	 */
+	private static final int RETRY_LOAD = 0;
+
+	private EspIdfJsonParser espIdfJsonParser;
+
+	@Override
+	protected Object checkInstanceLocation(Shell shell, Map applicationArguments)
+	{
+		Location instanceLoc = Platform.getInstanceLocation();
+		if (instanceLoc == null)
+		{
+			MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceMandatoryTitle,
+					IDEWorkbenchMessages.IDEApplication_workspaceMandatoryMessage);
+			return EXIT_OK;
+		}
+
+		boolean force = false;
+
+		// -data "/valid/path", workspace already set
+		if (instanceLoc.isSet())
+		{
+			// make sure the meta data version is compatible (or the user has
+			// chosen to overwrite it).
+			ReturnCode result = checkValidWorkspace(shell, instanceLoc.getURL());
+			if (result == ReturnCode.EXIT)
+			{
+				return EXIT_OK;
+			}
+			if (result == ReturnCode.VALID)
+			{
+				// at this point its valid, so try to lock it and update the
+				// metadata version information if successful
+				try
+				{
+					if (instanceLoc.lock())
+					{
+						writeWorkspaceVersion();
+						return null;
+					}
+
+					// we failed to create the directory.
+					// Two possibilities:
+					// 1. directory is already in use
+					// 2. directory could not be created
+					File workspaceDirectory = new File(instanceLoc.getURL().getFile());
+					if (workspaceDirectory.exists())
+					{
+						if (isDevLaunchMode(applicationArguments))
+						{
+							return EXIT_WORKSPACE_LOCKED;
+						}
+						MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceCannotLockTitle,
+								NLS.bind(IDEWorkbenchMessages.IDEApplication_workspaceCannotLockMessage,
+										workspaceDirectory.getAbsolutePath()));
+					}
+					else
+					{
+						MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetTitle,
+								IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetMessage);
+					}
+				}
+				catch (IOException e)
+				{
+					IDEWorkbenchPlugin.log("Could not obtain lock for workspace location", //$NON-NLS-1$
+							e);
+					MessageDialog.openError(shell, IDEWorkbenchMessages.InternalError, e.getMessage());
+				}
+				return EXIT_OK;
+			}
+			if (result == ReturnCode.INVALID)
+			{
+				force = true;
+			}
+		}
+
+		// Modifying only this part in the internal code to specify our configuration for the default workspace
+		ChooseWorkspaceData launchData = new ChooseWorkspaceData(getDefaultWorkspaceURL());
+
+		boolean parentShellVisible = false;
+		if (isValid(shell))
+		{
+			parentShellVisible = shell.getVisible();
+			// bug 455162, bug 427393: hide the splash if the workspace
+			// prompt dialog should be opened
+			if (parentShellVisible && launchData.getShowDialog())
+			{
+				shell.setVisible(false);
+			}
+		}
+
+		int returnValue = -1;
+		URL workspaceUrl = null;
+		while (true)
+		{
+			if (returnValue != RETRY_LOAD)
+			{
+				try
+				{
+					workspaceUrl = promptForWorkspace(shell, launchData, force);
+				}
+				catch (OperationCanceledException e)
+				{
+					// Chosen workspace location was not compatible, select default one
+					launchData = new ChooseWorkspaceData(instanceLoc.getDefault());
+
+					// Bug 551260: ignore 'use default location' setting on retries. If the user has
+					// no opportunity to set another location it would only fail again and again and
+					// again.
+					force = true;
+					continue;
+				}
+			}
+			if (workspaceUrl == null)
+			{
+				return EXIT_OK;
+			}
+
+			// if there is an error with the first selection, then force the
+			// dialog to open to give the user a chance to correct
+			force = true;
+
+			try
+			{
+				if (instanceLoc.isSet())
+				{
+					// restart with new location
+					return Workbench.setRestartArguments(workspaceUrl.getFile());
+				}
+
+				// the operation will fail if the url is not a valid
+				// instance data area, so other checking is unneeded
+				if (instanceLoc.set(workspaceUrl, true))
+				{
+					launchData.writePersistedData();
+					writeWorkspaceVersion();
+					return null;
+				}
+			}
+			catch (IllegalStateException e)
+			{
+				MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetTitle,
+						IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetMessage);
+				return EXIT_OK;
+			}
+			catch (IOException e)
+			{
+				MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetTitle,
+						IDEWorkbenchMessages.IDEApplication_workspaceCannotBeSetMessage);
+			}
+
+			// by this point it has been determined that the workspace is
+			// already in use -- force the user to choose again
+			MessageDialog dialog = new MessageDialog(null, IDEWorkbenchMessages.IDEApplication_workspaceInUseTitle,
+					null, NLS.bind(IDEWorkbenchMessages.IDEApplication_workspaceInUseMessage, workspaceUrl.getFile()),
+					MessageDialog.ERROR, 1, IDEWorkbenchMessages.IDEApplication_workspaceInUse_Retry,
+					IDEWorkbenchMessages.IDEApplication_workspaceInUse_Choose);
+			// the return value influences the next loop's iteration
+			returnValue = dialog.open();
+			// Remember the locked workspace as recent workspace
+			launchData.writePersistedData();
+		}
+	}
+
+	private String getDefaultWorkspaceURL()
+	{
+		espIdfJsonParser = new EspIdfJsonParser();
+		espIdfJsonParser.parseJsonAndLoadValues();
+		
+		try
+		{
+			if (espIdfJsonParser.isIdfJsonPresent())
+			{
+				String defaultWorkspacePath = espIdfJsonParser.getDefaultWorkspaceLocation();
+				Logger.log(defaultWorkspacePath);
+				return defaultWorkspacePath;
+			}
+			else
+			{
+				String userHome = System.getProperty("user.home"); //$NON-NLS-1$
+				Logger.log(userHome);
+				String workspaceUrl = userHome.concat(File.separator).concat("workspace"); //$NON-NLS-1$
+				Logger.log(workspaceUrl);
+				return workspaceUrl;
+			}	
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
+		
+		return null;
+	}
+
+	/**
+	 * Open a workspace selection dialog on the argument shell, populating the argument data with the user's selection.
+	 * Perform first level validation on the selection by comparing the version information. This method does not
+	 * examine the runtime state (e.g., is the workspace already locked?).
+	 *
+	 * @param shell
+	 * @param launchData
+	 * @param force      setting to true makes the dialog open regardless of the showDialog value
+	 * @return An URL storing the selected workspace or null if the user has canceled the launch operation.
+	 */
+	private URL promptForWorkspace(Shell shell, ChooseWorkspaceData launchData, boolean force)
+	{
+		URL url = null;
+
+		do
+		{
+			showChooseWorkspaceDialog(shell, launchData, force);
+
+			String instancePath = launchData.getSelection();
+			if (instancePath == null)
+			{
+				return null;
+			}
+
+			// the dialog is not forced on the first iteration, but is on every
+			// subsequent one -- if there was an error then the user needs to be
+			// allowed to fix it
+			force = true;
+
+			// 70576: don't accept empty input
+			if (instancePath.length() <= 0)
+			{
+				MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceEmptyTitle,
+						IDEWorkbenchMessages.IDEApplication_workspaceEmptyMessage);
+				continue;
+			}
+
+			// create the workspace if it does not already exist
+			File workspace = new File(instancePath);
+			if (!workspace.exists())
+			{
+				workspace.mkdir();
+			}
+
+			try
+			{
+				// Don't use File.toURL() since it adds a leading slash that Platform does not
+				// handle properly. See bug 54081 for more details.
+				String path = workspace.getAbsolutePath().replace(File.separatorChar, '/');
+				url = new URL("file", null, path); //$NON-NLS-1$
+			}
+			catch (MalformedURLException e)
+			{
+				MessageDialog.openError(shell, IDEWorkbenchMessages.IDEApplication_workspaceInvalidTitle,
+						IDEWorkbenchMessages.IDEApplication_workspaceInvalidMessage);
+				continue;
+			}
+			ReturnCode result = checkValidWorkspace(shell, url);
+			if (result == ReturnCode.INVALID)
+			{
+				throw new OperationCanceledException("Invalid workspace location: " + url); //$NON-NLS-1$
+			}
+			if (result == ReturnCode.EXIT)
+			{
+				return null;
+			}
+			return url;
+		} while (true);
+	}
+
+	/**
+	 * Write the version of the metadata into a known file overwriting any existing file contents. Writing the version
+	 * file isn't really crucial, so the function is silent about failure
+	 */
+	private static void writeWorkspaceVersion()
+	{
+		if (WORKSPACE_CHECK_REFERENCE_BUNDLE_VERSION == null)
+		{
+			// no reference bundle installed, no check possible
+			return;
+		}
+
+		Location instanceLoc = Platform.getInstanceLocation();
+		if (instanceLoc == null || instanceLoc.isReadOnly())
+		{
+			return;
+		}
+
+		File versionFile = getVersionFile(instanceLoc.getURL(), true);
+		if (versionFile == null)
+		{
+			return;
+		}
+
+		Properties props = new Properties();
+
+		// write new property
+		props.setProperty(WORKSPACE_CHECK_REFERENCE_BUNDLE_NAME, WORKSPACE_CHECK_REFERENCE_BUNDLE_VERSION.toString());
+
+		// write legacy property with an incremented version,
+		// so that pre-4.4 IDEs will also warn about the workspace
+		props.setProperty(WORKSPACE_CHECK_REFERENCE_BUNDLE_NAME_LEGACY, WORKSPACE_CHECK_LEGACY_VERSION_INCREMENTED);
+
+		try (OutputStream output = new FileOutputStream(versionFile))
+		{
+			props.store(output, null);
+		}
+		catch (IOException e)
+		{
+			IDEWorkbenchPlugin.log("Could not write version file", //$NON-NLS-1$
+					StatusUtil.newError(e));
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static boolean isDevLaunchMode(Map args)
+	{
+		// see org.eclipse.pde.internal.core.PluginPathFinder.isDevLaunchMode()
+		if (Boolean.getBoolean("eclipse.pde.launch")) //$NON-NLS-1$
+			return true;
+		return args.containsKey("-pdelaunch"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Helper method to check if a widget is not null and not disposed
+	 *
+	 * @param widget to be checked
+	 * @return true if widget is not disposed or null, false otherwise
+	 * @since 3.22
+	 */
+	public static boolean isValid(Widget widget)
+	{
+		return widget != null && !widget.isDisposed();
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
@@ -7,6 +7,7 @@ package com.espressif.idf.core.util;
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
 import org.eclipse.core.runtime.Platform;
@@ -62,7 +63,7 @@ public class EspIdfJsonParser
 		
 		
 		JSONParser parser = new JSONParser();
-		try (FileReader fr = new FileReader(idf_json_file))
+		try (FileReader fr = new FileReader(idf_json_file, StandardCharsets.UTF_8))
 		{
 			JSONObject jsonObj = (JSONObject) parser.parse(fr);
 			gitExecutablePath = (String) jsonObj.get(GIT_PATH);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
@@ -62,9 +62,9 @@ public class EspIdfJsonParser
 		
 		
 		JSONParser parser = new JSONParser();
-		try
+		try (FileReader fr = new FileReader(idf_json_file))
 		{
-			JSONObject jsonObj = (JSONObject) parser.parse(new FileReader(idf_json_file));
+			JSONObject jsonObj = (JSONObject) parser.parse(fr);
 			gitExecutablePath = (String) jsonObj.get(GIT_PATH);
 			idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
 			defaultWorkspaceLocation = (String) jsonObj.get(DEFAULT_WORSPACE_PATH);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EspIdfJsonParser.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import java.io.File;
+import java.io.FileReader;
+import java.net.URL;
+import java.text.MessageFormat;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.osgi.service.datalocation.Location;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * esp_idf.json parser utility class to parse the 
+ * stored configs for startup in esp_idf.json
+ * @author Ali Azam Rana
+ *
+ */
+public class EspIdfJsonParser
+{
+	/**
+	 * esp-idf.json is file created by the installer
+	 */
+	private static final String ESP_IDF_JSON_FILE = "esp_idf.json"; //$NON-NLS-1$
+	
+	// Variables defined in the esp-idf.json file
+	private static final String GIT_PATH = "gitPath"; //$NON-NLS-1$
+	private static final String IDF_VERSIONS_ID = "idfSelectedId"; //$NON-NLS-1$
+	private static final String IDF_INSTALLED_LIST_KEY = "idfInstalled"; //$NON-NLS-1$
+	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
+	private static final String IDF_PATH = "path"; //$NON-NLS-1$
+	private static final String DEFAULT_WORSPACE_PATH = "defaultWorkspace"; //$NON-NLS-1$
+
+	private String gitExecutablePath;
+	private String idfVersionId;
+	private String idfPath;
+	private String pythonExecutablePath;
+	private String defaultWorkspaceLocation;
+	private boolean isIdfJsonPresent;
+
+	public void parseJsonAndLoadValues()
+	{
+		// Get the location of the eclipse root directory
+		Location installLocation = Platform.getInstallLocation();
+		URL url = installLocation.getURL();
+		Logger.log("Eclipse Install location::" + url); //$NON-NLS-1$
+		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
+		if (!idf_json_file.exists())
+		{
+			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: '{0}'", url.getPath())); //$NON-NLS-1$
+			isIdfJsonPresent = false;
+			return;
+		}
+		
+		isIdfJsonPresent = true;
+		
+		
+		JSONParser parser = new JSONParser();
+		try
+		{
+			JSONObject jsonObj = (JSONObject) parser.parse(new FileReader(idf_json_file));
+			gitExecutablePath = (String) jsonObj.get(GIT_PATH);
+			idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
+			defaultWorkspaceLocation = (String) jsonObj.get(DEFAULT_WORSPACE_PATH);
+			JSONObject list = (JSONObject) jsonObj.get(IDF_INSTALLED_LIST_KEY);
+			if (list != null)
+			{
+				// selected esp-idf version information
+				JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
+				idfPath = (String) selectedIDFInfo.get(IDF_PATH);
+				pythonExecutablePath = (String) selectedIDFInfo.get(PYTHON_PATH);
+			}
+		}
+		catch (Exception e) 
+		{
+			Logger.log(e);
+		}
+	}
+
+	public String getGitExecutablePath()
+	{
+		return gitExecutablePath;
+	}
+
+	public String getIdfVersionId()
+	{
+		return idfVersionId;
+	}
+
+	public String getIdfPath()
+	{
+		return idfPath;
+	}
+
+	public String getPythonExecutablePath()
+	{
+		return pythonExecutablePath;
+	}
+
+	public boolean isIdfJsonPresent()
+	{
+		return isIdfJsonPresent;
+	}
+
+	public String getDefaultWorkspaceLocation()
+	{
+		return defaultWorkspaceLocation;
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -6,26 +6,17 @@ package com.espressif.idf.ui;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URL;
 import java.text.MessageFormat;
 
 import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.ILaunchBarManager;
-import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IStartup;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
@@ -34,6 +25,7 @@ import com.espressif.idf.core.build.Messages;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.ResourceChangeListener;
+import com.espressif.idf.core.util.EspIdfJsonParser;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.core.util.ToolChainUtil;
 import com.espressif.idf.ui.dialogs.MessageLinkDialog;
@@ -43,22 +35,11 @@ import com.espressif.idf.ui.update.InstallToolsHandler;
 @SuppressWarnings("restriction")
 public class InitializeToolsStartup implements IStartup
 {
-
-	/**
-	 * esp-idf.json is file created by the installer
-	 */
-	private static final String ESP_IDF_JSON_FILE = "esp_idf.json"; //$NON-NLS-1$
-
-	// Variables defined in the esp-idf.json file
-	private static final String GIT_PATH = "gitPath"; //$NON-NLS-1$
-	private static final String IDF_VERSIONS_ID = "idfSelectedId"; //$NON-NLS-1$
-	private static final String IDF_INSTALLED_LIST_KEY = "idfInstalled"; //$NON-NLS-1$
-	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
-	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
 
 	private String newIdfPath;
+	private EspIdfJsonParser espIdfJsonParser;
 
 	@Override
 	public void earlyStartup()
@@ -87,19 +68,15 @@ public class InitializeToolsStartup implements IStartup
 		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 		launchBarManager.addListener(new LaunchBarListener());
 
-		// Get the location of the eclipse root directory
-		Location installLocation = Platform.getInstallLocation();
-		URL url = installLocation.getURL();
-		Logger.log("Eclipse Install location::" + url);
-		File idf_json_file = new File(url.getPath() + File.separator + ESP_IDF_JSON_FILE);
-		if (!idf_json_file.exists())
+		espIdfJsonParser = new EspIdfJsonParser();
+		espIdfJsonParser.parseJsonAndLoadValues();
+		if (!espIdfJsonParser.isIdfJsonPresent())
 		{
-			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: '{0}'", url.getPath()));
 			return;
 		}
 		else if (isInstallerConfigSet())
 		{
-			checkForUpdatedVersion(idf_json_file);
+			checkForUpdatedVersion();
 			if (isInstallerConfigSet())
 			{
 				Logger.log("Ignoring esp_idf.json settings as it was configured earilier and idf_path is similar.");
@@ -132,105 +109,51 @@ public class InitializeToolsStartup implements IStartup
 			});
 		}
 
-		// read esp-idf.json file
-		JSONParser parser = new JSONParser();
-		try
+		// read esp-idf.json file configs
+		String gitExecutablePath = espIdfJsonParser.getGitExecutablePath();
+		String idfPath = espIdfJsonParser.getIdfPath();
+		String pythonExecutablePath = espIdfJsonParser.getPythonExecutablePath();
+		IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
+		idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_PATH, idfPath);
+
+		if (!StringUtil.isEmpty(pythonExecutablePath) && !StringUtil.isEmpty(gitExecutablePath))
 		{
-			JSONObject jsonObj = (JSONObject) parser.parse(new FileReader(idf_json_file));
-			String gitExecutablePath = (String) jsonObj.get(GIT_PATH);
-			String idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
-			JSONObject list = (JSONObject) jsonObj.get(IDF_INSTALLED_LIST_KEY);
-			if (list != null)
-			{
-				// selected esp-idf version information
-				JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
-				String idfPath = (String) selectedIDFInfo.get(IDF_PATH);
-				String pythonExecutablePath = (String) selectedIDFInfo.get(PYTHON_PATH);
+			ExportIDFTools exportIDFTools = new ExportIDFTools();
+			exportIDFTools.runToolsExport(pythonExecutablePath, gitExecutablePath, null, null);
 
-				// Add IDF_PATH to the eclipse CDT build environment variables
-				IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
-				idfEnvMgr.addEnvVariable(IDFEnvironmentVariables.IDF_PATH, idfPath);
+			// Configure toolchains
+			ToolChainUtil.configureToolChain();
 
-				if (!StringUtil.isEmpty(pythonExecutablePath) && !StringUtil.isEmpty(gitExecutablePath))
-				{
-					ExportIDFTools exportIDFTools = new ExportIDFTools();
-					exportIDFTools.runToolsExport(pythonExecutablePath, gitExecutablePath, null, null);
-
-					// Configure toolchains
-					ToolChainUtil.configureToolChain();
-
-					Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
-					scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
-					try
-					{
-						scopedPreferenceStore.flush();
-					}
-					catch (BackingStoreException e)
-					{
-						Logger.log(e);
-					}
-				}
-			}
-
-			// save state
-			Preferences prefs = getPreferences();
-			prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
+			Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
+			scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
 			try
 			{
-				prefs.flush();
+				scopedPreferenceStore.flush();
 			}
 			catch (BackingStoreException e)
 			{
 				Logger.log(e);
 			}
-
-		}
-		catch (
-				IOException
-				| ParseException e)
-		{
-			Logger.log(e);
 		}
 	}
 
-	private void checkForUpdatedVersion(File idf_json_file)
+	private void checkForUpdatedVersion()
 	{
-		// read esp-idf.json file
-		JSONParser parser = new JSONParser();
-		try (FileReader reader = new FileReader(idf_json_file))
+		String idfPath = espIdfJsonParser.getIdfPath();
+		IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
+		if (idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH).equals(idfPath))
+			return;
+		newIdfPath = idfPath;
+		Preferences prefs = getPreferences();
+		prefs.putBoolean(IS_INSTALLER_CONFIG_SET, false);
+		try
 		{
-			JSONObject jsonObj = (JSONObject) parser.parse(reader);
-			String idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
-			JSONObject list = (JSONObject) jsonObj.get(IDF_INSTALLED_LIST_KEY);
-			if (list == null)
-			{
-				return;
-			}
-			// selected esp-idf version information
-			JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
-			String idfPath = (String) selectedIDFInfo.get(IDF_PATH);
-			IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
-			if (idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH).equals(idfPath))
-				return;
-			newIdfPath = idfPath;
-			Preferences prefs = getPreferences();
-			prefs.putBoolean(IS_INSTALLER_CONFIG_SET, false);
-			try
-			{
-				prefs.flush();
-			}
-			catch (BackingStoreException e)
-			{
-				Logger.log(e);
-			}
+			prefs.flush();
 		}
-		catch (
-				IOException
-				| ParseException e)
+		catch (BackingStoreException e)
 		{
 			Logger.log(e);
 		}
-
 	}
 
 	private Preferences getPreferences()


### PR DESCRIPTION
## Description

The issue with installer where it sometimes references to the idf toolchain directory for workspace should be resolved now the default workspace is now either in the user home directory or is pointed by the **defaultWorkspace** property in the **esp_idf.json** file

Fixes # ([IEP-908](https://jira.espressif.com:8443/browse/IEP-908))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- Can be a breaking change but code reviews should be able to identify them

## How has this been tested?
**Test 1:**
- Launch the espressif ide
- For the first launch the workspace should now point to (USER_HOME/workspace) directory in the workspace selection dialog
**Test 2:**
- Add the esp_idf.json file if trying without the installer in the espressif ide root directory
- Check to see if the **defaultWorkspace** property is present if not add yourself and point to a path
- Launch the espressif ide the default workspace on the first launch should now point to the directory defined in previous step.
**Test3:**
Also make sure to change the workspace to some other directory and try to relaunch the IDE the workspace selection dialog on second start should always point to the last used directory.

**Test Configuration**:
* ESP-IDF Version: Any
* OS (Windows,Linux and macOS): All

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
