### PR TITLE
IEP-951 MESSAGE Error:... "configuration" is null when restart eclipse

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigProvider.java
@@ -28,7 +28,7 @@ public class SerialFlashLaunchConfigProvider extends IDFCoreLaunchConfigProvider
 
 	@Override
 	public boolean supports(ILaunchDescriptor descriptor, ILaunchTarget target) throws CoreException {
-		return target.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE);
+		return target != null && target.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE);
 	}
 
 	@Override


### PR DESCRIPTION
## Description
added check for a null target for supports() method

Fixes # ([IEP-951](https://jira.espressif.com:8443/browse/IEP-951))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1:
- restart eclipse, check log -> shouldn't be a message:!MESSAGE Error: Cannot invoke "org.eclipse.debug.core.ILaunchConfiguration.getType()" because "configuration" is null 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- target bar

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
