### PR TITLE
IEP-1000 Board doesn't match the target after cancel in debug/jtag tab

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
@@ -53,3 +53,4 @@ properties.mcu=ESP-IDF OpenOCD Path
 actionType.name = Heap Tracing
 command.name = Application Level Tracing
 variable.description = Default C/C++ application (path to binaries) is determined automatically after build
+esp_svd_path_desc = The path to the SVD file associated with the selected target. Will be determined before joining the debug session

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.properties
@@ -53,4 +53,4 @@ properties.mcu=ESP-IDF OpenOCD Path
 actionType.name = Heap Tracing
 command.name = Application Level Tracing
 variable.description = Default C/C++ application (path to binaries) is determined automatically after build
-esp_svd_path_desc = The path to the SVD file associated with the selected target. Will be determined before joining the debug session
+esp_svd_path_desc = The path to the SVD file associated with the selected target will be determined before joining the debug session

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -146,6 +146,11 @@
           name="default_app"
           resolver="com.espressif.idf.debug.gdbjtag.openocd.DefaultAppResolver">
     </variable>
+    <variable
+          description="%esp_svd_path_desc"
+          name="esp_svd_path"
+          resolver="com.espressif.idf.debug.gdbjtag.openocd.SvdPathResolver">
+    </variable>
  </extension>
  <extension
        point="org.eclipse.debug.core.processFactories">

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/SvdPathResolver.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/SvdPathResolver.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.debug.gdbjtag.openocd;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.variables.IDynamicVariable;
+import org.eclipse.core.variables.IDynamicVariableResolver;
+import org.eclipse.embedcdt.core.EclipseUtils;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+
+import com.espressif.idf.core.IDFConstants;
+import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget;
+
+public class SvdPathResolver implements IDynamicVariableResolver
+{
+
+	public String resolveValue(IDynamicVariable variable, String argument) throws CoreException
+	{
+		String selectedTarget = StringUtil.EMPTY;
+		String selectedTargetPath = StringUtil.EMPTY;
+		try
+		{
+			ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
+			selectedTarget = launchBarManager.getActiveLaunchTarget().getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET,
+					StringUtil.EMPTY);
+			if (StringUtil.isEmpty(selectedTarget))
+				return StringUtil.EMPTY;
+			URL svdUrl = Platform.getBundle(Activator.PLUGIN_ID)
+					.getResource("svd/".concat(selectedTarget.concat(".svd"))); //$NON-NLS-1$ //$NON-NLS-2$
+			String jarPath = new File(TabSvdTarget.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+					.getPath();
+			if (!jarPath.contains(".jar")) //$NON-NLS-1$
+			{
+				selectedTargetPath = new File(FileLocator.resolve(svdUrl).toURI()).getPath();
+			}
+			else
+			{
+				IProject project = EclipseUtils
+						.getProjectByLaunchConfiguration(launchBarManager.getActiveLaunchConfiguration());
+				IFolder svdFolder = project.getFolder(IDFConstants.BUILD_FOLDER).getFolder("svd"); //$NON-NLS-1$
+				if (!svdFolder.exists())
+				{
+					svdFolder.create(true, true, new NullProgressMonitor());
+				}
+				IFile svdFile = project.getFolder(IDFConstants.BUILD_FOLDER).getFile(svdUrl.getPath());
+				if (!svdFile.exists())
+				{
+					JarFile jarFile = new JarFile(jarPath);
+					JarEntry file = (JarEntry) jarFile.getEntry(svdUrl.getFile().substring(1));
+					if (file != null)
+					{
+						InputStream inputStream = jarFile.getInputStream(file);
+						svdFile.create(inputStream, true, new NullProgressMonitor());
+						inputStream.close();
+					}
+					jarFile.close();
+				}
+				project.refreshLocal(IProject.DEPTH_INFINITE, new NullProgressMonitor());
+				selectedTargetPath = svdFile.getRawLocation().toOSString();
+			}
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
+		return selectedTargetPath;
+	}
+
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/SvdPathResolver.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/SvdPathResolver.java
@@ -28,6 +28,12 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget;
 
+/**
+ * A resolver class for the esp_svd_path dynamic variable. Resolves SVD path by looking for appropriate files inside the
+ * plugin resources
+ * 
+ * @author Denys Almazov <denys.almazov@espressif.com>
+ */
 public class SvdPathResolver implements IDynamicVariableResolver
 {
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/Messages.java
@@ -59,6 +59,8 @@ public class Messages
 
 	public static String DllNotFound_ExceptionMessage;
 	public static String TabMain_Launch_Config;
+
+	public static String TabDebugger_SettingTargetJob;
 	// ------------------------------------------------------------------------
 
 	static

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -182,7 +182,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 		LaunchBarListener.setIgnoreJtagTargetChange(true);
 		parent.addDisposeListener(event -> {
-			String targetNameFromUI = fTargetName.getText();
+			String targetNameFromUI = fTarget.getText();
 			// TODO: find a better way to roll back target change in the launch bar when Cancel was pressed.
 			// We have to do like this because we don't have access to the cancel button
 			scheduleRevertTargetJob(targetNameFromUI);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -182,10 +182,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 		LaunchBarListener.setIgnoreJtagTargetChange(true);
 		parent.addDisposeListener(event -> {
-			String targetNameFromUI = fTarget.getText();
 			// TODO: find a better way to roll back target change in the launch bar when Cancel was pressed.
 			// We have to do like this because we don't have access to the cancel button
-			scheduleRevertTargetJob(targetNameFromUI);
+			scheduleRevertTargetJob();
 			LaunchBarListener.setIgnoreJtagTargetChange(false);
 		});
 
@@ -257,7 +256,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 		});
 	}
 
-	private void scheduleRevertTargetJob(String targetNameFromUI)
+	private void scheduleRevertTargetJob()
 	{
 		Job revertTargetJob = new Job(Messages.TabDebugger_SettingTargetJob)
 		{
@@ -270,12 +269,15 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 						return Status.CANCEL_STATUS;
 					}
 					String targetName = launchBarManager.getActiveLaunchConfiguration()
-							.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, targetNameFromUI);
-					ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
-					ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
-							.filter(target -> target.getId().contentEquals((targetName))).findFirst()
-							.orElseGet(() -> null);
-					launchBarManager.setActiveLaunchTarget(selectedTarget);
+							.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, StringUtil.EMPTY);
+					if (!targetName.isEmpty())
+					{
+						ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
+						ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
+								.filter(target -> target.getId().contentEquals((targetName))).findFirst()
+								.orElseGet(() -> null);
+						launchBarManager.setActiveLaunchTarget(selectedTarget);
+					}
 					return Status.OK_STATUS;
 				}
 				catch (CoreException e)

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -85,6 +85,7 @@ import com.espressif.idf.debug.gdbjtag.openocd.ui.preferences.WorkspaceMcuPage;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.properties.ProjectMcuPage;
 import com.espressif.idf.launch.serial.SerialFlashLaunchTargetProvider;
 import com.espressif.idf.launch.serial.ui.internal.NewSerialFlashTargetWizard;
