### PR TITLE
IEP-959 Debugger tab for C3/S3 chips set "via builtin USB-JTAG" option by default

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/DefaultBoardProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/DefaultBoardProvider.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core;
+
+import java.util.OptionalInt;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.espressif.idf.core.util.StringUtil;
+
+public class DefaultBoardProvider
+{
+	private static final int DEFAULT_BOARD_EMPTY_INDEX = 0;
+	private static final String ESP32C3_DEFAULT_BOARD = "ESP32-C3 chip (via builtin USB-JTAG)"; //$NON-NLS-1$
+	private static final String ESP32S3_DEFAULT_BOARD = "ESP32-S3 chip (via builtin USB-JTAG)"; //$NON-NLS-1$
+
+	private enum EspTarget
+	{
+		ESP32C3(ESP32C3_DEFAULT_BOARD), ESP32S3(ESP32S3_DEFAULT_BOARD), DEFAULT_TARGET(StringUtil.EMPTY);
+
+		private final String board;
+
+		EspTarget(String defaultBoard)
+		{
+			this.board = defaultBoard;
+		}
+
+		public static EspTarget enumOf(String value)
+		{
+			return Stream.of(EspTarget.values()).filter(target -> target.name().equalsIgnoreCase(value)).findAny()
+					.orElse(DEFAULT_TARGET);
+		}
+
+	}
+	
+	public int getIndexOfDefaultBoard(String targetName, String[] boardsForTarget)
+	{
+		String defaultBoard = EspTarget.enumOf(targetName).board;
+
+		OptionalInt index = IntStream.range(0, boardsForTarget.length)
+				.filter(i -> defaultBoard.equals(boardsForTarget[i])).findFirst();
+
+		return index.orElse(DEFAULT_BOARD_EMPTY_INDEX);
+	}
+
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -68,6 +68,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.json.simple.JSONArray;
 
+import com.espressif.idf.core.DefaultBoardProvider;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
@@ -474,7 +475,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 						fGdbClientExecutable.setText(IDFUtil.getXtensaToolchainExecutablePathByTarget(selectedItem));
 						boardConfigsMap = parser.getBoardsConfigs(selectedItem);
 						fTargetName.setItems(parser.getBoardsConfigs(selectedItem).keySet().toArray(new String[0]));
-						fTargetName.select(0);
+						fTargetName.select(new DefaultBoardProvider().getIndexOfDefaultBoard(selectedItem,
+								fTargetName.getItems()));
 						fTargetName.notifyListeners(SWT.Selection, null);
 					}
 
@@ -539,7 +541,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 				fTargetName.setItems(parser.getBoardsConfigs(selectedTarget).keySet().toArray(new String[0]));
 				boardConfigsMap = parser.getBoardsConfigs(selectedTarget);
 
