### PR TITLE
IEP-950 `Variables...` button doesn't work for Arguments group

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -40,6 +40,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.StringVariableSelectionDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ILabelProvider;
@@ -181,18 +182,25 @@ public class CMakeMainTab2 extends GenericMainTab {
 		composite.setLayout(layout);
 		composite.setLayoutData(gridData);
 		composite.setFont(parent.getFont());
-
-		argumentVariablesButton = createPushButton(composite, Messages.CMakeMainTab2_Variables, null);
-		argumentVariablesButton.addSelectionListener(fListener);
-		addControlAccessibleListener(argumentVariablesButton, argumentVariablesButton.getText()); // need to strip the
-																									// mnemonic from
-																									// buttons
-
+		Button argumentVariablesButton = createPushButton(composite, Messages.CMakeMainTab2_Variables, null);
+		argumentVariablesButton.addListener(SWT.Selection, e -> handleVariablesButtonSelected(argumentField));
 		Label instruction = new Label(group, SWT.NONE);
 		instruction.setText(Messages.CMakeMainTab2_Note);
 		gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
 		gridData.horizontalSpan = 2;
 		instruction.setLayoutData(gridData);
+	}
+
+	private void handleVariablesButtonSelected(Text textField) {
+		String variable = getVariable();
+		if (variable != null)
+			textField.insert(variable);
+	}
+
+	private String getVariable() {
+		StringVariableSelectionDialog dialog = new StringVariableSelectionDialog(getShell());
+		dialog.open();
+		return dialog.getVariableExpression();
 	}
 
 	protected void createUartComposite(Composite parent) {


### PR DESCRIPTION
## Description

fixed `Variables...` button listener for Arguments group

Fixes # ([IEP-950](https://jira.espressif.com:8443/browse/IEP-950))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
Test 1:
- Edit launch configuration -> click on Variables... button near the Arguments field
- Select any variable
- Variable should be insert into text field
Test 2:
- Repeat Test 1 with different Flash Over (JTAG, UART, DFU)
Test 3:
- OK and reopen

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch configuration

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
