### PR TITLE
IEP-931: espressif-ide:couldn't open after changing the language config

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/EclipseIniUtil.java
@@ -98,10 +98,13 @@ public class EclipseIniUtil
 		File file = new File(eclipseIniUri);
 		eclipseIniFileContents = FileUtils.readLines(file, Charset.defaultCharset());
 		int indexOfVmArgs = eclipseIniFileContents.indexOf(ECLIPSE_INI_VMARGS);
-		eclipseIniArgs = new ArrayList<String>();
-		for (int i = indexOfVmArgs + 1; i < eclipseIniFileContents.size(); i++)
+		if (indexOfVmArgs != -1)
 		{
-			eclipseIniArgs.add(eclipseIniFileContents.get(i));
+			eclipseIniArgs = new ArrayList<String>();
+			for (int i = indexOfVmArgs + 1; i < eclipseIniFileContents.size(); i++)
+			{
+				eclipseIniArgs.add(eclipseIniFileContents.get(i));
+			}			
 		}
 	}
 
@@ -118,20 +121,24 @@ public class EclipseIniUtil
 			}
 		}
 
-		contentsToWrite.add(ECLIPSE_INI_VMARGS);
-
-		for (Entry<String, String> entry : eclipseVmArgMap.entrySet())
+		if (eclipseIniFileContents.indexOf(ECLIPSE_INI_VMARGS) != -1)
 		{
-			if (!StringUtil.isEmpty(entry.getValue()))
+			contentsToWrite.add(ECLIPSE_INI_VMARGS);
+
+			for (Entry<String, String> entry : eclipseVmArgMap.entrySet())
 			{
-				String contentToWrite = entry.getKey() + "=" + entry.getValue(); //$NON-NLS-1$
-				contentsToWrite.add(contentToWrite);
-			}
-			else
-			{
-				contentsToWrite.add(entry.getKey());
-			}
+				if (!StringUtil.isEmpty(entry.getValue()))
+				{
+					String contentToWrite = entry.getKey() + "=" + entry.getValue(); //$NON-NLS-1$
+					contentsToWrite.add(contentToWrite);
+				}
+				else
+				{
+					contentsToWrite.add(entry.getKey());
+				}
+			}	
 		}
+		
 
 		FileUtils.writeLines(file, contentsToWrite);
 	}
@@ -140,6 +147,11 @@ public class EclipseIniUtil
 	{
 		eclipseIniSwitchMap = new HashMap<>();
 		int indexOfVmArgs = eclipseIniFileContents.indexOf(ECLIPSE_INI_VMARGS);
+		if (indexOfVmArgs == -1)
+		{
+			indexOfVmArgs = eclipseIniFileContents.size();
+		}
+		
 		for (int i = 0; i < indexOfVmArgs; i++)
 		{
 			String key = eclipseIniFileContents.get(i);
@@ -160,6 +172,11 @@ public class EclipseIniUtil
 	{
 		eclipseVmArgMap = new HashMap<>();
 		int indexOfVmArgs = eclipseIniFileContents.indexOf(ECLIPSE_INI_VMARGS);
+		if (indexOfVmArgs == -1)
+		{
+			return;
+		}
+		
 		for (int i = indexOfVmArgs + 1; i < eclipseIniFileContents.size(); i++)
 		{
 			String[] arg = eclipseIniFileContents.get(i).split("=");


### PR DESCRIPTION
## Description

Changes to eclipse ini utility class to handle single line parameters in configs for language change. The ide was not able to open due to wrong configuration format of the file

Fixes # ([IEP-931](https://jira.espressif.com:8443/browse/IEP-931))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Remove everything in the espress-ide.ini file only keep the -vm argument to point to the vm and then change language the ide should launch after language change with only vm config in ini file

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