+import com.espressif.idf.ui.LaunchBarListener;
 
 /**
  * @since 7.0
@@ -168,11 +169,13 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 	@Override
 	public void createControl(Composite parent)
 	{
-
 		if (Activator.getInstance().isDebugging())
 		{
 			System.out.println("openocd.TabDebugger.createControl() ");
 		}
+
+		LaunchBarListener.setIgnoreJtagTargetChange(true);
+		parent.addDisposeListener(e -> LaunchBarListener.setIgnoreJtagTargetChange(false));
 
 		if (!(parent instanceof ScrolledComposite))
 		{
@@ -458,18 +461,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 						String selectedItem = fTarget.getText();
 						if (!selectedItem.contentEquals(updatedSelectedTarget))
 						{
-							try
-							{
-								ILaunchConfigurationWorkingCopy wc = launchBarManager.getActiveLaunchConfiguration()
-										.getWorkingCopy();
-								wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
-								TabSvdTarget.updateSvd(selectedItem, wc);
-								wc.doSave();
-							}
-							catch (CoreException e1)
-							{
-								Logger.log(e1);
-							}
 							updateLaunchBar(selectedItem);
 						}
 						fGdbClientExecutable.setText(IDFUtil.getXtensaToolchainExecutablePathByTarget(selectedItem));
@@ -1513,19 +1504,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 		// JTAG options
 		if (fFlashVoltage != null && fTarget != null && fTargetName != null)
 		{
-			try
-			{
-				ILaunchConfigurationWorkingCopy wc = configuration.getWorkingCopy();
-				wc.setAttribute(IDFLaunchConstants.JTAG_FLASH_VOLTAGE, fFlashVoltage.getText());
-				wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, fTarget.getText());
-				wc.setAttribute(IDFLaunchConstants.JTAG_BOARD, fTargetName.getText());
-				wc.doSave();
-			}
-			catch (CoreException e)
-			{
-				Logger.log(e);
-			}
-
+			configuration.setAttribute(IDFLaunchConstants.JTAG_FLASH_VOLTAGE, fFlashVoltage.getText());
+			configuration.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, fTarget.getText());
+			configuration.setAttribute(IDFLaunchConstants.JTAG_BOARD, fTargetName.getText());
 		}
 
 		// Force thread update

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabSvdTarget.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabSvdTarget.java
@@ -4,29 +4,10 @@
  *******************************************************************************/
 package com.espressif.idf.debug.gdbjtag.openocd.ui;
 
