### PR TITLE
IEP-958 New debug configuration fields should be pre-filled

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFProjectNature.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFProjectNature.java
@@ -43,7 +43,7 @@ public class IDFProjectNature implements IProjectNature
 
 	public static boolean hasNature(IProject project) throws CoreException
 	{
-		if (project == null)
+		if (project == null || !project.isOpen())
 		{
 			return false;
 		}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
@@ -6,6 +6,7 @@ package com.espressif.idf.debug.gdbjtag.openocd;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -77,8 +78,10 @@ public class IDFDebugLaunchDescriptorType implements ILaunchDescriptorType
 		{
 			Logger.log(e);
 		}
-		return Stream.of(resources).filter(resource -> resource.getType() == IResource.PROJECT)
-				.map(IResource::getProject).findFirst();
+		return resources == null ? Optional.empty()
+				: Stream.of(resources).filter(Objects::nonNull)
+						.filter(resource -> resource.getType() == IResource.PROJECT).map(IResource::getProject)
+						.findFirst();
 	}
 
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/IDFDebugLaunchDescriptorType.java
@@ -4,18 +4,18 @@
  *******************************************************************************/
 package com.espressif.idf.debug.gdbjtag.openocd;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.ILaunchDescriptorType;
-import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFProjectNature;
 import com.espressif.idf.core.build.IDFLaunchConstants;
@@ -44,8 +44,8 @@ public class IDFDebugLaunchDescriptorType implements ILaunchDescriptorType
 			String identifier = type.getIdentifier();
 			if (identifier.equals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 			{
-				IProject project = getProject();
-				project = project != null ? project : config.getMappedResources()[0].getProject();
+				IProject project = getMappedProject(config)
+						.orElseGet(() -> EclipseUtil.getDefaultIDFProject().orElseThrow());
 				if (IDFProjectNature.hasNature(project))
 				{
 					IDFProjectLaunchDescriptor descriptor = descriptors.get(config);
@@ -66,21 +66,19 @@ public class IDFDebugLaunchDescriptorType implements ILaunchDescriptorType
 		return null;
 	}
 
-	private IProject getProject()
+	private Optional<IProject> getMappedProject(ILaunchConfiguration config)
 	{
-		List<IProject> projectList = new ArrayList<>(1);
-		Display.getDefault().syncExec(new Runnable()
+		IResource[] resources = null;
+		try
 		{
-
-			@Override
-			public void run()
-			{
-				IProject project = EclipseUtil.getSelectedProjectInExplorer();
-				projectList.add(project);
-			}
-		});
-		IProject project = projectList.get(0);
-		return project;
+			resources = config.getMappedResources();
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		return Stream.of(resources).filter(resource -> resource.getType() == IResource.PROJECT)
+				.map(IResource::getProject).findFirst();
 	}
 
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -15,14 +15,9 @@
 
 package com.espressif.idf.debug.gdbjtag.openocd.ui;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Optional;
 
 import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.model.CModelException;
-import org.eclipse.cdt.core.model.CoreModel;
 import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.core.model.ICElement;
 import org.eclipse.cdt.core.model.ICProject;
@@ -44,7 +39,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Link;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
@@ -249,43 +243,15 @@ public class TabMain extends CMainTab2
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
 	{
-		super.setDefaults(configuration);
-
-		IProject selectedProject = getSelectedProject();
-		if (selectedProject != null)
-		{
-			ICProject icProject = CCorePlugin.getDefault().getCoreModel().create(selectedProject);
-			initializeCProject(icProject, configuration);
-		}
-		try
-		{
-			configuration.doSave();
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
-		}
+		Optional<IProject> selectedProject = EclipseUtil.getDefaultIDFProject();
+		selectedProject.ifPresent(project -> initializeDefaultProject(project, configuration));
 	}
 
-	private IProject getSelectedProject()
+	private void initializeDefaultProject(IProject project, ILaunchConfigurationWorkingCopy configuration)
 	{
-		List<IProject> projectList = new ArrayList<>(1);
-		Display.getDefault().syncExec(() -> {
-			IProject project = EclipseUtil.getSelectedProjectInExplorer();
-			if (project != null)
-				projectList.add(project);
-
-		});
-		try
-		{
-			ICProject[] projects = CoreModel.getDefault().getCModel().getCProjects();
-			projectList.addAll(Stream.of(projects).map(ICProject::getProject).collect(Collectors.toList()));
-		}
-		catch (CModelException e)
-		{
-			Logger.log(e);
-		}
-		return projectList.get(0);
+		ICProject icProject = CCorePlugin.getDefault().getCoreModel().create(project);
+		initializeCProject(icProject, configuration);
+		initializeProgramName(icProject, configuration);
 	}
 
 	@Override


### PR DESCRIPTION
## Description

The project field couldn't be pre-filled during creating a debug configuration. This case is fixed in this PR. The code is extracted to UI util class, so it can be reused for launch configuration also.

Fixes # ([IEP-958](https://jira.espressif.com:8443/browse/IEP-958))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Test 1:
creating debug configurations with different cases:
- Select the project in the project explorer, and create a new debug configuration. Project in debug configuration == selected project in the project explorer
- Select the closed project in the project explorer, and create a new debug configuration. Project in debug configuration == next available project in the project explorer
- restart eclipse, and create a new debug configuration without selecting anything in project explorer. Project in debug configuration == first available project in the project explorer

- Test 2
test build and debug after creating debug configurations with different scenarios. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Debug configuration
- Build/debug

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
