### PR TITLE
IEP-925 2.9.1 project combo is empty and launch can throw an exception

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -54,6 +54,7 @@ import org.eclipse.cdt.core.IConsoleParser;
 import org.eclipse.cdt.core.IConsoleParser2;
 import org.eclipse.cdt.core.build.CBuildConfiguration;
 import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.cdt.core.envvar.EnvironmentVariable;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.cdt.core.index.IIndexManager;
@@ -141,8 +142,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	{
 		super(config, name);
 		buildConfiguration = config;
-		ICMakeToolChainManager manager = IDFCorePlugin.getService(ICMakeToolChainManager.class);
-		this.toolChainFile = manager.getToolChainFileFor(getToolChain());
 	}
 
 	public IDFBuildConfiguration(IBuildConfiguration config, String name, IToolChain toolChain)
@@ -266,8 +265,10 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				.toArray(IBinary[]::new);
 	}
 
-	public ICMakeToolChainFile getToolChainFile()
+	public ICMakeToolChainFile getToolChainFile() throws CoreException
 	{
+		ICMakeToolChainManager manager = IDFCorePlugin.getService(ICMakeToolChainManager.class);
+		this.toolChainFile = manager.getToolChainFileFor(getToolChain());
 		return toolChainFile;
 	}
 
@@ -799,6 +800,14 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		return folder;
 	}
 
+	@Override
+	public IToolChain getToolChain() throws CoreException
+	{
+		String typeId = getProperty(TOOLCHAIN_TYPE);
+		String id = getProperty(TOOLCHAIN_ID);
+		IToolChainManager toolChainManager = CCorePlugin.<IToolChainManager>getService(IToolChainManager.class);
+		return toolChainManager.getToolChain(typeId, id);
+	}
 	private static IPath getComponentsPath()
 	{
 		return new org.eclipse.core.runtime.Path(IDFConstants.BUILD_FOLDER).append("ide").append(ESP_IDF_COMPONENTS); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -60,6 +60,10 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 			try
 			{
 				ILaunchTarget target = barManager.getActiveLaunchTarget();
+				if (target == null)
+				{
+					return null;
+				}
 				for (IToolChain tc : toolChainManager.getToolChainsMatching(target.getAttributes()))
 				{
 					if (tc instanceof AbstractESPToolchain)

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -137,7 +137,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		if (checkIfPortIsEmpty(configuration)) {
 			return;
 		}
-		String arguments = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_TOOL_ARGUMENTS,
+		String arguments = configuration.getAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS,
 				espFlashCommand);
 		arguments = arguments.replace(ESPFlashUtil.SERIAL_PORT, serialPort);
 		if (!arguments.isEmpty()) {
@@ -183,7 +183,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		openocdExe = openocdExe.replace(DEFAULT_PATH, tmp);
 		commands.add(openocdExe);
 
-		String arguments = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_TOOL_ARGUMENTS, ""); //$NON-NLS-1$
+		String arguments = configuration.getAttribute(IDFLaunchConstants.ATTR_JTAG_FLASH_ARGUMENTS, ""); //$NON-NLS-1$
 		arguments = arguments.replace(DEFAULT_PATH, tmp).trim();
 		commands.addAll(StringUtils.splitCommandLineOptions(arguments));
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -42,6 +42,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.launchbar.core.target.launch.ITargetedLaunch;
@@ -49,6 +50,7 @@ import org.eclipse.launchbar.ui.internal.Activator;
 import org.eclipse.launchbar.ui.target.ILaunchTargetUIManager;
 import org.eclipse.swt.widgets.Display;
 
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
@@ -75,6 +77,10 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 	@Override
 	public ITargetedLaunch getLaunch(ILaunchConfiguration configuration, String mode, ILaunchTarget target)
 			throws CoreException {
+		if (target == null) {
+			ILaunchBarManager barManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+			target = barManager.getActiveLaunchTarget();
+		}
 		return new SerialFlashLaunch(configuration, mode, null, target);
 	}
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.eclipse.cdt.serial.SerialPort;
-import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -38,7 +37,7 @@ import org.eclipse.tm.terminal.view.ui.interfaces.IConfigurationPanel;
 import org.eclipse.tm.terminal.view.ui.interfaces.IConfigurationPanelContainer;
 import org.osgi.service.prefs.Preferences;
 
-import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
+import com.espressif.idf.core.IDFProjectNature;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.terminal.connector.serial.activator.Activator;
@@ -105,9 +104,7 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		{
 			try
 			{
-				IBuildConfiguration activeBuildConfig = project.getActiveBuildConfig();
-				if (activeBuildConfig != null
-						&& activeBuildConfig.getName().startsWith(IDFBuildConfigurationProvider.ID))
+				if (project.hasNature(IDFProjectNature.ID))
 				{
 					projectCombo.add(project.getName());
 				}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EclipseUtil.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EclipseUtil.java
@@ -17,7 +17,7 @@ import org.eclipse.ui.ISelectionService;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
-import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
+import com.espressif.idf.core.IDFProjectNature;
 import com.espressif.idf.core.logging.Logger;
 
 /**
@@ -70,8 +70,7 @@ public class EclipseUtil
 		IProject project = getSelectedProject(IPageLayout.ID_PROJECT_EXPLORER);
 		try
 		{
-			if (project != null && project.getActiveBuildConfig() != null
-					&& project.getActiveBuildConfig().getName().startsWith(IDFBuildConfigurationProvider.ID))
+			if (project != null && project.hasNature(IDFProjectNature.ID))
 			{
 				return project;
 			}
@@ -94,10 +93,10 @@ public class EclipseUtil
 		IStructuredSelection structured = (IStructuredSelection) service.getSelection(viewID);
 		if (structured instanceof IStructuredSelection)
 		{
-			Object selectedObject = ((IStructuredSelection) structured).getFirstElement();
+			Object selectedObject = structured.getFirstElement();
 			if (selectedObject instanceof IAdaptable)
 			{
-				IResource resource = (IResource) ((IAdaptable) selectedObject).getAdapter(IResource.class);
+				IResource resource = ((IAdaptable) selectedObject).getAdapter(IResource.class);
 				if (resource != null)
 				{
 					return resource.getProject();


### PR DESCRIPTION
## Description

to show all idf projects, we are checking if a project has an IDF project nature now and passing the active launch target if the default one is missing. Also, to fix the indexer stuck when closing a project, we are returning null in the getCBuildConfiguration method when active launch target is null to avoid exceptions.

Fixes # ([IEP-925](https://jira.espressif.com:8443/browse/IEP-925))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Test 1 (Combo is empty test)
- create a few espressif IDF projects and few C/C++ projects
- Launch Terminal -> ESP-IDF Serial Monitor -> Project name combo should contain only esp-idf projects
Test 2 (launch exception)
- Right-click on project, Run As -> Run Configurations... -> Double click to create a new project and click 'Run' -> No exception expected
Test 3 (Indexer stuck on close and reopening the project)
- build the project, wait for the indexer, and close the project during the indexer running -> project should be able to close and reopen without the indexer stuck. (Verify a few times, since deadlock can be random in this case) 


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- build
- launch
- ESP-IDF Serial Monitor 
- Indexer
- project

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
