### PR TITLE
GH #798: At execution Espressif-IDE getting 'Cannot invoke "org.eclipse.debug.core.ILaunchConfiguration.getType()" because "configuration" is null'

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
@@ -15,6 +15,13 @@ import org.eclipse.launchbar.core.ILaunchBarManager;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
 
+/**
+ * This provider allows you getting the active launch configuration from the ILaunchBarManager, even if it is not yet
+ * initialized. In this case, we look for the initialization Job and join it.
+ * 
+ * @author Denys Almazov <denys.almazov@espressif.com>
+ *
+ */
 public class ActiveLaunchConfigurationProvider
 {
 	private ILaunchBarManager launchBarManager;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
@@ -17,7 +17,17 @@ import com.espressif.idf.core.logging.Logger;
 
 public class ActiveLaunchConfigurationProvider
 {
-	private static ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+	private ILaunchBarManager launchBarManager;
+
+	public ActiveLaunchConfigurationProvider(ILaunchBarManager launchBarManager)
+	{
+		this.launchBarManager = launchBarManager;
+	}
+
+	public ActiveLaunchConfigurationProvider()
+	{
+		this(IDFCorePlugin.getService(ILaunchBarManager.class));
+	}
 
 	public ILaunchConfiguration getActiveLaunchConfiguration() throws CoreException
 	{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ActiveLaunchConfigurationProvider.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.build;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.logging.Logger;
+
+public class ActiveLaunchConfigurationProvider
+{
+	private static ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+
+	public ILaunchConfiguration getActiveLaunchConfiguration() throws CoreException
+	{
+		ILaunchConfiguration configuration = launchBarManager.getActiveLaunchConfiguration();
+
+		if (configuration == null)
+		{
+				Job[] jobs = Job.getJobManager().find(null);
+				@SuppressWarnings("restriction")
+				Optional<Job> launchBarInitJob = Stream.of(jobs)
+						.filter(job -> job.getName()
+								.equals(org.eclipse.launchbar.core.internal.Messages.LaunchBarManager_0))
+						.findAny();
+				launchBarInitJob.ifPresent(job -> {
+					try
+					{
+						job.join();
+					}
+					catch (InterruptedException e)
+					{
+						Logger.log(e);
+						Thread.currentThread().interrupt();
+					}
+				});
+				configuration = launchBarManager.getActiveLaunchConfiguration();
+		}
+		return configuration;
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -113,6 +113,7 @@ import com.google.gson.Gson;
 public class IDFBuildConfiguration extends CBuildConfiguration
 {
 
+	private static final ActiveLaunchConfigurationProvider LAUNCH_CONFIG_PROVIDER = new ActiveLaunchConfigurationProvider();
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
 	protected static final String COMPONENTS = "components"; //$NON-NLS-1$
@@ -247,7 +248,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	{
 		try
 		{
-			ILaunchConfiguration configuration = new ActiveLaunchConfigurationProvider().getActiveLaunchConfiguration();
+			ILaunchConfiguration configuration = LAUNCH_CONFIG_PROVIDER.getActiveLaunchConfiguration();
 			if (configuration != null
 					&& configuration.getType().getIdentifier().equals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 			{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -92,7 +92,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.launchbar.core.ILaunchBarManager;
@@ -248,15 +247,14 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	{
 		try
 		{
-			ILaunchConfiguration configuration = IDFCorePlugin.getService(ILaunchBarManager.class)
-					.getActiveLaunchConfiguration();
-			ILaunchConfigurationType debugConfigurationType = DebugPlugin.getDefault().getLaunchManager()
-					.getLaunchConfigurationType(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
-			if (configuration.getType().equals(debugConfigurationType))
+			ILaunchConfiguration configuration = new ActiveLaunchConfigurationProvider().getActiveLaunchConfiguration();
+			if (configuration != null
+					&& configuration.getType().getIdentifier().equals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 			{
 				configuration = getBoundConfiguration(configuration);
 			}
-			String property = configuration.getAttribute(name, StringUtil.EMPTY);
+			String property = configuration == null ? StringUtil.EMPTY
+					: configuration.getAttribute(name, StringUtil.EMPTY);
 			property = property.isBlank() ? getSettings().get(name, StringUtil.EMPTY) : property;
 			return property;
 		}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigProvider.java
@@ -30,7 +30,7 @@ public class SerialFlashLaunchConfigProvider extends IDFCoreLaunchConfigProvider
 	@Override
 	public boolean supports(ILaunchDescriptor descriptor, ILaunchTarget target) throws CoreException
 	{
-		return target.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE);
+		return target != null && target.getTypeId().equals(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE);
 	}
 
 	@Override

--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.espressif.idf.core;bundle-version="1.0.1",
  junit-jupiter-api,
  org.junit,
- junit-jupiter-params
+ junit-jupiter-params,
+ org.eclipse.launchbar.core
 Bundle-ClassPath: .,
  lib/jmock-2.12.0.jar,
  lib/commons-collections4-4.4.jar,
@@ -72,6 +73,7 @@ Export-Package: com.espressif.idf.core.test,
  org.jmock.auto,
  org.jmock.lib
 Import-Package: org.eclipse.core.runtime,
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.variables,
  org.junit.jupiter.params,
- org.junit.jupiter.params.provider,
- org.eclipse.core.variables
+ org.junit.jupiter.params.provider

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ActiveLaunchConfigurationTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ActiveLaunchConfigurationTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import com.espressif.idf.core.build.ActiveLaunchConfigurationProvider;
+import com.espressif.idf.core.logging.Logger;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ActiveLaunchConfigurationTest
+{
+
+	private static final String EXPECTED_LAUNCH_CONFIG_NAME = "expected_launch_config_name";
+
+	@Test
+	void get_active_launch_configuration_returns_expected_config_when_init_launchbar_job_is_active()
+			throws CoreException
+	{
+		ILaunchBarManager launchBarManager = mock(ILaunchBarManager.class);
+		ILaunchConfiguration launchConfiguration = mock(ILaunchConfiguration.class);
+
+		when(launchConfiguration.getName()).thenReturn(EXPECTED_LAUNCH_CONFIG_NAME);
+		when(launchBarManager.getActiveLaunchConfiguration()).thenReturn(null);
+		ActiveLaunchConfigurationProvider provider = new ActiveLaunchConfigurationProvider(launchBarManager);
+		runInitLaunchBarJob(launchBarManager, launchConfiguration);
+		ILaunchConfiguration configuration = provider.getActiveLaunchConfiguration();
+		
+		assertEquals(EXPECTED_LAUNCH_CONFIG_NAME, configuration.getName());
+	}
+
+	@Test
+	void get_active_launch_configuration_returns_expected_config_when_init_launchbar_job_is_not_active()
+			throws CoreException
+	{
+		ILaunchBarManager launchBarManager = mock(ILaunchBarManager.class);
+		ILaunchConfiguration launchConfiguration = mock(ILaunchConfiguration.class);
+
+		when(launchConfiguration.getName()).thenReturn(EXPECTED_LAUNCH_CONFIG_NAME);
+		when(launchBarManager.getActiveLaunchConfiguration()).thenReturn(launchConfiguration);
+		ActiveLaunchConfigurationProvider provider = new ActiveLaunchConfigurationProvider(launchBarManager);
+		ILaunchConfiguration configuration = provider.getActiveLaunchConfiguration();
+
+		assertEquals(EXPECTED_LAUNCH_CONFIG_NAME, configuration.getName());
+	}
+
+	private void runInitLaunchBarJob(ILaunchBarManager launchBarManager, ILaunchConfiguration launchConfiguration)
+	{
+		@SuppressWarnings("restriction")
+		Job job = new Job(org.eclipse.launchbar.core.internal.Messages.LaunchBarManager_0)
+		{
+
+			protected IStatus run(IProgressMonitor monitor)
+			{
+				try
+				{
+					when(launchBarManager.getActiveLaunchConfiguration()).thenReturn(launchConfiguration);
+				}
+				catch (CoreException e)
+				{
+					Logger.log(e);
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		job.schedule();
+	}
+
+}


### PR DESCRIPTION
## Description

The problem was that LaunchBarManager could return null because it was not yet initialized during the eclipse starting phase. 

Fixes # ([IEP-1002](https://jira.espressif.com:8443/browse/IEP-1002))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1
- run build -> during indexer phase restart eclipse -> after restarting open error log -> should be no NPE exception there

Test 2
- create/clean a workspace -> install tools -> create new project -> create new launch configuration  -> should be created correctly. Verify that there is no such error:
<img width="314" alt="Screenshot 2023-07-25 at 20 38 54" src="https://github.com/espressif/idf-eclipse-plugin/assets/24419842/2589de09-a917-4437-b707-7489d22dfb08">


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- build
- IDFBuildConfiguration

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