-import java.io.File;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.embedcdt.core.EclipseUtils;
+import org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes;
 import org.eclipse.embedcdt.debug.gdbjtag.ui.TabSvd;
-import org.eclipse.launchbar.core.ILaunchBarManager;
-
-import com.espressif.idf.core.IDFConstants;
-import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.StringUtil;
-import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 
 /**
  * Svd target class for loading the svd files from the plugin directly
@@ -36,87 +17,14 @@ import com.espressif.idf.debug.gdbjtag.openocd.Activator;
  */
 public class TabSvdTarget extends TabSvd
 {
-	public TabSvdTarget()
-	{
-		super();
-	}
+	private static final String ESP_SVD_PATH = "esp_svd_path"; //$NON-NLS-1$
 
 	@Override
-	public void initializeFrom(ILaunchConfiguration configuration)
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
 	{
-		String selectedTarget = StringUtil.EMPTY;
-		try
-		{
-			ILaunchConfigurationWorkingCopy wc = configuration.getWorkingCopy();
-			selectedTarget = wc.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, StringUtil.EMPTY);
-			if (StringUtil.isEmpty(selectedTarget))
-			{
-				selectedTarget = Activator.getService(ILaunchBarManager.class).getActiveLaunchTarget()
-						.getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, StringUtil.EMPTY);
-			}
-			updateSvd(selectedTarget, wc);
-			wc.doSave();
-		}
-		catch (Exception e)
-		{
-			Logger.log(e);
-		}
-
-		super.initializeFrom(configuration);
+		configuration.setAttribute(ConfigurationAttributes.SVD_PATH,
+				VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(ESP_SVD_PATH, null));
+		super.setDefaults(configuration);
 	}
 
