### PR TITLE
IEP-952: Espressif IDE popup for old tool versions popping up after installing tools via IDE

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -17,5 +17,5 @@ CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource.
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
 IncreasePartitionSizeTitle=Low Application Partition Size
 IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
-ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file
-ToolsInitializationDifferentPathMessageBoxMessage=A different IDF path was found in the startup configuration file do you want to install the tools in this path or keep the older path\nNew Path: {0}\nOld Path: {1}
+ToolsInitializationDifferentPathMessageBoxTitle=Startup esp_idf.json file is updated.
+ToolsInitializationDifferentPathMessageBoxMessage=esp_idf.json file is updated on {0}.\nThis can happen if you have updated the IDE using a newer version of installer or have modified the file yourself.\nDo you want to initialize current workspace environment using that?

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -17,5 +17,5 @@ CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource.
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
 IncreasePartitionSizeTitle=Low Application Partition Size
 IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
-ToolsInitializationDifferentPathMessageBoxTitle=Startup esp_idf.json file is updated.
-ToolsInitializationDifferentPathMessageBoxMessage=esp_idf.json file is updated on {0}.\nThis can happen if you have updated the IDE using a newer version of installer or have modified the file yourself.\nDo you want to initialize current workspace environment using that?
+ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file
+ToolsInitializationDifferentPathMessageBoxMessage=A different IDF path was found in the startup configuration file do you want to install the tools in this path or keep the older path\nNew Path: {0}\nOld Path: {1}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -10,7 +10,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
+import java.text.DateFormat;
 import java.text.MessageFormat;
+import java.util.Date;
 
 import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -56,10 +58,8 @@ public class InitializeToolsStartup implements IStartup
 	private static final String IDF_INSTALLED_LIST_KEY = "idfInstalled"; //$NON-NLS-1$
 	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
-	private static final String IS_INSTALLER_CONFIG_SET = "isInstallerConfigSet"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
-
-	private String newIdfPath;
+	private static final String LAST_MODIFIED_ESP_IDF_JSON_FILE = "lastModifed-esp_idf.json"; //$NON-NLS-1$
 
 	@Override
 	public void earlyStartup()
@@ -99,27 +99,19 @@ public class InitializeToolsStartup implements IStartup
 			Logger.log(MessageFormat.format("esp-idf.json file doesn't exist at this location: '{0}'", url.getPath()));
 			return;
 		}
-		else if (isInstallerConfigSet())
+		else if (isConfigFileUpdated(idf_json_file))
 		{
-			checkForUpdatedVersion(idf_json_file);
-			if (isInstallerConfigSet())
-			{
-				Logger.log("Ignoring esp_idf.json settings as it was configured earilier and idf_path is similar.");
-				return;
-			}
-
-			IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
 			Display.getDefault().syncExec(() -> {
 				Shell shell = new Shell(Display.getDefault());
 				MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.YES | SWT.NO);
 				messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
 				messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage,
-						newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
+						getFormattedDateAndTime(idf_json_file.lastModified())));
 				int response = messageBox.open();
 				if (response == SWT.NO)
 				{
 					Preferences prefs = getPreferences();
-					prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
+					prefs.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
 					try
 					{
 						prefs.flush();
@@ -134,7 +126,11 @@ public class InitializeToolsStartup implements IStartup
 			});
 		}
 
-		// read esp-idf.json file
+		updateEnvUsingIdfJsonFile(idf_json_file);
+	}
+
+	private void updateEnvUsingIdfJsonFile(File idf_json_file)
+	{
 		JSONParser parser = new JSONParser();
 		try
 		{
@@ -163,6 +159,7 @@ public class InitializeToolsStartup implements IStartup
 
 					Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 					scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
+					scopedPreferenceStore.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
 					try
 					{
 						scopedPreferenceStore.flush();
@@ -173,19 +170,6 @@ public class InitializeToolsStartup implements IStartup
 					}
 				}
 			}
-
-			// save state
-			Preferences prefs = getPreferences();
-			prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
-			try
-			{
-				prefs.flush();
-			}
-			catch (BackingStoreException e)
-			{
-				Logger.log(e);
-			}
-
 		}
 		catch (
 				IOException
@@ -195,44 +179,11 @@ public class InitializeToolsStartup implements IStartup
 		}
 	}
 
-	private void checkForUpdatedVersion(File idf_json_file)
+	private boolean isConfigFileUpdated(File idfJsonFile)
 	{
-		// read esp-idf.json file
-		JSONParser parser = new JSONParser();
-		try (FileReader reader = new FileReader(idf_json_file))
-		{
-			JSONObject jsonObj = (JSONObject) parser.parse(reader);
-			String idfVersionId = (String) jsonObj.get(IDF_VERSIONS_ID);
-			JSONObject list = (JSONObject) jsonObj.get(IDF_INSTALLED_LIST_KEY);
-			if (list == null)
-			{
-				return;
-			}
-			// selected esp-idf version information
-			JSONObject selectedIDFInfo = (JSONObject) list.get(idfVersionId);
-			String idfPath = (String) selectedIDFInfo.get(IDF_PATH);
-			IDFEnvironmentVariables idfEnvMgr = new IDFEnvironmentVariables();
-			if (idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH).equals(idfPath))
-				return;
-			newIdfPath = idfPath;
-			Preferences prefs = getPreferences();
-			prefs.putBoolean(IS_INSTALLER_CONFIG_SET, false);
-			try
-			{
-				prefs.flush();
-			}
-			catch (BackingStoreException e)
-			{
-				Logger.log(e);
-			}
-		}
-		catch (
-				IOException
-				| ParseException e)
-		{
-			Logger.log(e);
-		}
-
+		long currentFileLastModified = idfJsonFile.lastModified();
+		long lastModifiedDateInPrefStore = getPreferences().getLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, -1);
+		return currentFileLastModified > lastModifiedDateInPrefStore;
 	}
 
 	private Preferences getPreferences()