-				fTargetName.select(0);
+				fTargetName.select(
+						new DefaultBoardProvider().getIndexOfDefaultBoard(selectedTarget, fTargetName.getItems()));
 				fTargetName.addSelectionListener(new SelectionAdapter()
 				{
 					@SuppressWarnings("unchecked")

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -66,6 +66,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 import org.json.simple.JSONArray;
 
+import com.espressif.idf.core.DefaultBoardProvider;
 import com.espressif.idf.core.IDFDynamicVariables;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
@@ -716,7 +717,8 @@ public class CMakeMainTab2 extends GenericMainTab {
 					}
 					boardConfigsMap = parser.getBoardsConfigs(selectedItem);
 					fTargetName.setItems(parser.getBoardsConfigs(selectedItem).keySet().toArray(new String[0]));
-					fTargetName.select(0);
+					fTargetName.select(
+							new DefaultBoardProvider().getIndexOfDefaultBoard(selectedItem, fTargetName.getItems()));
 					updateArgumentsField();
 				}
 
@@ -762,7 +764,8 @@ public class CMakeMainTab2 extends GenericMainTab {
 			fTargetName = new Combo(group, SWT.SINGLE | SWT.BORDER | SWT.READ_ONLY);
 			fTargetName.setItems(parser.getBoardsConfigs(selectedTarget).keySet().toArray(new String[0]));
 			boardConfigsMap = parser.getBoardsConfigs(selectedTarget);
-			fTargetName.select(0);
+			fTargetName
+					.select(new DefaultBoardProvider().getIndexOfDefaultBoard(selectedTarget, fTargetName.getItems()));
 			fTargetName.addSelectionListener(new SelectionAdapter() {
 				@Override
 				public void widgetSelected(SelectionEvent e) {

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/DefaultBoardProviderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/DefaultBoardProviderTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.espressif.idf.core.DefaultBoardProvider;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DefaultBoardProviderTest
+{
+
+	private static final int ESP32C3_EXPECTED_INDEX = 1;
+	private static final int ESP32S3_EXPECTED_INDEX = 2;
+	private static final int ESP32_EXPECTED_INDEX = 0;
+	private static final int ESP32S2_EXPECTED_INDEX = 0;
+	private static final int ESP32C2_EXPECTED_INDEX = 0;
+	private static final int ESP32C6_EXPECTED_INDEX = 0;
+	private static final int ESP32H2_EXPECTED_INDEX = 0;
+
+	@ParameterizedTest
+	@MethodSource("argumentsAndExpectedResultProvider")
+	void getIndexOfDefaultBoard_returns_expected_index_for_esp32s3_target(String target, String[] boardArray,
+			int expectedIndex)
+	{
+
+		int index = new DefaultBoardProvider().getIndexOfDefaultBoard(target, boardArray);
+		assertEquals(expectedIndex, index);
+	}
+
+	@ParameterizedTest
+	@MethodSource("argumentsAndExpectedResultProvider")
+	void getIndexOfDefaultBoard_ignores_case_for_target_and_returns_expected_result(String target, String[] boardArray,
+			int expectedIndex)
+	{
+		target = target.toUpperCase();
+
+		int index = new DefaultBoardProvider().getIndexOfDefaultBoard(target, boardArray);
+
+		assertEquals(expectedIndex, index);
+	}
+
+	static Stream<Arguments> argumentsAndExpectedResultProvider()
+	{
+		return Stream.of(
+				Arguments.of("esp32s3",
+						new String[] { "ESP32-S3 chip (via ESP-PROG)", "ESP32-S3 chip (via ESP USB Bridge)",
+								"ESP32-S3 chip (via builtin USB-JTAG)" },
+						ESP32S3_EXPECTED_INDEX),
+				Arguments.of("esp32c3", new String[] { "ESP32-C3 chip (via ESP USB Bridge)",
+						"ESP32-C3 chip (via builtin USB-JTAG)", "ESP32-C3 chip (via ESP-PROG)" },
+						ESP32C3_EXPECTED_INDEX),
+				Arguments.of("esp32", new String[] { "ESP-WROVER-KIT 1.8V", "ESP32 chip (via ESP USB Bridge)",
+						"ESP-WROVER-KIT 3.3V" }, ESP32_EXPECTED_INDEX),
+				Arguments.of("esp32s2",
+						new String[] { "ESP32-S2 chip (via ESP USB Bridge)", "ESP32-S2-KALUGA-1",
+								"ESP32-S2 chip (via ESP-PROG)" },
+						ESP32S2_EXPECTED_INDEX),
+				Arguments.of("esp32c2",
+						new String[] { "ESP32-C2 chip (via ESP-PROG)", "ESP32-C2 chip (via ESP USB Bridge)"
+						
+						}, ESP32C2_EXPECTED_INDEX),
+				Arguments.of(
+						"esp32c6", new String[] { "ESP32-C6 chip (via builtin USB-JTAG)",
+								"ESP32-C6 chip (via ESP-PROG)", "ESP32-C6 chip (via ESP USB Bridge)" },
+						ESP32C6_EXPECTED_INDEX),
+				Arguments.of("esp32h2", new String[] { "ESP32-H2 chip (via ESP-PROG)",
+						"ESP32-H2 chip (via ESP USB Bridge)", "ESP32-H2 chip (via builtin USB-JTAG)" },
+						ESP32H2_EXPECTED_INDEX));
+	}
+}


### PR DESCRIPTION
## Description

Provided default boards for C3/S3 chips

Fixes # ([IEP-959](https://jira.espressif.com:8443/browse/IEP-959))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?
Test 1:
- create a new debug/launch configuration -> select C3/S3 target. Default board with via builtin USB-JTAG should be selected

Test 2:
- select any board other then C3/S3 -> default board is first from the list

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch configuration with flash via the JTAG option
- Debug configuration

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [x] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
