### PR TITLE
IEP-962 Test coverage for OutputStreamThread

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/logging/Logger.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/logging/Logger.java
@@ -54,6 +54,8 @@ public class Logger
 
 	public static void log(Plugin plugin, Exception e)
 	{
+		if (plugin == null)
+			return;
 		if (e instanceof CoreException)
 		{
 			plugin.getLog().log(((CoreException) e).getStatus());

--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Espressif Systems
 Automatic-Module-Name: com.espressif.idf.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
- com.espressif.idf.core;bundle-version="1.0.1"
+ com.espressif.idf.core;bundle-version="1.0.1",
+ junit-jupiter-api
 Bundle-ClassPath: .,
  lib/jmock-2.12.0.jar,
  lib/commons-collections4-4.4.jar,

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/OutputStreamThreadTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/OutputStreamThreadTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,14 +17,14 @@ class OutputStreamThreadTest
 	private static final String TEST_INPUT = "Test, Input";
 
 	@Test
-	public void testOutputStreamThreadShouldWriteContentToOutputStream() throws IOException, InterruptedException
+	public void testOutputStreamThreadShouldWriteContentToOutputStream()
 	{
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
 		OutputStreamThread thread = new OutputStreamThread(outputStream, TEST_INPUT, UTF_8);
 		thread.run();
 
-		String actualOutput = new String(outputStream.toByteArray(), UTF_8);
+		String actualOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
 		assertEquals(TEST_INPUT, actualOutput);
 	}
 
@@ -43,9 +43,7 @@ class OutputStreamThreadTest
 	@Test
 	void testOutputStreamThreadWithNullOutputStreamShouldThrowException()
 	{
-		assertThrows(IllegalArgumentException.class, () -> {
-			new OutputStreamThread(null, TEST_INPUT, UTF_8);
-		});
+		assertThrows(IllegalArgumentException.class, () -> new OutputStreamThread(null, TEST_INPUT, UTF_8));
 	}
 
 	@Test
@@ -53,20 +51,18 @@ class OutputStreamThreadTest
 	{
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-		assertThrows(IllegalArgumentException.class, () -> {
-			new OutputStreamThread(outputStream, null, UTF_8);
-		});
+		assertThrows(IllegalArgumentException.class, () -> new OutputStreamThread(outputStream, null, UTF_8));
 	}
 
 	@Test
-	void testOutputStreamShouldBeEmptyIfIncorrectCharsetSent() throws IOException, InterruptedException
+	void testOutputStreamShouldBeEmptyIfIncorrectCharsetSent()
 	{
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		OutputStreamThread thread = new OutputStreamThread(outputStream, TEST_INPUT, "incorrectCharset");
 
 		thread.run();
 
-		String actualOutput = new String(outputStream.toByteArray(), UTF_8);
+		String actualOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
 		assertEquals("", actualOutput);
 
 	}

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/OutputStreamThreadTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/OutputStreamThreadTest.java
@@ -1,0 +1,73 @@
+package com.espressif.idf.core.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.espressif.idf.core.OutputStreamThread;
+
+class OutputStreamThreadTest
+{
+
+	private static final String UTF_8 = "UTF-8";
+	private static final String TEST_INPUT = "Test, Input";
+
+	@Test
+	public void testOutputStreamThreadShouldWriteContentToOutputStream() throws IOException, InterruptedException
+	{
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+		OutputStreamThread thread = new OutputStreamThread(outputStream, TEST_INPUT, UTF_8);
+		thread.run();
+
+		String actualOutput = new String(outputStream.toByteArray(), UTF_8);
+		assertEquals(TEST_INPUT, actualOutput);
+	}
+
+	@Test
+	void testOutputStreamThreadWithDefaultCharsetShouldWriteContentToOutputStream()
+	{
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+		OutputStreamThread thread = new OutputStreamThread(outputStream, TEST_INPUT, null);
+		thread.run();
+
+		String actualOutput = new String(outputStream.toByteArray());
+		assertEquals(TEST_INPUT, actualOutput);
+	}
+
+	@Test
+	void testOutputStreamThreadWithNullOutputStreamShouldThrowException()
+	{
+		assertThrows(IllegalArgumentException.class, () -> {
+			new OutputStreamThread(null, TEST_INPUT, UTF_8);
+		});
+	}
+
+	@Test
+	void testOutputStreamThreadWithNullContentStreamShouldThrowException()
+	{
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+		assertThrows(IllegalArgumentException.class, () -> {
+			new OutputStreamThread(outputStream, null, UTF_8);
+		});
+	}
+
+	@Test
+	void testOutputStreamShouldBeEmptyIfIncorrectCharsetSent() throws IOException, InterruptedException
+	{
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		OutputStreamThread thread = new OutputStreamThread(outputStream, TEST_INPUT, "incorrectCharset");
+
+		thread.run();
+
+		String actualOutput = new String(outputStream.toByteArray(), UTF_8);
+		assertEquals("", actualOutput);
+
+	}
+}


### PR DESCRIPTION
## Description

test coverage for OutputStreamThread class

Fixes # ([IEP-962](https://jira.espressif.com:8443/browse/IEP-962))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?
No changes in code, so just run JUnit tests;

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- Junit tests

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
