### PR TITLE
IEP-977 NVS Table editor - validation on integer types is incorrect

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/NvsBeanValidator.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/NvsBeanValidator.java
@@ -120,7 +120,7 @@ public class NvsBeanValidator
 		BigInteger bigIntegerValue = null;
 		try
 		{
-			bigIntegerValue = BigIntDecoder.decode(value);
+			bigIntegerValue = new BigInteger(value);
 		}
 		catch (NumberFormatException e)
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/NvsBeanValidator.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/NvsBeanValidator.java
@@ -14,6 +14,7 @@ import com.espressif.idf.core.build.NvsTableBean;
 
 public class NvsBeanValidator
 {
+	private static final int STRING_VALUE_LIMIT = 4000;
 	private static final String NAMESPACE = "namespace"; //$NON-NLS-1$
 	private static final Map<String, BigInteger> minValuesMap = initMinValuesMap();
 	private static final Map<String, BigInteger> maxValuesMap = initMaxValuesMap();
@@ -89,7 +90,7 @@ public class NvsBeanValidator
 
 		if (value.isBlank())
 		{
-			return Messages.NameValidationError_2;
+			return Messages.NvsValidation_ValueValidationErr_2;
 		}
 
 		if (type.contentEquals("file")) //$NON-NLS-1$
@@ -99,7 +100,7 @@ public class NvsBeanValidator
 
 		if (encoding.contentEquals("string") || encoding.contentEquals("binary")) //$NON-NLS-1$ //$NON-NLS-2$
 		{
-			if (value.length() > 4000)
+			if (value.getBytes().length > STRING_VALUE_LIMIT)
 			{
 				return Messages.NvsValidation_ValueValidationErr_3;
 			}
@@ -144,7 +145,7 @@ public class NvsBeanValidator
 		if (!List.of(NvsTableDataService.getEncodings(type)).contains(encoding))
 		{
 			return String.format(Messages.NvsValidation_EncodingValidationErr_1, type,
-					NvsTableDataService.getEncodings(type), encoding);
+					String.join(",", NvsTableDataService.getEncodings(type)), encoding); //$NON-NLS-1$
 		}
 		return StringUtil.EMPTY;
 	}

--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Espressif Systems
 Automatic-Module-Name: com.espressif.idf.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
- com.espressif.idf.core;bundle-version="1.0.1"
+ com.espressif.idf.core;bundle-version="1.0.1",
+ junit-jupiter-api
 Bundle-ClassPath: .,
  lib/jmock-2.12.0.jar,
  lib/commons-collections4-4.4.jar,
@@ -65,3 +66,5 @@ Export-Package: com.espressif.idf.core.test,
  org.jmock.api,
  org.jmock.auto,
  org.jmock.lib
