### PR TITLE
IEP-932:Create /latest links to the espressf-ide downloads for each release version

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -150,3 +150,7 @@ jobs:
         aws s3 cp --acl=public-read "./releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64-${FOLDER_NAME}.dmg" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
         aws s3 cp --acl=public-read "./releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64-${FOLDER_NAME}.dmg" s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/
         aws cloudfront create-invalidation --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} --paths "/dl/idf-eclipse-plugin/updates/latest/*"
+        aws s3api put-object --acl=public-read  --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-win32.win32.x86_64/latest"  --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${ARCHIVE_VERSION}-win32.win32.x86_64.zip"
+        aws s3api put-object --acl=public-read  --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64/latest"  --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64-v${ARCHIVE_VERSION}.dmg"
+        aws s3api put-object --acl=public-read  --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64/latest"  --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64-v${ARCHIVE_VERSION}.dmg"
+        aws s3api put-object --acl=public-read  --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-linux.gtk.x86_64/latest"  --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${ARCHIVE_VERSION}-linux.gtk.x86_64.tar.gz"

--- a/docs/Espressif-IDE.md
+++ b/docs/Espressif-IDE.md
@@ -31,19 +31,21 @@ Espressif-IDE is an Integrated Development Environment(IDE) based on Eclipse CDT
 - Host operating systems supported: Windows, macOS, and Linux 
 
 ## Downloads
-### Espressif-IDE v2.9.0 (Latest stable)
+### Espressif-IDE
+
+You can find the latest Espressif-IDE release notes from [here](https://github.com/espressif/idf-eclipse-plugin/releases). Provided below are the direct download links for various platforms.
 
 | OS  | Download |
 | ------------- | ------------- |
-| Windows  | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-2.9.0-win32.win32.x86_64.zip">Espressif-IDE-2.9.0-win32.win32.x86_64.zip</a>  |
-| macosx | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64-v2.9.0.dmg">Espressif-IDE-macosx-cocoa-x86_64-v2.9.0.dmg</a>  |
-| macosx aarch64| <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64-v2.9.0.dmg">Espressif-IDE-macosx-cocoa-aarch64-v2.9.0.dmg</a>  |
-| linux | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-2.9.0-linux.gtk.x86_64.tar.gz">Espressif-IDE-2.9.0-linux.gtk.x86_64.tar.gz</a>  |
+| Windows  | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-win32.win32.x86_64/latest">Espressif-IDE-win32.win32.x86_64</a>  |
+| macOS x86_64 | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64/latest">Espressif-IDE-macosx-cocoa-x86_64</a>  |
+| macOS aarch64| <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64/latest">Espressif-IDE-macosx-cocoa-aarch64</a>  |
+| Linux | <a href ="https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-linux.gtk.x86_64/latest">Espressif-IDE-linux.gtk.x86_64</a>  |
 
 ### Espressif-IDE Update site
 Please check the update site installation instructions from <a href="https://github.com/espressif/idf-eclipse-plugin#installing-idf-plugin-using-update-site-url">here</a>
 
-### macOS security notice
+### macOS security notice (Applicable for Nightly Builds)
 On macOS, if you download the archive with the browser, the strict security checks on recent macOS will prevent it to run, and complain that the program is damaged. That’s obviously not true, and the fix is simple, you need to remove the `com.apple.quarantine` extended attribute.
 ```
 $ xattr -d com.apple.quarantine ~/Downloads/Espressif-IDE-x.x.x-macosx.cocoa.x86_64.tar.gz


### PR DESCRIPTION
IEP-932:Create /latest links to the espressf-ide downloads for each release version

## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-932](https://jira.espressif.com:8443/browse/IEP-932))

## Type of change
- This change requires a documentation update

## How has this been tested?

Below links should reflect the latest stable version after each release is published

https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-win32.win32.x86_64/latest
https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64/latest
https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64/latest
https://dl.espressif.com/dl/idf-eclipse-plugin/ide/Espressif-IDE-linux.gtk.x86_64/latest


## Dependent components impacted by this PR:

- Download links mentioned above

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