-	public static void updateSvd(String selectedTarget, ILaunchConfigurationWorkingCopy wc)
-	{
-		try
-		{
-			if (StringUtil.isEmpty(selectedTarget))
-				return;
-			URL svdUrl = Platform.getBundle(Activator.PLUGIN_ID)
-					.getResource("svd/".concat(selectedTarget.concat(".svd"))); //$NON-NLS-1$ //$NON-NLS-2$
-			String jarPath = new File(TabSvdTarget.class.getProtectionDomain().getCodeSource().getLocation().toURI())
-					.getPath();
-			String selectedTargetPath = StringUtil.EMPTY;
-			if (!jarPath.contains(".jar")) //$NON-NLS-1$
-			{
-				selectedTargetPath = new File(FileLocator.resolve(svdUrl).toURI()).getPath();
-			}
-			else
-			{
-				IProject project = EclipseUtils.getProjectByLaunchConfiguration(wc);
-				IFolder svdFolder = project.getFolder(IDFConstants.BUILD_FOLDER).getFolder("svd"); //$NON-NLS-1$
-				if (!svdFolder.exists())
-				{
-					svdFolder.create(true, true, new NullProgressMonitor());
-				}
-				IFile svdFile = project.getFolder(IDFConstants.BUILD_FOLDER).getFile(svdUrl.getPath());
-				if (!svdFile.exists())
-				{
-					JarFile jarFile = new JarFile(jarPath);
-					JarEntry file = (JarEntry) jarFile.getEntry(svdUrl.getFile().substring(1));
-					if (file != null)
-					{
-						InputStream inputStream = jarFile.getInputStream(file);
-						svdFile.create(inputStream, true, new NullProgressMonitor());
-						inputStream.close();
-					}
-					jarFile.close();
-				}
-				project.refreshLocal(IProject.DEPTH_INFINITE, new NullProgressMonitor());
-				selectedTargetPath = svdFile.getRawLocation().toOSString();
-			}
-
-			String currentSvdPath = wc.getAttribute(
-					org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes.SVD_PATH, StringUtil.EMPTY);
-			if (StringUtil.isEmpty(currentSvdPath) || !currentSvdPath.equals(selectedTargetPath))
-			{
-				wc.setAttribute(org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes.SVD_PATH,
-						selectedTargetPath);
-			}
-		}
-		catch (Exception e)
-		{
-			selectedTarget = StringUtil.EMPTY;
-			Logger.log(e);
-		}
-	}
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/messages.properties
@@ -399,4 +399,5 @@ DebugConfigurationNotFoundMsg=No matching debug configuration was found for the 
 AppLvlTracingJob=Launching application level tracing
 
 DllNotFound_ExceptionMessage=some required DLL(s) not found
+TabDebugger_SettingTargetJob=Setting a target in launch bar...
 TabMain_Launch_Config=Launch Configuration:

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -705,14 +705,6 @@ public class CMakeMainTab2 extends GenericMainTab {
 					}
 
 					if (!selectedItem.contentEquals(updatedSelectedTarget) && isFlashOverJtag) {
-						try {
-							ILaunchConfigurationWorkingCopy wc = launchBarManager.getActiveLaunchConfiguration()
-									.getWorkingCopy();
-							wc.setAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, selectedItem);
-							wc.doSave();
-						} catch (CoreException e2) {
-							Logger.log(e2);
-						}
 						updateLaunchBar(selectedItem);
 					}
 					boardConfigsMap = parser.getBoardsConfigs(selectedItem);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -119,8 +119,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 	public void createControl(Composite parent) {
 		LaunchBarListener.setIgnoreJtagTargetChange(true);
 		parent.addDisposeListener(event -> {
-			String targetNameFromUI = fTarget.getText();
-			scheduleRevertTargetJob(targetNameFromUI);
+			scheduleRevertTargetJob();
 			LaunchBarListener.setIgnoreJtagTargetChange(false);
 		});
 
@@ -857,7 +856,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 		}
 	}
 
