### PR TITLE
IEP-984 org.slf4j.api dependency cannot be resolved

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -64,8 +64,8 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jgit.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
-			<unit id="org.slf4j.api" version="0.0.0"/>
-			<unit id="org.slf4j.binding.simple" version="0.0.0"/>
+			<unit id="slf4j.api" version="0.0.0"/>
+			<unit id="slf4j.simple" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/egit/updates" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.debug.core;bundle-version="3.11.0",
  org.eclipse.launchbar.core,
  com.espressif.idf.core.test;bundle-version="0.0.1",
- org.eclipse.jface
+ org.eclipse.jface,
+ slf4j.api
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.launchbar.ui,
  org.eclipse.launchbar.ui.controls.internal,


### PR DESCRIPTION
looks like org.slf4j.api was removed from the egit dependencies 
