### PR TITLE
IEP-976 Test coverage for BigIntDecoder

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/BigIntDecoder.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/BigIntDecoder.java
@@ -45,7 +45,7 @@ public class BigIntDecoder
 		}
 
 		return hasSign ? new BigInteger(firstChar + stringToDecode.substring(index), radix)
-				: new BigInteger(stringToDecode.substring(index));
+				: new BigInteger(stringToDecode.substring(index), radix);
 	}
 
 }

--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Espressif Systems
 Automatic-Module-Name: com.espressif.idf.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
- com.espressif.idf.core;bundle-version="1.0.1"
+ com.espressif.idf.core;bundle-version="1.0.1",
+ junit-jupiter-api
 Bundle-ClassPath: .,
  lib/jmock-2.12.0.jar,
  lib/commons-collections4-4.4.jar,
@@ -65,3 +66,5 @@ Export-Package: com.espressif.idf.core.test,
  org.jmock.api,
  org.jmock.auto,
  org.jmock.lib
+Import-Package: org.junit.jupiter.params,
+ org.junit.jupiter.params.provider

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/BigIntDecoderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/BigIntDecoderTest.java
@@ -56,6 +56,15 @@ public class BigIntDecoderTest
 	}
 
 	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "#A3F, 2623", "#A3F, 2623", "#AA, 170", "#FF, 255" })
+	void test_decode_positive_hexadecimal_hash_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
 	@CsvSource({ "+0xA3F, 2623", "+0XA3F, 2623", "+0xAA, 170", "+0XFF, 255" })
 	void test_decode_positive_with_sign_hexadecimal_number(String stringToDecode, int expectedResult)
 	{

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/BigIntDecoderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/BigIntDecoderTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util.test;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.espressif.idf.core.util.BigIntDecoder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BigIntDecoderTest
+{
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "12345, 12345", "234, 234", "564, 564" })
+	void test_decode_positive_dec_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "+12345, 12345", "+234, 234", "+564, 564" })
+	void test_decode_positive_dec_with_sign_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "-12345, -12345", "-234, -234", "-564, -564" })
+	void test_decode_negative_dec_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "0xA3F, 2623", "0XA3F, 2623", "0xAA, 170", "0XFF, 255" })
+	void test_decode_positive_hexadecimal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "+0xA3F, 2623", "+0XA3F, 2623", "+0xAA, 170", "+0XFF, 255" })
+	void test_decode_positive_with_sign_hexadecimal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "-0xA3F, -2623", "-0XA3F, -2623", "-0xAA, -170", "-0XFF, -255" })
+	void test_decode_negative_hexadecimal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "017, 15", "023, 19", "075, 61", "0127, 87", "0456, 302" })
+	void test_decode_positive_octal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "+017, 15", "+023, 19", "+075, 61", "+0127, 87", "+0456, 302" })
+	void test_decode_positive_with_sign_octal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+	@ParameterizedTest(name = "value ''{0}'' decoded to {1}")
+	@CsvSource({ "-017, -15", "-023, -19", "-075, -61", "-0127, -87", "-0456, -302" })
+	void test_decode_negative_octal_number(String stringToDecode, int expectedResult)
+	{
+		BigInteger decodedNumber = BigIntDecoder.decode(stringToDecode);
+
+		Assertions.assertEquals(expectedResult, decodedNumber.intValue());
+	}
+
+
+	@Test
+	void test_decode_invalid_number()
+	{
+		String stringToDecode = "12AB";
+
+		Assertions.assertThrows(NumberFormatException.class, () -> BigIntDecoder.decode(stringToDecode));
+	}
+}


### PR DESCRIPTION
## Description

Added test coverage for BigIntDecoder class. Also, during the test I found bug, so I fixed it in this PR. The bug was in the incorrect decoding of hex, and octal values without a sign.

Fixes # ([IEP-976](https://jira.espressif.com:8443/browse/IEP-976))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?
BigIntDecoder is using for validating data in the NVS table, so to test it:
- Open the NVS table editor
- Add a new row 
- type some name in a new row and select 'data' as a type 
- select encoding, for example u8 and type hex/oct/dec numbers for example 0xFF - should be ok, 0xFFF - out of range for u8, FF - incorrect format

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- NVS table editor validation input

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
