### PR TITLE
Fix: IEP-1014 Unable to create a serial port object from the invalid port 

### DIFF
--- a/bundles/com.espressif.idf.branding/about.properties
+++ b/bundles/com.espressif.idf.branding/about.properties
@@ -2,6 +2,6 @@ blurb=ESP-IDF Eclipse Plugin\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2021 ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. All rights reserved.
+Copyright (c) 2015-2023 Espressif Systems. All rights reserved.
 \n\
 Visit https://www.espressif.com/

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -16,7 +16,6 @@
 package com.espressif.idf.launch.serial.ui.internal;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collection;
@@ -168,7 +167,7 @@ public class NewSerialFlashTargetWizardPage extends WizardPage {
 					}
 				}
 			}
-		} catch (IOException e) {
+		} catch (Exception e) {
 			Activator.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
 					Messages.NewSerialFlashTargetWizardPage_Fetching, e));
 		}


### PR DESCRIPTION
## Description

Fix the below error.  This happens when you're trying to open an serial port which doesn't exist. ` /dev/cu.usbserial-00001414B` does not exist in my serial port list, but this was my last saved serial port in the wizard. When I try to launch the serial launch target wizard, it will throw the following error.

```
!STACK 0
com.fazecast.jSerialComm.SerialPortInvalidPortException: Unable to create a serial port object from the invalid port descriptor: /dev/cu.usbserial-00001414B
	at com.fazecast.jSerialComm.SerialPort.getCommPort(SerialPort.java:410)
	at com.espressif.idf.launch.serial.ui.internal.NewSerialFlashTargetWizardPage.createControl(NewSerialFlashTargetWizardPage.java:158)
	at org.eclipse.jface.wizard.Wizard.createPageControls(Wizard.java:178)
	at org.eclipse.jface.wizard.WizardDialog.createPageControls(WizardDialog.java:744)
	at org.eclipse.jface.wizard.WizardDialog.createContents(WizardDialog.java:636)

```
Fixes # ([IEP-1014](https://jira.espressif.com:8443/browse/IEP-1014))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
