### PR TITLE
Bump version to 2.11.0

### DIFF
--- a/bundles/com.espressif.idf.branding/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.espressif.idf.branding;singleton:=true
-Bundle-Version: 2.10.0.qualifier
+Bundle-Version: 2.11.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/bundles/com.espressif.idf.branding/pom.xml
+++ b/bundles/com.espressif.idf.branding/pom.xml
@@ -4,14 +4,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>com.espressif.idf.branding</artifactId>
-	<version>2.10.0-SNAPSHOT</version>
+	<version>${espressif-ide-release-version}-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
 		<buildId>${buildTimestamp}</buildId>
-		<releaseName>2.9.1</releaseName>
+		<releaseName>${espressif-ide-release-version}</releaseName>
 	</properties>
 
 	<parent>

--- a/features/com.espressif.idf.feature/feature.xml
+++ b/features/com.espressif.idf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.espressif.idf.feature"
       label="Espressif IDF Plugins for Eclipse"
-      version="2.10.0.qualifier"
+      version="2.11.0.qualifier"
       provider-name="ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD"
       plugin="com.espressif.idf.branding">
 

--- a/features/com.espressif.idf.feature/pom.xml
+++ b/features/com.espressif.idf.feature/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.espressif.idf.feature</groupId>
 	<artifactId>com.espressif.idf.feature</artifactId>
-	<version>2.10.0-SNAPSHOT</version>
+	<version>${espressif-ide-release-version}-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<parent>

--- a/releng/com.espressif.idf.configuration/pom.xml
+++ b/releng/com.espressif.idf.configuration/pom.xml
@@ -10,6 +10,7 @@
 		<tycho-version>3.0.4</tycho-version>
 		<tycho-extras.version>${tycho-version}</tycho-extras.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<espressif-ide-release-version>2.11.0</espressif-ide-release-version>
 	</properties>
 
 	<build>

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Espressif-IDE" uid="com.espressif.idf.product" id="com.espressif.idf.branding.idf" application="org.eclipse.ui.ide.workbench" version="2.10.0" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Espressif-IDE" uid="com.espressif.idf.product" id="com.espressif.idf.branding.idf" application="org.eclipse.ui.ide.workbench" version="2.11.0" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/com.espressif.idf.branding/icons/alt_about.png"/>

--- a/releng/com.espressif.idf.product/pom.xml
+++ b/releng/com.espressif.idf.product/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.espressif.idf</groupId>
 	<artifactId>com.espressif.idf.target</artifactId>
-	<version>2.10.0-SNAPSHOT</version>
+	<version>${espressif-ide-release-version}-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<parent>
@@ -16,8 +16,7 @@
 	<properties>
 		<productId>com.espressif.idf.product</productId>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-		<releaseName>2.10.0</releaseName>
-		<archiveFileName>Espressif-IDE-${releaseName}</archiveFileName>
+		<archiveFileName>Espressif-IDE-${espressif-ide-release-version}</archiveFileName>
 		<rootFolder>Espressif-IDE</rootFolder>
 	</properties>
 	

--- a/releng/com.espressif.idf.update/pom.xml
+++ b/releng/com.espressif.idf.update/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>com.espressif.idf.update</artifactId>
-	<version>2.10.0-SNAPSHOT</version>
+	<version>${espressif-ide-release-version}-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<parent>

--- a/tests/com.espressif.idf.core.test/pom.xml
+++ b/tests/com.espressif.idf.core.test/pom.xml
@@ -16,11 +16,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.espressif.idf</groupId>
-			<artifactId>com.espressif.idf.branding</artifactId>
-			<version>2.10.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>com.espressif.idf</groupId>
 			<artifactId>com.espressif.idf.core</artifactId>
 			<version>1.0.1-SNAPSHOT</version>
 		</dependency>


### PR DESCRIPTION
## Description

Bump version to 2.11.0

Fixes # ([IEP-1005](https://jira.espressif.com:8443/browse/IEP-1005))

## Type of change

Update version number to 2.11.0

## How has this been tested?

- Verify Espressif-IDE About version number
- Verify Update site version number

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Verify Espressif-IDE About version number
- Verify Update site version number
- Verify the generated installers version number

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