-	private void scheduleRevertTargetJob(String targetNameFromUI) {
+	private void scheduleRevertTargetJob() {
 		Job revertTargetJob = new Job(Messages.CMakeMainTab2_SettingTargetJob) {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
@@ -867,12 +866,15 @@ public class CMakeMainTab2 extends GenericMainTab {
 					}
 
 					String targetName = launchBarManager.getActiveLaunchConfiguration()
-							.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, targetNameFromUI);
-					ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
-					ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
-							.filter(target -> target.getId().contentEquals((targetName))).findFirst()
-							.orElseGet(() -> null);
-					launchBarManager.setActiveLaunchTarget(selectedTarget);
+							.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, StringUtil.EMPTY);
+					if (!targetName.isEmpty()) {
+						ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
+						ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
+								.filter(target -> target.getId().contentEquals((targetName))).findFirst()
+								.orElseGet(() -> null);
+						launchBarManager.setActiveLaunchTarget(selectedTarget);
+					}
+
 					return Status.OK_STATUS;
 				} catch (CoreException e) {
 					Logger.log(e);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -119,7 +119,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 	public void createControl(Composite parent) {
 		LaunchBarListener.setIgnoreJtagTargetChange(true);
 		parent.addDisposeListener(event -> {
-			String targetNameFromUI = fTargetName.getText();
+			String targetNameFromUI = fTarget.getText();
 			scheduleRevertTargetJob(targetNameFromUI);
 			LaunchBarListener.setIgnoreJtagTargetChange(false);
 		});

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -42,6 +42,7 @@ public class Messages extends NLS {
 	public static String configBoardTooTip;
 	public static String CMakeMainTab2_OpeonOcdSetupGroupTitle;
 	public static String CMakeMainTab2_JtagFlashingNotSupportedMsg;
+	public static String CMakeMainTab2_SettingTargetJob;
 	public static String IDFLaunchTargetNotFoundMsg1;
 	public static String IDFLaunchTargetNotFoundMsg2;
 	public static String IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle;

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -31,6 +31,7 @@ configBoardLabel=Board:
 configBoardTooTip=Select a board based on ESP target
 CMakeMainTab2_OpeonOcdSetupGroupTitle=OpenOCD Setup:
 CMakeMainTab2_JtagFlashingNotSupportedMsg=(JTAG flash functionality isn't available, please update OpenOCD. The minimum required version is v0.10.0-esp32-20210401)
+CMakeMainTab2_SettingTargetJob=Setting a target in launch bar...
 
 IDFLaunchTargetNotFoundMsg1=IDF Launch Target with 
 IDFLaunchTargetNotFoundMsg2=\ is not found. 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -41,6 +41,7 @@ public class LaunchBarListener implements ILaunchBarListener
 	{
 		jtagIgnored = status;
 	}
+
 	@Override
 	public void activeLaunchTargetChanged(ILaunchTarget target)
 	{
@@ -70,10 +71,11 @@ public class LaunchBarListener implements ILaunchBarListener
 		{
 			ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
 			ILaunchConfiguration activeConfig = launchBarManager.getActiveLaunchConfiguration();
-			if (activeConfig == null) {
+			if (activeConfig == null)
+			{
 				return;
 			}
-			
+
 			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
 			if (projectName.isEmpty())
 			{
@@ -98,25 +100,29 @@ public class LaunchBarListener implements ILaunchBarListener
 					{
 						// get current target
 						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
-						final String jtag_device_id = activeConfig.getAttribute("org.eclipse.cdt.debug.gdbjtag.core.jtagDeviceId", ""); //$NON-NLS-1$ //$NON-NLS-2$
-						if ((activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false) && !jtagIgnored)
+						final String jtag_device_id = activeConfig
+								.getAttribute("org.eclipse.cdt.debug.gdbjtag.core.jtagDeviceId", ""); //$NON-NLS-1$ //$NON-NLS-2$
+						if ((activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false)
 								|| jtag_device_id.contentEquals("ESP-IDF GDB OpenOCD")) //$NON-NLS-1$
+								&& !jtagIgnored)
 						{
-							String targetForJtagFlash = activeConfig.getWorkingCopy().getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
-							if (!newTarget.equals(targetForJtagFlash)) 
+							String targetForJtagFlash = activeConfig.getWorkingCopy()
+									.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
+							if (!newTarget.equals(targetForJtagFlash))
 							{
 								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(),
 										Messages.LaunchBarListener_TargetChanged_Title,
 										MessageFormat.format(Messages.LaunchBarListener_TargetDontMatch_Msg, newTarget,
 												targetForJtagFlash, activeConfig.getName()));
-								if (isYes) {
+								if (isYes)
+								{
 									ILaunchBarUIManager uiManager = UIPlugin.getService(ILaunchBarUIManager.class);
 									uiManager.openConfigurationEditor(launchBarManager.getActiveLaunchDescriptor());
 									return;
 								}
 							}
 						}
-						
+
 						// If both are not same
 						if (currentTarget != null && !newTarget.equals(currentTarget))
 						{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -45,21 +45,17 @@ public class LaunchBarListener implements ILaunchBarListener
 	@Override
 	public void activeLaunchTargetChanged(ILaunchTarget target)
 	{
-		Display.getDefault().asyncExec(new Runnable()
+		Display.getDefault().asyncExec(() ->
 		{
-
-			@Override
-			public void run()
-			{
 				if (target != null)
 				{
-					String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", ""); //$NON-NLS-1$
+				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
+						StringUtil.EMPTY);
 					if (!StringUtil.isEmpty(targetName))
 					{
 						update(targetName);
 					}
 				}
-			}
 		});
 
 	}
@@ -76,7 +72,8 @@ public class LaunchBarListener implements ILaunchBarListener
 				return;
 			}
 
-			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+			String projectName = activeConfig.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME,
+					StringUtil.EMPTY);
 			if (projectName.isEmpty())
 			{
 				ILaunchDescriptor activeLaunchDescriptor = launchBarManager.getActiveLaunchDescriptor();
@@ -100,14 +97,14 @@ public class LaunchBarListener implements ILaunchBarListener
 					{
 						// get current target
 						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
-						final String jtag_device_id = activeConfig
-								.getAttribute("org.eclipse.cdt.debug.gdbjtag.core.jtagDeviceId", ""); //$NON-NLS-1$ //$NON-NLS-2$
+
 						if ((activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false)
-								|| jtag_device_id.contentEquals("ESP-IDF GDB OpenOCD")) //$NON-NLS-1$
+								|| activeConfig.getType().getIdentifier()
+										.contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 								&& !jtagIgnored)
 						{
 							String targetForJtagFlash = activeConfig.getWorkingCopy()
-									.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, ""); //$NON-NLS-1$
+									.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, StringUtil.EMPTY);
 							if (!newTarget.equals(targetForJtagFlash))
 							{
 								boolean isYes = MessageDialog.openQuestion(EclipseUtil.getShell(),
@@ -183,7 +180,7 @@ public class LaunchBarListener implements ILaunchBarListener
 				deleteDirectory(file);
 			}
 		}
-		return directoryToBeDeleted.getName().equals("build") ? true : directoryToBeDeleted.delete(); //$NON-NLS-1$
+		return directoryToBeDeleted.getName().equals("build") || directoryToBeDeleted.delete(); //$NON-NLS-1$
 	}
 
 	private void cleanSdkConfig(IResource project)


### PR DESCRIPTION
## Description

The initial bug can be reproduced this way:  select board in the debug/jtag tab -> click cancel -> select the previous target in the launch bar -> open the debug tab again -> board doesn't match the target. This happens because we had to save the target attribute of the configuration not only when we finish the dialog, but in the moment when the target is changed. We had to do this because we want the SVD path to always be according to the selected target. However, it led us to the problem when we couldn't actually add a custom SVD path, because it will be always reinitialized after the configuration is reopened. Moreover, it saves the wrong value for the SVD path, if the SVD path is not opened before the finish dialog.

To address this issue, I made the following changes: I removed the saving configuration in the listeners (which also ensures proper operation cancellation), and I introduced a dynamic variable for the SVD path. This variable will be replaced during the debug phase to resolve the problem

Fixes # ([IEP-1000](https://jira.espressif.com:8443/browse/IEP-1000))
Fixes #([IEP-1004](https://jira.espressif.com:8443/browse/IEP-1004))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Test 1:
- Edit debug configuration -> select different target -> click cancel ->  edit the same configuration again -> all pre-filled values should be correct
Test 2:
- Edit launch configuration -> select flash over jtag -> select different target ->  click finish
- Edit launch configuration again -> select different target -> click cancel -> edit the same configuration again -> all pre-filled 
values should be correct
Test 3:
- Create a new debug configuration
- in the SVD tab as path should be provided ${esp_svd_path} dynamic variable
- this variable should be present in the Variables... list
- debug the project with this configuration -> check peripherals view

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows, Linux, and macOS):

## Dependent components impacted by this PR:

- SVD tab/ SVD path
- Debug configuration, Launch configuration

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Introduced a new system for resolving the System View Description (SVD) path, enhancing the software's ability to locate necessary files.
- Added a feature to revert target changes in the launch bar when the "Cancel" button is pressed, improving user control over target selection.
- Implemented a new method to handle different cases based on the active launch configuration and target, improving the software's adaptability.

Refactor:
- Simplified the logic in the `CMakeMainTab2` class by removing unnecessary code blocks and introducing more efficient methods.
- Streamlined the `TabDebugger` class with updates to UI elements, tooltips, and methods, enhancing the user interface's intuitiveness.

Note: The remaining changes do not have a direct impact on end-users and are categorized as "Refactor" or "Chores."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->