@@ -240,8 +191,10 @@ public class InitializeToolsStartup implements IStartup
 		return InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 	}
 
-	private boolean isInstallerConfigSet()
+	private String getFormattedDateAndTime(long timestamp)
 	{
-		return getPreferences().getBoolean(IS_INSTALLER_CONFIG_SET, false);
+		Date date = new Date(timestamp);
+		DateFormat dateFormat = DateFormat.getDateTimeInstance();
+		return dateFormat.format(date);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -59,7 +59,7 @@ public class InitializeToolsStartup implements IStartup
 	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
-	private static final String LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP = "esp_idf_json_lastmodified_timestamp"; //$NON-NLS-1$
+	private static final String LAST_MODIFIED_ESP_IDF_JSON_FILE = "lastModifed-esp_idf.json"; //$NON-NLS-1$
 
 	@Override
 	public void earlyStartup()
@@ -111,7 +111,7 @@ public class InitializeToolsStartup implements IStartup
 				if (response == SWT.NO)
 				{
 					Preferences prefs = getPreferences();
-					prefs.putLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, idf_json_file.lastModified());
+					prefs.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
 					try
 					{
 						prefs.flush();
@@ -123,12 +123,10 @@ public class InitializeToolsStartup implements IStartup
 
 					return;
 				}
-				else 
-				{
-					updateEnvUsingIdfJsonFile(idf_json_file);
-				}
 			});
 		}
+
+		updateEnvUsingIdfJsonFile(idf_json_file);
 	}
 
 	private void updateEnvUsingIdfJsonFile(File idf_json_file)
@@ -161,7 +159,7 @@ public class InitializeToolsStartup implements IStartup
 
 					Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 					scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
-					scopedPreferenceStore.putLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, idf_json_file.lastModified());
+					scopedPreferenceStore.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
 					try
 					{
 						scopedPreferenceStore.flush();
@@ -184,7 +182,7 @@ public class InitializeToolsStartup implements IStartup
 	private boolean isConfigFileUpdated(File idfJsonFile)
 	{
 		long currentFileLastModified = idfJsonFile.lastModified();
-		long lastModifiedDateInPrefStore = getPreferences().getLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, -1);
+		long lastModifiedDateInPrefStore = getPreferences().getLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, -1);
 		return currentFileLastModified > lastModifiedDateInPrefStore;
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -59,7 +59,7 @@ public class InitializeToolsStartup implements IStartup
 	private static final String PYTHON_PATH = "python"; //$NON-NLS-1$
 	private static final String IDF_PATH = "path"; //$NON-NLS-1$
 	private static final String DOC_URL = "\"https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables\""; //$NON-NLS-1$
-	private static final String LAST_MODIFIED_ESP_IDF_JSON_FILE = "lastModifed-esp_idf.json"; //$NON-NLS-1$
+	private static final String LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP = "esp_idf_json_lastmodified_timestamp"; //$NON-NLS-1$
 
 	@Override
 	public void earlyStartup()
@@ -111,7 +111,7 @@ public class InitializeToolsStartup implements IStartup
 				if (response == SWT.NO)
 				{
 					Preferences prefs = getPreferences();
-					prefs.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
+					prefs.putLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, idf_json_file.lastModified());
 					try
 					{
 						prefs.flush();
@@ -123,10 +123,12 @@ public class InitializeToolsStartup implements IStartup
 
 					return;
 				}
+				else 
+				{
+					updateEnvUsingIdfJsonFile(idf_json_file);
+				}
 			});
 		}
-
-		updateEnvUsingIdfJsonFile(idf_json_file);
 	}
 
 	private void updateEnvUsingIdfJsonFile(File idf_json_file)
@@ -159,7 +161,7 @@ public class InitializeToolsStartup implements IStartup
 
 					Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 					scopedPreferenceStore.putBoolean(InstallToolsHandler.INSTALL_TOOLS_FLAG, true);
-					scopedPreferenceStore.putLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, idf_json_file.lastModified());
+					scopedPreferenceStore.putLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, idf_json_file.lastModified());
 					try
 					{
 						scopedPreferenceStore.flush();
@@ -182,7 +184,7 @@ public class InitializeToolsStartup implements IStartup
 	private boolean isConfigFileUpdated(File idfJsonFile)
 	{
 		long currentFileLastModified = idfJsonFile.lastModified();
-		long lastModifiedDateInPrefStore = getPreferences().getLong(LAST_MODIFIED_ESP_IDF_JSON_FILE, -1);
+		long lastModifiedDateInPrefStore = getPreferences().getLong(LAST_MODIFIED_ESP_IDF_JSON_TIMESTAMP, -1);
 		return currentFileLastModified > lastModifiedDateInPrefStore;
 	}
 


### PR DESCRIPTION
## Description

Checking the esp_idf.json timestamp for env initialization

Fixes # ([IEP-952](https://jira.espressif.com:8443/browse/IEP-952))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Use the tests in the following PR (https://github.com/espressif/idf-eclipse-plugin/pull/662). 
Also try to install the tools in the IDE after the IDE is initialized via esp_idf.json file and try to close and reopen the IDE to see if the message popup appears. The original jira ticket also contains links to the forum and github issues.

**Test Configuration**:
* ESP-IDF Version: Any
* OS (Windows,Linux and macOS): Windows only (Since installer is currently given for Windows only)

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
