### PR TITLE
IEP-956: JGIT EGIT failing to load due to missing slf4j with latest release

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -64,6 +64,8 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
+			<unit id="org.slf4j.api" version="0.0.0"/>
+			<unit id="org.slf4j.binding.simple" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/egit/updates" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
## Description

Added the required slf4j api for the resolution of errors related to egit

Fixes # ([IEP-956](https://jira.espressif.com:8443/browse/IEP-956))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Building locally and seeing if any errors are seen at the start related to IDE.

**Test Configuration**:
* OS (Windows,Linux and macOS): Windows

## Checklist
- [x] PR Self Reviewed

