### PR TITLE
IEP-927 JTAG and Debugging for Custom Build Folder doesn't work

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
@@ -3,8 +3,8 @@ package com.espressif.idf.core.build;
 public final class IDFLaunchConstants
 {
 	public static final String ESP_LAUNCH_TARGET_TYPE = "com.espressif.idf.launch.serial.core.serialFlashTarget"; //$NON-NLS-1$
-	public static final String ATTR_IDF_TARGET =  "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
-	public static final String DEBUG_LAUNCH_CONFIG_TYPE= "com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"; //$NON-NLS-1$
+	public static final String ATTR_IDF_TARGET = "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
+	public static final String DEBUG_LAUNCH_CONFIG_TYPE = "com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"; //$NON-NLS-1$
 	public static final String RUN_LAUNCH_CONFIG_TYPE = "com.espressif.idf.launch.serial.launchConfigurationType"; //$NON-NLS-1$
 	public static final String FLASH_OVER_JTAG = "FLASH_OVER_JTAG"; //$NON-NLS-1$
 	public static final String DFU = "DFU"; //$NON-NLS-1$
@@ -14,4 +14,5 @@ public final class IDFLaunchConstants
 	public static final String ATTR_SERIAL_FLASH_ARGUMENTS = "com.espressif.idf.launch.serial.core.serialFlashArguments"; //$NON-NLS-1$
 	public static final String ATTR_DFU_FLASH_ARGUMENTS = "com.espressif.idf.launch.serial.core.dfuFlashArguments"; //$NON-NLS-1$
 	public static final String ATTR_JTAG_FLASH_ARGUMENTS = "com.espressif.idf.debug.gdbjtag.openocd.jtagFlashArguments"; //$NON-NLS-1$
+	public static final String ATTR_LAUNCH_CONFIGURATION_NAME = "com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationName"; //$NON-NLS-1$
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
@@ -53,3 +53,4 @@ properties.mcu=ESP-IDF OpenOCD Path
 
 actionType.name = Heap Tracing
 command.name = Application Level Tracing
+variable.description = Default C/C++ application (path to binaries) is determined automatically after build

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -139,5 +139,13 @@
           class="com.espressif.idf.debug.gdbjtag.openocd.OpenOCDPluginStartup">
     </startup>
  </extension>
+ <extension
+       point="org.eclipse.core.variables.dynamicVariables">
+    <variable
+          description="%variable.description"
+          name="default_app"
+          resolver="com.espressif.idf.debug.gdbjtag.openocd.DefaultAppResolver">
+    </variable>
+ </extension>
 
 </plugin>

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/DefaultAppResolver.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/DefaultAppResolver.java
@@ -1,0 +1,38 @@
+package com.espressif.idf.debug.gdbjtag.openocd;
+
+import java.io.File;
+
+import org.eclipse.cdt.core.model.CoreModel;
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.variables.IDynamicVariable;
+import org.eclipse.core.variables.IDynamicVariableResolver;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+
+import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.util.GenericJsonReader;
+import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.StringUtil;
+
+public class DefaultAppResolver implements IDynamicVariableResolver
+{
+
+	@Override
+	public String resolveValue(IDynamicVariable variable, String argument) throws CoreException
+	{
+		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+		ILaunchConfiguration activeConfig = launchBarManager.getActiveLaunchConfiguration();
+		String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME,
+				StringUtil.EMPTY);
+		IProject activeProject = CoreModel.getDefault().getCModel().getCProject(projectName).getProject();
+		GenericJsonReader jsonReader = new GenericJsonReader(
+				IDFUtil.getBuildDir(activeProject) + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON);
+		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
+
+		return IDFUtil.getBuildDir(activeProject) + File.separator + value;
+	}
+
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/DynamicVariableResolver.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/DynamicVariableResolver.java
@@ -17,10 +17,9 @@ package com.espressif.idf.debug.gdbjtag.openocd;
 import java.util.regex.Matcher;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.embedcdt.core.EclipseUtils;
 
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.PersistentPreferences;
-
-import org.eclipse.embedcdt.core.EclipseUtils;
 
 // Resolves variables from persistent preferences.
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -68,6 +68,7 @@ import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
+import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.Messages;
 
 /**
@@ -298,7 +299,8 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 		{
 			monitor = new NullProgressMonitor();
 		}
-		if (config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, "").isEmpty()) //$NON-NLS-1$
+		if (config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+				DefaultPreferences.PROGRAM_APP_DEFAULT).contentEquals(DefaultPreferences.PROGRAM_APP_DEFAULT))
 		{
 			setProgramNameAtr(config);
 		}
@@ -318,7 +320,7 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
 		if (!StringUtil.isEmpty(value))
 		{
-			programName = IDFConstants.BUILD_FOLDER + File.separator + value;
+			programName = IDFUtil.getBuildDir(project) + File.separator + value;
 		}
 		wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, programName);
 		wc.doSave();

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -16,7 +16,6 @@
 package com.espressif.idf.debug.gdbjtag.openocd.dsf;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -25,7 +24,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
 import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
 import org.eclipse.cdt.dsf.concurrent.Query;
@@ -42,7 +40,6 @@ import org.eclipse.cdt.dsf.gdb.service.command.IGDBControl;
 import org.eclipse.cdt.dsf.service.DsfServicesTracker;
 import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.cdt.utils.spawner.ProcessFactory;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -54,7 +51,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.ISourceLocator;
 import org.eclipse.embedcdt.core.StringUtils;
@@ -62,13 +58,8 @@ import org.eclipse.embedcdt.debug.gdbjtag.core.DebugUtils;
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.AbstractGnuMcuLaunchConfigurationDelegate;
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.GnuMcuServerServicesLaunchSequence;
 
-import com.espressif.idf.core.IDFConstants;
-import com.espressif.idf.core.util.GenericJsonReader;
-import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
-import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.Messages;
 
 /**
@@ -299,31 +290,11 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 		{
 			monitor = new NullProgressMonitor();
 		}
-		if (config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-				DefaultPreferences.PROGRAM_APP_DEFAULT).contentEquals(DefaultPreferences.PROGRAM_APP_DEFAULT))
-		{
-			setProgramNameAtr(config);
-		}
+
 		if (mode.equals(ILaunchManager.DEBUG_MODE) || mode.equals(ILaunchManager.RUN_MODE))
 		{
 			launchDebugger(config, launch, monitor);
 		}
-	}
-
-	private void setProgramNameAtr(ILaunchConfiguration config) throws CoreException
-	{
-		ILaunchConfigurationWorkingCopy wc = config.getWorkingCopy();
-		IProject project = config.getMappedResources()[0].getProject();
-		String programName = ""; //$NON-NLS-1$
-		GenericJsonReader jsonReader = new GenericJsonReader(
-				IDFUtil.getBuildDir(project) + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON);
-		String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
-		if (!StringUtil.isEmpty(value))
-		{
-			programName = IDFUtil.getBuildDir(project) + File.separator + value;
-		}
-		wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, programName);
-		wc.doSave();
 	}
 
 	private void launchDebugger(ILaunchConfiguration config, ILaunch launch, IProgressMonitor monitor)

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
@@ -14,12 +14,12 @@
 
 package com.espressif.idf.debug.gdbjtag.openocd.preferences;
 
+import org.eclipse.embedcdt.core.EclipseUtils;
+import org.eclipse.embedcdt.core.preferences.Discoverer;
+
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
-
-import org.eclipse.embedcdt.core.EclipseUtils;
-import org.eclipse.embedcdt.core.preferences.Discoverer;
 
 public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.preferences.DefaultPreferences {
 
@@ -92,6 +92,12 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// ------------------------------------------------------------------------
 
+	// C/C++ project variables
+
+	public static final String PROGRAM_APP_DEFAULT = "${default_app}"; //$NON-NLS-1$
+
+	// ------------------------------------------------------------------------
+
 	// HKCU & HKLM LOCAL_MACHINE
 	private static final String REG_SUBKEY = "\\GNU ARM Eclipse\\OpenOCD";
 	// Standard Microsoft recommendation.
@@ -132,6 +138,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// ------------------------------------------------------------------------
 
+	@Override
 	public String getExecutableName() {
 
 		String key = PersistentPreferences.EXECUTABLE_NAME;
@@ -143,6 +150,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 		return value;
 	}
 
+	@Override
 	public String getExecutableNameOs() {
 
 		String key = EclipseUtils.getKeyOs(PersistentPreferences.EXECUTABLE_NAME_OS);
@@ -154,6 +162,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 		return value;
 	}
 
+	@Override
 	public void putExecutableName(String value) {
 
 		String key = PersistentPreferences.EXECUTABLE_NAME;
@@ -166,6 +175,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// ------------------------------------------------------------------------
 
+	@Override
 	public String getInstallFolder() {
 
 		String key = PersistentPreferences.INSTALL_FOLDER;
@@ -182,6 +192,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 		return value;
 	}
 
+	@Override
 	public void putInstallFolder(String value) {
 
 		String key = PersistentPreferences.INSTALL_FOLDER;
@@ -194,6 +205,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// ------------------------------------------------------------------------
 
+	@Override
 	public String getSearchPath() {
 
 		String key = PersistentPreferences.SEARCH_PATH;
@@ -205,6 +217,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 		return value;
 	}
 
+	@Override
 	public String getSearchPathOs() {
 
 		String key = EclipseUtils.getKeyOs(PersistentPreferences.SEARCH_PATH_OS);
@@ -216,6 +229,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 		return value;
 	}
 
+	@Override
 	public void putSearchPath(String value) {
 
 		String key = PersistentPreferences.SEARCH_PATH;
@@ -228,6 +242,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// ------------------------------------------------------------------------
 
+	@Override
 	protected String getRegistryInstallFolder(String subFolder, String executableName) {
 
 		String path = Discoverer.getRegistryInstallFolder(executableName, subFolder, REG_SUBKEY, REG_NAME);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
@@ -58,6 +58,7 @@ public class Messages
 	public static String AppLvlTracingJob;
 
 	public static String DllNotFound_ExceptionMessage;
+	public static String TabMain_Launch_Config;
 	// ------------------------------------------------------------------------
 
 	static

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -25,12 +25,24 @@ import org.eclipse.cdt.core.settings.model.ICProjectDescription;
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.launch.ui.CMainTab2;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Link;
 
 import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.GenericJsonReader;
 import com.espressif.idf.core.util.IDFUtil;
@@ -39,7 +51,6 @@ import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 
 public class TabMain extends CMainTab2
 {
-
 	/**
 	 * If the preference is set to true, check program and disable Debug button if not found. The default GDB Hardware
 	 * Debug plug-in behaviour is to do not check program, to allow project-less debug sessions.
@@ -77,7 +88,6 @@ public class TabMain extends CMainTab2
 			config.rename(name);
 			renamed = true;
 
-			
 			IPath elfFilePath = IDFUtil.getELFFilePath(project);
 			IBinary[] bins = getBinaryFiles((ICProject) cElement);
 			if (bins != null)
@@ -123,11 +133,11 @@ public class TabMain extends CMainTab2
 		}
 	}
 
+	@Override
 	protected void updateProgramFromConfig(ILaunchConfiguration config)
 	{
-		if (fProgText != null && getCProject() != null)
+		if (fProgText != null)
 		{
-			IProject project = getCProject().getProject();
 			String programName = EMPTY_STRING;
 			try
 			{
@@ -138,12 +148,14 @@ public class TabMain extends CMainTab2
 				Logger.log(ce);
 			}
 
-			if (StringUtil.isEmpty(programName))
+			if (StringUtil.isEmpty(programName) && getCProject() != null)
 			{
 				try
 				{
+					IProject project = getCProject().getProject();
 					// project description file
-					GenericJsonReader jsonReader = new GenericJsonReader(IDFUtil.getBuildDir(project) + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON);
+					GenericJsonReader jsonReader = new GenericJsonReader(
+							IDFUtil.getBuildDir(project) + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON);
 					String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
 					if (!StringUtil.isEmpty(value))
 					{
@@ -157,6 +169,135 @@ public class TabMain extends CMainTab2
 
 			}
 			fProgText.setText(programName);
+		}
+	}
+
+	@Override
+	protected void createBuildConfigCombo(Composite parent, int colspan)
+	{
+
+		Composite comboComp = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout(2, false);
+		comboComp.setLayout(layout);
+		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		gd.horizontalSpan = colspan;
+		comboComp.setLayoutData(gd);
+		Link dlabel = new Link(comboComp, SWT.NONE);
+		dlabel.setText(Messages.TabMain_Launch_Config);
+
+		fBuildConfigCombo = new Combo(comboComp, SWT.READ_ONLY | SWT.DROP_DOWN);
+		fBuildConfigCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		fBuildConfigCombo.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				updateLaunchConfigurationDialog();
+			}
+		});
+
+	}
+
+	@Override
+	protected void updateBuildOptionFromConfig(ILaunchConfiguration config)
+	{
+		int buildBeforeLaunchValue = ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING;
+		try
+		{
+			buildBeforeLaunchValue = config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_BUILD_BEFORE_LAUNCH,
+					buildBeforeLaunchValue);
+			String configName = EMPTY_STRING;
+			configName = config.getAttribute(IDFLaunchConstants.ATTR_LAUNCH_CONFIGURATION_NAME, configName);
+			updateBuildConfigCombo(configName);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
+		if (fDisableBuildButton != null)
+			fDisableBuildButton.setSelection(
+					buildBeforeLaunchValue == ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_DISABLED);
+		if (fEnableBuildButton != null)
+			fEnableBuildButton.setSelection(
+					buildBeforeLaunchValue == ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_ENABLED);
+		if (fWorkspaceSettingsButton != null)
+			fWorkspaceSettingsButton.setSelection(
+					buildBeforeLaunchValue == ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING);
+	}
+
+	@Override
+	protected void updateBuildConfigCombo(String selectedConfigName)
+	{
+		fBuildConfigCombo.removeAll();
+		int offset = 0;
+		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+		try
+		{
+			ILaunchConfiguration[] configs = launchManager.getLaunchConfigurations(DebugPlugin.getDefault()
+					.getLaunchManager().getLaunchConfigurationType(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE));
+			for (ILaunchConfiguration config : configs)
+			{
+				IResource[] mappedResource = config.getMappedResources();
+				if (mappedResource != null
+						&& mappedResource[0].getProject().getName().contentEquals(fProjText.getText()))
+				{
+					fBuildConfigCombo.add(config.getName());
+					if (config.getName().contentEquals(selectedConfigName))
+					{
+						fBuildConfigCombo.select(offset);
+					}
+					offset += 1;
+				}
+			}
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		if (fBuildConfigCombo.getText().isBlank())
+		{
+			fBuildConfigCombo.select(0);
+		}
+
+	}
+
+	@Override
+	public void performApply(ILaunchConfigurationWorkingCopy config)
+	{
+		config.setAttribute(IDFLaunchConstants.ATTR_LAUNCH_CONFIGURATION_NAME, fBuildConfigCombo.getText());
+		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_BUILD_CONFIG_ID, AUTO_CONFIG);
+		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_BUILD_CONFIG_AUTO, true);
+		if (fDisableBuildButton != null)
+		{
+			int buildBeforeLaunchValue = ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING;
+			if (fDisableBuildButton.getSelection())
+			{
+				buildBeforeLaunchValue = ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_DISABLED;
+			}
+			else if (fEnableBuildButton.getSelection())
+			{
+				buildBeforeLaunchValue = ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_ENABLED;
+			}
+			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_BUILD_BEFORE_LAUNCH, buildBeforeLaunchValue);
+		}
+
+		ICProject cProject = this.getCProject();
+		if (cProject != null && cProject.exists())
+		{
+			config.setMappedResources(new IResource[] { cProject.getProject() });
+		}
+		else
+		{
+			config.setMappedResources(null);
+		}
+
+		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText());
+		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, fProgText.getText());
+		if (fCoreText != null)
+		{
+			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_COREFILE_PATH, fCoreText.getText());
+			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_DEBUGGER_POST_MORTEM_TYPE, getSelectedCoreType());
 		}
 	}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -15,8 +15,6 @@
 
 package com.espressif.idf.debug.gdbjtag.openocd.ui;
 
-import java.io.File;
-
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.core.model.ICElement;
@@ -41,13 +39,11 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Link;
 
-import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.GenericJsonReader;
 import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
+import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 
 public class TabMain extends CMainTab2
 {
@@ -109,9 +105,6 @@ public class TabMain extends CMainTab2
 
 		if (binary != null)
 		{
-			String path;
-			path = binary.getResource().getProjectRelativePath().toOSString();
-			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, path);
 			if (!renamed)
 			{
 				String name = binary.getElementName();
@@ -141,33 +134,15 @@ public class TabMain extends CMainTab2
 			String programName = EMPTY_STRING;
 			try
 			{
-				programName = config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, EMPTY_STRING);
+				programName = config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+						DefaultPreferences.PROGRAM_APP_DEFAULT);
+				programName = programName.isBlank() ? DefaultPreferences.PROGRAM_APP_DEFAULT : programName;
 			}
 			catch (CoreException ce)
 			{
 				Logger.log(ce);
 			}
 
-			if (StringUtil.isEmpty(programName) && getCProject() != null)
-			{
-				try
-				{
-					IProject project = getCProject().getProject();
-					// project description file
-					GenericJsonReader jsonReader = new GenericJsonReader(
-							IDFUtil.getBuildDir(project) + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON);
-					String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
-					if (!StringUtil.isEmpty(value))
-					{
-						programName = IDFUtil.getBuildDir(project) + File.separator + value;
-					}
-				}
-				catch (CoreException e)
-				{
-					Logger.log(e);
-				}
-
-			}
 			fProgText.setText(programName);
 		}
 	}
@@ -300,5 +275,4 @@ public class TabMain extends CMainTab2
 			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_DEBUGGER_POST_MORTEM_TYPE, getSelectedCoreType());
 		}
 	}
-
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -268,7 +268,8 @@ public class TabMain extends CMainTab2
 		}
 
 		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText());
-		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, fProgText.getText());
+		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+				fProgText.getText().isBlank() ? DefaultPreferences.PROGRAM_APP_DEFAULT : fProgText.getText());
 		if (fCoreText != null)
 		{
 			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_COREFILE_PATH, fCoreText.getText());

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -159,7 +159,7 @@ public class TabMain extends CMainTab2
 					String value = jsonReader.getValue("app_elf"); //$NON-NLS-1$
 					if (!StringUtil.isEmpty(value))
 					{
-						programName = IDFConstants.BUILD_FOLDER + File.separator + value;
+						programName = IDFUtil.getBuildDir(project) + File.separator + value;
 					}
 				}
 				catch (CoreException e)

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
@@ -399,3 +399,4 @@ DebugConfigurationNotFoundMsg=No matching debug configuration was found for the 
 AppLvlTracingJob=Launching application level tracing
 
 DllNotFound_ExceptionMessage=some required DLL(s) not found
+TabMain_Launch_Config=Launch Configuration:

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
@@ -11,9 +11,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.debug.core.ILaunchConfiguration;
 
 import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.EspConfigParser;
@@ -24,6 +27,9 @@ public class ESPFlashUtil {
 	private static final int OPENOCD_JTAG_FLASH_SUPPORT_V = 20201125;
 	public static final String VERSION_PATTERN = "(v.\\S+)"; //$NON-NLS-1$
 	public static final String SERIAL_PORT = "${serial_port}"; //$NON-NLS-1$
+
+	private ESPFlashUtil() {
+	}
 
 	/**
 	 * @param launch
@@ -60,8 +66,15 @@ public class ESPFlashUtil {
 	public static String getEspJtagFlashCommand(ILaunchConfiguration configuration) {
 		String espFlashCommand = "-c program_esp_bins <path-to-build-dir> flasher_args.json verify reset"; //$NON-NLS-1$
 		try {
-			String buildPath = configuration.getMappedResources()[0].getProject().getFolder(IDFConstants.BUILD_FOLDER)
-					.getLocationURI().getPath();
+
+			String buildPath = configuration.getMappedResources()[0].getProject()
+					.getPersistentProperty(new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY));
+			// converting to UNIX path so openocd could read it
+			buildPath = new Path(buildPath).toString();
+
+			buildPath = buildPath.isBlank() ? configuration.getMappedResources()[0].getProject()
+					.getFolder(IDFConstants.BUILD_FOLDER).getLocationURI().getPath() : buildPath;
+
 			char a = buildPath.charAt(2);
 			if (a == ':') {
 				buildPath = buildPath.substring(1);


### PR DESCRIPTION
## Description

Fixed jtag flashing issue with custom build folder by modifying ESPFlashUtil class and getting custom build folder from project. Also, I've added a Launch Config selector to the main debug config tab, making the build process more intuitive with the debug config. Essentially, we are linking our run configuration to the debug configuration so that we can get all the necessary build settings: 
![image](https://user-images.githubusercontent.com/24419842/231255871-5efe6330-b52b-49ff-90d2-5d96c44fc587.png)


Fixes # ([IEP-927](https://jira.espressif.com:8443/browse/IEP-927))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Test 1:
- create a new project
- select the custom build folder
- create a new debug configuration
- debug the project

Test 2:
- full clean the project
- create more launch configurations with different settings (build folders, different targets)
- jtag flash, then debug with different launch configurations set in debugger main tab

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

-  Build process
-  Debug
-  Debug configuration, main tab

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