+Import-Package: org.junit.jupiter.params,
+ org.junit.jupiter.params.provider

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/NvsBeanValidatorTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/NvsBeanValidatorTest.java
@@ -1,0 +1,311 @@
+package com.espressif.idf.core.util.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.espressif.idf.core.build.NvsTableBean;
+import com.espressif.idf.core.util.Messages;
+import com.espressif.idf.core.util.NvsBeanValidator;
+import com.espressif.idf.core.util.NvsTableDataService;
+import com.espressif.idf.core.util.StringUtil;
+
+class NvsBeanValidatorTest
+{
+
+	@Test
+	void validate_empty_key_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setKey(StringUtil.EMPTY);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 0);
+
+		assertEquals(Messages.NvsValidation_KeyValidationErr_1, actualResult);
+	}
+
+	@Test
+	void validate_key_longer_then_15_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setKey("test key longer then 15");
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 0);
+
+		assertEquals(Messages.NvsValidation_KeyValidationErr_2, actualResult);
+	}
+
+	@Test
+	void validate_valid_key_returns_empty_string()
+	{
+		NvsTableBean tesTableBean = new NvsTableBean();
+		tesTableBean.setKey("valid key");
+
+		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, 0);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_empty_type_returns_empty_string()
+	{
+		NvsTableBean tesTableBean = new NvsTableBean();
+
+		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, 1);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_not_supported_encoding_returns_validation_error()
+	{
+		String encoding = "Non existing encoding";
+		String type = "file";
+		String expectedResult = String.format(Messages.NvsValidation_EncodingValidationErr_1, type,
+				String.join(",", NvsTableDataService.getEncodings(type)), encoding);
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType(type);
+		testTableBean.setEncoding(encoding);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 2);
+
+		assertEquals(expectedResult, actualResult);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "file, hex2bin", "file, base64", "file, string", "file, binary", "data, u8", "data, i8", "data, u16",
+			"data, i16", "data, u32", "data, i32", "data, u64", "data, i64", "data, string", "data, hex2bin",
+			"data, base64", "namespace, ''", "'', ''" })
+	void validate_supported_encoding_returns_empty_string(String type, String encoding)
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType(type);
+		testTableBean.setEncoding(encoding);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 2);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_non_empty_value_with_type_namespace_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("namespace");
+		testTableBean.setValue("test");
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(Messages.NvsValidation_ValueValidationErr_1, actualResult);
+	}
+
+	@Test
+	void validate_with_empty_value_with_type_namespace_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("namespace");
+		testTableBean.setValue(StringUtil.EMPTY);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "file", "data", "namespace" })
+	void validate_empty_value_with_type_other_then_namespace_returns_validation_error(String type)
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("file");
+		testTableBean.setValue(StringUtil.EMPTY);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(Messages.NvsValidation_ValueValidationErr_2, actualResult);
+	}
+	
+	@ParameterizedTest
+	@ValueSource(strings = { "C:", "test", "file.exe" })
+	void validate_value_with_type_file_returns_empty_string(String value)
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("file");
+		testTableBean.setValue(value);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_out_of_limit_value_with_data_type_and_string_encoding_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding("string");
+		String valueOverLimit = "";
+		while (valueOverLimit.getBytes().length < 4001)
+		{
+			valueOverLimit += "q";
+		}
+		testTableBean.setValue(valueOverLimit);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(Messages.NvsValidation_ValueValidationErr_3, actualResult);
+
+	}
+
+	@Test
+	void validate_valid_value_with_data_type_and_string_encoding_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding("string");
+		testTableBean.setValue("test");
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+
+	@Test
+	void validate_out_of_limit_value_with_data_type_and_binary_encoding_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding("binary");
+		String valueOverLimit = "";
+		while (valueOverLimit.getBytes().length < 4001)
+		{
+			valueOverLimit += "q";
+		}
+		testTableBean.setValue(valueOverLimit);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(Messages.NvsValidation_ValueValidationErr_3, actualResult);
+
+	}
+
+	@Test
+	void validate_valid_value_with_data_type_and_binary_encoding_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding("binary");
+		testTableBean.setValue("test");
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "u8, 0", "u8, 120", "u8, 255", "i8, -128", "i8, 0", "i8, 120", "i8, 127", "u16, 0", "u16, 360",
+			"u16, 65535", "i16, -32768", "i16, 0", "i16, 120", "i16, 32767", "u32, 0", "u32, 1000", "u32, 4294967295",
+			"i32, -2147483648", "i32, 9", "i32, 2147483647", "u64, 0", "u64, 2000", "u64, 18446744073709551615",
+			"i64, -9223372036854775808", "i64, 3000", "i64, 9223372036854775807" })
+	void validate_valid_integer_in_range_returns_empty_string(String encoding, String value)
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding(encoding);
+		testTableBean.setValue(value);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "u8, -1", "u8, -20", "u8, 256", "i8, -129", "i8, -150", "i8, 150", "i8, 128", "u16, -1", "u16, -50",
+			"u16, 65536", "i16, -32769", "i16, -2147483649", "i16, -38000", "i16, 32768", "u32, -1", "u32, -1000",
+			"u32, 4294967296", "i32, -2147483649", "i32, 2147483648", "u64, -1", "u64, 18446744073709551616",
+			"i64, -9223372036854775809", "i64, 9223372036854775808" })
+	void validate_valid_integer_out_of_range_returns_validation_error(String encoding, String value)
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setEncoding(encoding);
+		testTableBean.setValue(value);
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(String.format(Messages.NvsValidation_NumberValueValidationErr_2, value, encoding), actualResult);
+	}
+
+	@Test
+	void validate_non_integer_number_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		String value = "test";
+		String expectedResult = "";
+		testTableBean.setType("data");
+		testTableBean.setEncoding("i8");
+		testTableBean.setValue(value);
+		try
+		{
+			BigInteger number = new BigInteger(value);
+		}
+		catch (NumberFormatException e)
+		{
+			expectedResult = String.format(Messages.NvsValidation_NumberValueValidationErr_1, e.getLocalizedMessage());
+		}
+		
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(expectedResult, actualResult);
+	}
+
+	@Test
+	void validate_not_specified_index_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 4);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_first_bean_with_type_other_then_namespace_returns_validation_error()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+
+		String actualResult = new NvsBeanValidator().validateFirstBean(testTableBean);
+
+		assertEquals(Messages.NvsValidation_FirstBeanValidationErr, actualResult);
+	}
+
+	@Test
+	void validate_first_with_namespace_type_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("namespace");
+
+		String actualResult = new NvsBeanValidator().validateFirstBean(testTableBean);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+
+	@Test
+	void validate_data_value_with_non_existing_encoding_returns_empty_string()
+	{
+		NvsTableBean testTableBean = new NvsTableBean();
+		testTableBean.setType("data");
+		testTableBean.setValue("test");
+		testTableBean.setEncoding("non-existing");
+
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+
+		assertEquals(StringUtil.EMPTY, actualResult);
+	}
+}

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/NvsBeanValidatorTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/NvsBeanValidatorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -15,8 +17,15 @@ import com.espressif.idf.core.util.NvsBeanValidator;
 import com.espressif.idf.core.util.NvsTableDataService;
 import com.espressif.idf.core.util.StringUtil;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class NvsBeanValidatorTest
 {
+
+	private static final int NON_EXISTING_COLUMN = 4;
+	private static final int VALUE_COLUMN = 3;
+	private static final int ENCODING_COLUMN = 2;
+	private static final int TYPE_COLUMN = 1;
+	private static final int NAME_COLUMN = 0;
 
 	@Test
 	void validate_empty_key_returns_validation_error()
@@ -24,7 +33,7 @@ class NvsBeanValidatorTest
 		NvsTableBean testTableBean = new NvsTableBean();
 		testTableBean.setKey(StringUtil.EMPTY);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 0);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, NAME_COLUMN);
 
 		assertEquals(Messages.NvsValidation_KeyValidationErr_1, actualResult);
 	}
