### PR TITLE
IEP-858 Incorrect target change notification after eclipse restart

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/ResourceChangeListener.java
@@ -12,6 +12,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 
 import com.espressif.idf.core.IDFConstants;
@@ -21,7 +22,12 @@ import com.espressif.idf.core.util.RecheckConfigsHelper;
 
 public class ResourceChangeListener implements IResourceChangeListener
 {
+	ILaunchBarListener launchBarListener;
 
+	public ResourceChangeListener(ILaunchBarListener launchBarListener)
+	{
+		this.launchBarListener = launchBarListener;
+	}
 	@Override
 	public void resourceChanged(IResourceChangeEvent event)
 	{
@@ -85,6 +91,8 @@ public class ResourceChangeListener implements IResourceChangeListener
 			{
 				ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
 				ILaunchConfiguration[] configs = launchManager.getLaunchConfigurations();
+				// remove launch bar listener before updating launch bar
+				launchBarManager.removeListener(launchBarListener);
 				for (ILaunchConfiguration config : configs)
 				{
 					IResource[] mappedResource = config.getMappedResources();
@@ -100,6 +108,8 @@ public class ResourceChangeListener implements IResourceChangeListener
 						}
 					}
 				}
+				// adding launch bar listener only before adding last configuration
+				launchBarManager.addListener(launchBarListener);
 				if (project.isOpen())
 				{
 					launchBarManager.launchObjectAdded(project);
@@ -108,6 +118,7 @@ public class ResourceChangeListener implements IResourceChangeListener
 				{
 					launchBarManager.launchObjectRemoved(project);
 				}
+
 			}
 		}
 	}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -16,6 +16,7 @@ import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.swt.SWT;
@@ -83,9 +84,10 @@ public class InitializeToolsStartup implements IStartup
 
 			}
 		});
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener());
+		ILaunchBarListener launchBarListener = new LaunchBarListener();
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(new ResourceChangeListener(launchBarListener));
 		ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
-		launchBarManager.addListener(new LaunchBarListener());
+		launchBarManager.addListener(launchBarListener);
 
 		// Get the location of the eclipse root directory
 		Location installLocation = Platform.getInstallLocation();


### PR DESCRIPTION
## Description

removing the launch bar listener before updating the launch bar and adding it back just before adding the last configuration.

Fixes # ([IEP-858](https://jira.espressif.com:8443/browse/IEP-858))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Here are steps to reproduce the issue on master. This use case should be fixed on this branch:

1. Create a new project,  set an esp32 target, and build

2. Create a new launch configuration, set the esp32s2 target

3. close/reopening project -> see default configuration with esp32 target, but notifier says that target changed from esp32s2 from esp32. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch target has changed notification msg

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
