### PR TITLE
IEP-966 openocd server always has default timeout 25 seconds

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/GdbServerBackend.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/GdbServerBackend.java
@@ -25,9 +25,9 @@ import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.GnuMcuGdbServerBackend;
 import org.osgi.framework.BundleContext;
 
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
-import com.espressif.idf.ui.UIPlugin;
 
 public class GdbServerBackend extends GnuMcuGdbServerBackend {
 
@@ -139,7 +139,8 @@ public class GdbServerBackend extends GnuMcuGdbServerBackend {
 
 	@Override
 	public int getServerLaunchTimeoutSeconds() {
-		return Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, Activator.GDB_SERVER_LAUNCH_TIMEOUT, fGdbServerLaunchDefaultTimeout, null);
+		return Platform.getPreferencesService().getInt(IDFCorePlugin.PLUGIN_ID, Activator.GDB_SERVER_LAUNCH_TIMEOUT,
+				fGdbServerLaunchDefaultTimeout, null);
 	}
 
 	public String getServerName() {

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/LocalTerminal.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.Platform;
 
-import com.espressif.idf.ui.UIPlugin;
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.ui.preferences.EspresssifPreferencesPage;
 import com.pty4j.PtyProcess;
 import com.pty4j.PtyProcessBuilder;
@@ -33,8 +33,12 @@ public class LocalTerminal
 	public Process connect() throws IOException
 	{
 		String[] args = arguments.toArray(new String[arguments.size()]);
-		int numberOfRows =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_LINES, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null);
-		int numberOfCols =  Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_CHARS_IN_A_LINE, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);
+		int numberOfRows = Platform.getPreferencesService().getInt(IDFCorePlugin.PLUGIN_ID,
+				EspresssifPreferencesPage.NUMBER_OF_LINES,
+				EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null);
+		int numberOfCols = Platform.getPreferencesService().getInt(IDFCorePlugin.PLUGIN_ID,
+				EspresssifPreferencesPage.NUMBER_OF_CHARS_IN_A_LINE,
+				EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);
 		PtyProcessBuilder ptyProcessBuilder = new PtyProcessBuilder(args).setEnvironment(environment)
 				.setDirectory(workingDir.getAbsolutePath()).setInitialColumns(numberOfCols).setInitialRows(numberOfRows)
 				.setConsole(false).setCygwin(false).setLogFile(null);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -1,5 +1,7 @@
 package com.espressif.idf.ui.preferences;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -13,9 +15,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFCorePreferenceConstants;
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.ui.UIPlugin;
 
 public class EspresssifPreferencesPage extends PreferencePage implements IWorkbenchPreferencePage
 {
@@ -34,7 +36,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	public EspresssifPreferencesPage()
 	{
 		super();
-		setPreferenceStore(UIPlugin.getDefault().getPreferenceStore());
+		setPreferenceStore(new ScopedPreferenceStoreWithoutDefaults(InstanceScope.INSTANCE, IDFCorePlugin.PLUGIN_ID));
 		setDescription(Messages.EspresssifPreferencesPage_IDFSpecificPrefs);
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -1,7 +1,5 @@
 package com.espressif.idf.ui.preferences;
 
-import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -16,8 +14,8 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import com.espressif.idf.core.IDFCorePreferenceConstants;
-import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.ui.UIPlugin;
 
 public class EspresssifPreferencesPage extends PreferencePage implements IWorkbenchPreferencePage
 {
@@ -26,7 +24,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	public static final String NUMBER_OF_CHARS_IN_A_LINE = "numberOfCharsInALine"; //$NON-NLS-1$
 	public static final int DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES = 1000;
 	public static final int DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE = 500;
-	
+
 	private static final String GDB_SERVER_LAUNCH_TIMEOUT = "fGdbServerLaunchTimeout"; //$NON-NLS-1$
 	private Text numberOfCharsInLineText;
 	private Text numberLineText;
@@ -36,20 +34,19 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	public EspresssifPreferencesPage()
 	{
 		super();
-		setPreferenceStore(new ScopedPreferenceStoreWithoutDefaults(InstanceScope.INSTANCE, IDFCorePlugin.PLUGIN_ID));
+		setPreferenceStore(UIPlugin.getDefault().getPreferenceStore());
 		setDescription(Messages.EspresssifPreferencesPage_IDFSpecificPrefs);
 	}
 
 	@Override
 	public void init(IWorkbench workbench)
 	{
+		initializeDefaults();
 	}
 
 	@Override
 	protected Control createContents(Composite parent)
 	{
-		initializeDefaults();
-
 		Composite mainComposite = new Composite(parent, SWT.NONE);
 		GridLayout gridLayout = new GridLayout();
 		gridLayout.numColumns = 1;
@@ -62,7 +59,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		mainComposite.setLayoutData(data);
 
 		addccacheControl(mainComposite);
-		
+
 		addGdbSettings(mainComposite);
 
 		addSerialSettings(mainComposite);
@@ -133,7 +130,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 
 			int numberOfLines = Integer.parseInt(numberLineText.getText());
 			getPreferenceStore().setValue(NUMBER_OF_LINES, numberOfLines);
-			
+
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, ccacheBtn.getSelection());
 		}
 		catch (Exception e)
@@ -149,7 +146,8 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	{
 		gdbSettingsText.setText(Integer.toString(getPreferenceStore().getDefaultInt(GDB_SERVER_LAUNCH_TIMEOUT)));
 		numberLineText.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_LINES)));
-		numberOfCharsInLineText.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_CHARS_IN_A_LINE)));
+		numberOfCharsInLineText
+				.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_CHARS_IN_A_LINE)));
 		ccacheBtn.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS));
 	}
 
@@ -158,6 +156,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		getPreferenceStore().setDefault(GDB_SERVER_LAUNCH_TIMEOUT, 25);
 		getPreferenceStore().setDefault(NUMBER_OF_CHARS_IN_A_LINE, DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE);
 		getPreferenceStore().setDefault(NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES);
-		getPreferenceStore().setDefault(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, IDFCorePreferenceConstants.CMAKE_CCACHE_DEFAULT_STATUS);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS,
+				IDFCorePreferenceConstants.CMAKE_CCACHE_DEFAULT_STATUS);
 	}
 }


### PR DESCRIPTION
## Description

Our usage for espressif preference page values looks like this:
1. `Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, Activator.GDB_SERVER_LAUNCH_TIMEOUT, fGdbServerLaunchDefaultTimeout, null);
`
2. `int numberOfRows = Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_LINES, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES, null); `

3. `int numberOfCols = Platform.getPreferencesService().getInt(UIPlugin.PLUGIN_ID, EspresssifPreferencesPage.NUMBER_OF_CHARS_IN_A_LINE, EspresssifPreferencesPage.DEFAULT_SERIAL_MONITOR_NUMBER_OF_CHARS_IN_LINE, null);`
Fixes # ([IEP-966](https://jira.espressif.com:8443/browse/IEP-966))

changed preference store for the Espressif preference page accordingly to these calls;
## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
Test 1:
- Set different values on Espressif Preference page
- restart eclipse
- open espressif preference page -> values must be the same as it was after the saving

Test 2:
- change server launch timeout -> try to debug application -> see if server timeout has an effect
- change serial monitor setting
- enable/disable cmake cache 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Espressif preference page and related components (Debug, Terminal, Build)

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