@@ -35,7 +44,7 @@ class NvsBeanValidatorTest
 		NvsTableBean testTableBean = new NvsTableBean();
 		testTableBean.setKey("test key longer then 15");
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 0);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, NAME_COLUMN);
 
 		assertEquals(Messages.NvsValidation_KeyValidationErr_2, actualResult);
 	}
@@ -46,7 +55,7 @@ class NvsBeanValidatorTest
 		NvsTableBean tesTableBean = new NvsTableBean();
 		tesTableBean.setKey("valid key");
 
-		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, 0);
+		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, NAME_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -56,7 +65,7 @@ class NvsBeanValidatorTest
 	{
 		NvsTableBean tesTableBean = new NvsTableBean();
 
-		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, 1);
+		String actualResult = new NvsBeanValidator().validateBean(tesTableBean, TYPE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -72,7 +81,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType(type);
 		testTableBean.setEncoding(encoding);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 2);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, ENCODING_COLUMN);
 
 		assertEquals(expectedResult, actualResult);
 	}
@@ -87,7 +96,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType(type);
 		testTableBean.setEncoding(encoding);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 2);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, ENCODING_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -99,7 +108,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType("namespace");
 		testTableBean.setValue("test");
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(Messages.NvsValidation_ValueValidationErr_1, actualResult);
 	}
@@ -111,7 +120,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType("namespace");
 		testTableBean.setValue(StringUtil.EMPTY);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -124,7 +133,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType("file");
 		testTableBean.setValue(StringUtil.EMPTY);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(Messages.NvsValidation_ValueValidationErr_2, actualResult);
 	}
@@ -137,7 +146,7 @@ class NvsBeanValidatorTest
 		testTableBean.setType("file");
 		testTableBean.setValue(value);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -155,7 +164,7 @@ class NvsBeanValidatorTest
 		}
 		testTableBean.setValue(valueOverLimit);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(Messages.NvsValidation_ValueValidationErr_3, actualResult);
 
@@ -169,7 +178,7 @@ class NvsBeanValidatorTest
 		testTableBean.setEncoding("string");
 		testTableBean.setValue("test");
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -188,7 +197,7 @@ class NvsBeanValidatorTest
 		}
 		testTableBean.setValue(valueOverLimit);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(Messages.NvsValidation_ValueValidationErr_3, actualResult);
 
@@ -202,7 +211,7 @@ class NvsBeanValidatorTest
 		testTableBean.setEncoding("binary");
 		testTableBean.setValue("test");
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -219,7 +228,7 @@ class NvsBeanValidatorTest
 		testTableBean.setEncoding(encoding);
 		testTableBean.setValue(value);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -236,7 +245,7 @@ class NvsBeanValidatorTest
 		testTableBean.setEncoding(encoding);
 		testTableBean.setValue(value);
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(String.format(Messages.NvsValidation_NumberValueValidationErr_2, value, encoding), actualResult);
 	}
@@ -259,7 +268,7 @@ class NvsBeanValidatorTest
 			expectedResult = String.format(Messages.NvsValidation_NumberValueValidationErr_1, e.getLocalizedMessage());
 		}
 		
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(expectedResult, actualResult);
 	}
@@ -269,7 +278,7 @@ class NvsBeanValidatorTest
 	{
 		NvsTableBean testTableBean = new NvsTableBean();
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 4);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, NON_EXISTING_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}
@@ -304,7 +313,7 @@ class NvsBeanValidatorTest
 		testTableBean.setValue("test");
 		testTableBean.setEncoding("non-existing");
 
-		String actualResult = new NvsBeanValidator().validateBean(testTableBean, 3);
+		String actualResult = new NvsBeanValidator().validateBean(testTableBean, VALUE_COLUMN);
 
 		assertEquals(StringUtil.EMPTY, actualResult);
 	}


### PR DESCRIPTION
## Description

changed validation for integers, so only decimals are correct now. Also added test coverage for NvsBeanValidator.

Fixes # ([IEP-977](https://jira.espressif.com:8443/browse/IEP-977))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Test 1:
- Open Nvs table editor
- Add a column with type data and some integer encoding.
- write different integer formats, only decimal in correct range should pass validation

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- NVS table editor

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
