### PR TITLE
IEP-1018 Automation of hints viewer

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
@@ -24,7 +24,7 @@ public class IDFCorePreferenceConstants
 	public static final String CMAKE_CCACHE_STATUS = "cmakeCCacheStatus"; //$NON-NLS-1$
 	public static final String AUTOMATE_BUILD_HINTS_STATUS = "automateHintsStatus"; //$NON-NLS-1$
 	public static final boolean CMAKE_CCACHE_DEFAULT_STATUS = true;
-	public static final boolean AUTOMATE_BUILD_HINTS_DEFAULT_STATUS = false;
+	public static final boolean AUTOMATE_BUILD_HINTS_DEFAULT_STATUS = true;
 	/**
 	 * Returns the node in the preference in the given context.
 	 *

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
@@ -22,8 +22,9 @@ public class IDFCorePreferenceConstants
 {
 	// CMake CCache preferences
 	public static final String CMAKE_CCACHE_STATUS = "cmakeCCacheStatus"; //$NON-NLS-1$
+	public static final String AUTOMATE_BUILD_HINTS_STATUS = "automateHintsStatus"; //$NON-NLS-1$
 	public static final boolean CMAKE_CCACHE_DEFAULT_STATUS = true;
-
+	public static final boolean AUTOMATE_BUILD_HINTS_DEFAULT_STATUS = false;
 	/**
 	 * Returns the node in the preference in the given context.
 	 *

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -7,9 +7,11 @@ package com.espressif.idf.core.build;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.cdt.core.IConsoleParser;
 
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.util.StringUtil;
@@ -50,8 +52,18 @@ public class EspIdfErrorParser implements IConsoleParser
 	{
 		for (ReHintPair reHintEntry : reHintsList)
 		{
-			boolean isRegexMatchesWithProcessedString = Pattern.compile(reHintEntry.getRe()).matcher(paramString)
-					.find();
+			boolean isRegexMatchesWithProcessedString = false;
+			try
+			{
+				isRegexMatchesWithProcessedString = Pattern.compile(reHintEntry.getRe()).matcher(paramString).find();
+			}
+			catch (PatternSyntaxException e)
+			{
+				// catching incompatible Python regex
+				Logger.log(e);
+				continue;
+			}
+
 			if (isRegexMatchesWithProcessedString)
 			{
 				allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -4,7 +4,6 @@
  *******************************************************************************/
 package com.espressif.idf.core.build;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -13,7 +12,6 @@ import org.eclipse.cdt.core.IConsoleParser;
 
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
-import com.espressif.idf.core.util.HintsUtil;
 import com.espressif.idf.core.util.StringUtil;
 
 /**
@@ -40,9 +38,14 @@ import com.espressif.idf.core.util.StringUtil;
 public class EspIdfErrorParser implements IConsoleParser
 {
 
-	private List<ReHintPair> reHintsList = HintsUtil.getReHintsList(new File(HintsUtil.getHintsYmlPath()));
-	private List<ReHintPair> allMatchesList = new ArrayList<>();
+	private List<ReHintPair> reHintsList;
+	private List<ReHintPair> allMatchesList;
 
+	public EspIdfErrorParser(List<ReHintPair> reHintPairs)
+	{
+		this.reHintsList = reHintPairs;
+		this.allMatchesList = new ArrayList<>();
+	}
 	public boolean processLine(String paramString)
 	{
 		for (ReHintPair reHintEntry : reHintsList)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -1,3 +1,7 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.core.build;
 
 import java.io.File;
@@ -10,13 +14,39 @@ import org.eclipse.cdt.core.IConsoleParser;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.util.HintsUtil;
+import com.espressif.idf.core.util.StringUtil;
 
+/**
+ * The EspIdfErrorParser class implements the IConsoleParser interface to parse console output for ESP-IDF errors and
+ * extract relevant hints. It processes each line of the console output and checks against a list of regular expression
+ * patterns to identify errors and their corresponding hints.
+ *
+ * This class maintains a list of regular expression hint pairs (ReHintPair) that are used to match and identify errors,
+ * and associate them with appropriate hints. It accumulates matched pairs in the 'allMatchesList' for further
+ * processing.
+ *
+ * The processLine method is responsible for processing each input line by iterating through the list of regular
+ * expression hint pairs. It uses regular expressions to determine if the line matches any error pattern. If a match is
+ * found, the corresponding hint is associated with the error message and added to the 'allMatchesList'.
+ *
+ * If no matches are found using regular expressions, the processLine method performs a substring-based check against
+ * the error patterns to capture potential matches. If any matches are identified, the corresponding hints are again
+ * associated with the errors and added to the 'allMatchesList'.
+ *
+ * The shutdown method is used to trigger the completion of parsing. It notifies listeners registred in the UI plugin
+ * that the list of available hints has changed, providing the accumulated error hint pairs to any interested parties.
+ * The 'allMatchesList' is then cleared to prepare for the next parsing session.
+ *
+ * Note: This class assumes the availability of HintsUtil and ReHintPair classes.
+ *
+ * @author Denys Almazov (denys.almazov@espressif.com)
+ *
+ */
 public class EspIdfErrorParser implements IConsoleParser
 {
 
 	private List<ReHintPair> reHintsList = HintsUtil.getReHintsList(new File(HintsUtil.getHintsYmlPath()));
 	private List<ReHintPair> allMatchesList = new ArrayList<>();
-	private List<String> errorList = new ArrayList<>();
 
 	public boolean processLine(String paramString)
 	{
@@ -25,8 +55,7 @@ public class EspIdfErrorParser implements IConsoleParser
 			boolean isRegexMatchesWithField = Pattern.compile(reHintEntry.getRe()).matcher(paramString).find();
 			if (isRegexMatchesWithField)
 			{
-				allMatchesList.add(reHintEntry);
-				errorList.add(paramString);
+				allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
 			}
 		}
 		if (allMatchesList.isEmpty())
@@ -35,8 +64,7 @@ public class EspIdfErrorParser implements IConsoleParser
 			{
 				if (reHintEntry.getRe().contains(paramString))
 				{
-					allMatchesList.add(reHintEntry);
-					errorList.add(paramString);
+					allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
 				}
 			}
 		}
@@ -45,16 +73,8 @@ public class EspIdfErrorParser implements IConsoleParser
 
 	public void shutdown()
 	{
-		StringBuilder comBuilder = new StringBuilder();
-		for (int i = 0; i < errorList.size(); i++)
-		{
-			comBuilder.append(errorList.get(i) + "-" + reHintsList.get(i).getHint() + "\n");
-		}
 		OpenDialogListenerSupport.getSupport().firePropertyChange(PopupDialog.AVAILABLE_HINTS.name(),
-				PopupDialog.AVAILABLE_HINTS.name(),
-				comBuilder.toString());
+					StringUtil.EMPTY, new ArrayList<>(allMatchesList));
 		allMatchesList.clear();
 	}
-
-
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -51,8 +51,9 @@ public class EspIdfErrorParser implements IConsoleParser
 	{
 		for (ReHintPair reHintEntry : reHintsList)
 		{
-			boolean isRegexMatchesWithField = Pattern.compile(reHintEntry.getRe()).matcher(paramString).find();
-			if (isRegexMatchesWithField)
+			boolean isRegexMatchesWithProcessedString = Pattern.compile(reHintEntry.getRe()).matcher(paramString)
+					.find();
+			if (isRegexMatchesWithProcessedString)
 			{
 				allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
 				return true;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -1,0 +1,60 @@
+package com.espressif.idf.core.build;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.cdt.core.IConsoleParser;
+
+import com.espressif.idf.core.resources.OpenDialogListenerSupport;
+import com.espressif.idf.core.resources.PopupDialog;
+import com.espressif.idf.core.util.HintsUtil;
+
+public class EspIdfErrorParser implements IConsoleParser
+{
+
+	private List<ReHintPair> reHintsList = HintsUtil.getReHintsList(new File(HintsUtil.getHintsYmlPath()));
+	private List<ReHintPair> allMatchesList = new ArrayList<>();
+	private List<String> errorList = new ArrayList<>();
+
+	public boolean processLine(String paramString)
+	{
+		for (ReHintPair reHintEntry : reHintsList)
+		{
+			boolean isRegexMatchesWithField = Pattern.compile(reHintEntry.getRe()).matcher(paramString).find();
+			if (isRegexMatchesWithField)
+			{
+				allMatchesList.add(reHintEntry);
+				errorList.add(paramString);
+			}
+		}
+		if (allMatchesList.isEmpty())
+		{
+			for (ReHintPair reHintEntry : reHintsList)
+			{
+				if (reHintEntry.getRe().contains(paramString))
+				{
+					allMatchesList.add(reHintEntry);
+					errorList.add(paramString);
+				}
+			}
+		}
+		return false;
+	}
+
+	public void shutdown()
+	{
+		StringBuilder comBuilder = new StringBuilder();
+		for (int i = 0; i < errorList.size(); i++)
+		{
+			comBuilder.append(errorList.get(i) + "-" + reHintsList.get(i).getHint() + "\n");
+		}
+		OpenDialogListenerSupport.getSupport().firePropertyChange(PopupDialog.AVAILABLE_HINTS.name(),
+				PopupDialog.AVAILABLE_HINTS.name(),
+				comBuilder.toString());
+		allMatchesList.clear();
+	}
+
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -55,16 +55,7 @@ public class EspIdfErrorParser implements IConsoleParser
 			if (isRegexMatchesWithField)
 			{
 				allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
-			}
-		}
-		if (allMatchesList.isEmpty())
-		{
-			for (ReHintPair reHintEntry : reHintsList)
-			{
-				if (reHintEntry.getRe().contains(paramString))
-				{
-					allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
-				}
+				return true;
 			}
 		}
 		return false;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -29,10 +29,6 @@ import com.espressif.idf.core.util.StringUtil;
  * expression hint pairs. It uses regular expressions to determine if the line matches any error pattern. If a match is
  * found, the corresponding hint is associated with the error message and added to the 'allMatchesList'.
  *
- * If no matches are found using regular expressions, the processLine method performs a substring-based check against
- * the error patterns to capture potential matches. If any matches are identified, the corresponding hints are again
- * associated with the errors and added to the 'allMatchesList'.
- *
  * The shutdown method is used to trigger the completion of parsing. It notifies listeners registred in the UI plugin
  * that the list of available hints has changed and providing the accumulated error hint pairs. The 'allMatchesList' is
  * then cleared to prepare for the next parsing session.

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -34,10 +34,9 @@ import com.espressif.idf.core.util.StringUtil;
  * associated with the errors and added to the 'allMatchesList'.
  *
  * The shutdown method is used to trigger the completion of parsing. It notifies listeners registred in the UI plugin
- * that the list of available hints has changed, providing the accumulated error hint pairs to any interested parties.
- * The 'allMatchesList' is then cleared to prepare for the next parsing session.
+ * that the list of available hints has changed and providing the accumulated error hint pairs. The 'allMatchesList' is
+ * then cleared to prepare for the next parsing session.
  *
- * Note: This class assumes the availability of HintsUtil and ReHintPair classes.
  *
  * @author Denys Almazov (denys.almazov@espressif.com)
  *

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/EspIdfErrorParser.java
@@ -6,12 +6,9 @@ package com.espressif.idf.core.build;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.cdt.core.IConsoleParser;
 
-import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.util.StringUtil;
@@ -50,27 +47,13 @@ public class EspIdfErrorParser implements IConsoleParser
 	}
 	public boolean processLine(String paramString)
 	{
-		for (ReHintPair reHintEntry : reHintsList)
-		{
-			boolean isRegexMatchesWithProcessedString = false;
-			try
-			{
-				isRegexMatchesWithProcessedString = Pattern.compile(reHintEntry.getRe()).matcher(paramString).find();
-			}
-			catch (PatternSyntaxException e)
-			{
-				// catching incompatible Python regex
-				Logger.log(e);
-				continue;
-			}
+		int initialListSize = allMatchesList.size();
+		reHintsList.stream().filter(
+				reHintEntry -> reHintEntry.getRe().map(pattern -> pattern.matcher(paramString).find()).orElse(false))
+				.forEach(matchedReHintEntry -> allMatchesList
+						.add(new ReHintPair(paramString, matchedReHintEntry.getHint())));
 
-			if (isRegexMatchesWithProcessedString)
-			{
-				allMatchesList.add(new ReHintPair(paramString, reHintEntry.getHint()));
-				return true;
-			}
-		}
-		return false;
+		return allMatchesList.size() != initialListSize;
 	}
 
 	public void shutdown()

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -420,8 +420,13 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$
 				throw new CmakeBuildException();
 			}
-
-			watchProcess(p, new IConsoleParser[] { epm, new StatusParser(), new EspIdfErrorParser() });
+			boolean buildHintsStatus = Platform.getPreferencesService().getBoolean(IDFCorePlugin.PLUGIN_ID,
+					IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS,
+					IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS, null);
+			IConsoleParser[] consoleParsers = buildHintsStatus
+					? new IConsoleParser[] { epm, new StatusParser(), new EspIdfErrorParser() }
+					: new IConsoleParser[] { epm, new StatusParser() };
+			watchProcess(p, consoleParsers);
 
 			final String isSkip = System.getProperty("skip.idf.components"); //$NON-NLS-1$
 			if (!Boolean.parseBoolean(isSkip))

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -105,6 +105,7 @@ import com.espressif.idf.core.internal.CMakeConsoleWrapper;
 import com.espressif.idf.core.internal.CMakeErrorParser;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.DfuCommandsUtil;
+import com.espressif.idf.core.util.HintsUtil;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.ParitionSizeHandler;
 import com.espressif.idf.core.util.StringUtil;
@@ -423,7 +424,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 					IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS,
 					IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS, null);
 			IConsoleParser[] consoleParsers = buildHintsStatus
-					? new IConsoleParser[] { epm, new StatusParser(), new EspIdfErrorParser() }
+					? new IConsoleParser[] { epm, new StatusParser(),
+							new EspIdfErrorParser(HintsUtil.getReHintsList(new File(HintsUtil.getHintsYmlPath()))) }
 					: new IConsoleParser[] { epm, new StatusParser() };
 			watchProcess(p, consoleParsers);
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -140,7 +140,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private IBuildConfiguration buildConfiguration;
 	private IProgressMonitor monitor;
 	public boolean isProgressSet;
-	public static List<String> errorLines = new ArrayList<>();
 
 	public IDFBuildConfiguration(IBuildConfiguration config, String name) throws CoreException
 	{
@@ -564,8 +563,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 								}
 								else
 								{
-									if (consoleParser.processLine(line) != true)
-										errorLines.add(line);
+									consoleParser.processLine(line);
 								}
 							}
 						}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ReHintPair.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ReHintPair.java
@@ -4,6 +4,11 @@
  *******************************************************************************/
 package com.espressif.idf.core.build;
 
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import com.espressif.idf.core.logging.Logger;
+
 /**
  * Represents a parsed re and hint entries of a hints.yml file.
  * 
@@ -11,18 +16,25 @@ package com.espressif.idf.core.build;
  */
 public class ReHintPair
 {
-	private String re;
+	private Pattern re;
 	private String hint;
 
 	public ReHintPair(String re, String hint)
 	{
-		this.re = re;
+		try
+		{
+			this.re = Pattern.compile(re);
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
 		this.hint = hint;
 	}
 
-	public String getRe()
+	public Optional<Pattern> getRe()
 	{
-		return re;
+		return Optional.ofNullable(re);
 	}
 
 	public String getHint()

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ReHintPair.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/ReHintPair.java
@@ -6,6 +6,7 @@ package com.espressif.idf.core.build;
 
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import com.espressif.idf.core.logging.Logger;
 
@@ -25,7 +26,7 @@ public class ReHintPair
 		{
 			this.re = Pattern.compile(re);
 		}
-		catch (Exception e)
+		catch (PatternSyntaxException e)
 		{
 			Logger.log(e);
 		}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/PopupDialog.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/resources/PopupDialog.java
@@ -1,0 +1,6 @@
+package com.espressif.idf.core.resources;
+
+public enum PopupDialog
+{
+	LOW_PARTITION_SIZE, AVAILABLE_HINTS
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
@@ -57,17 +57,15 @@ public class ParitionSizeHandler
 				+ "partition-table.bin"); //$NON-NLS-1$
 
 		Process process = startProcess(commands);
-		String partitionTableContent = new String(process.getInputStream().readAllBytes());
-		return partitionTableContent;
+		return new String(process.getInputStream().readAllBytes());
 	}
 
 	private Process startProcess(List<String> commands) throws IOException
 	{
-		infoStream.write(String.join(" ", commands) + '\n'); //$NON-NLS-1$ //$NON-NLS-2$
+		infoStream.write(String.join(" ", commands) + '\n'); //$NON-NLS-1$
 		Path workingDir = (Path) project.getLocation();
 		ProcessBuilder processBuilder = new ProcessBuilder(commands).directory(workingDir.toFile());
-		Process process = processBuilder.start();
-		return process;
+		return processBuilder.start();
 	}
 
 	private void startIdfSizeProcess() throws IOException, CoreException

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ParitionSizeHandler.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
+import com.espressif.idf.core.resources.PopupDialog;
 
 public class ParitionSizeHandler
 {
@@ -100,7 +101,8 @@ public class ParitionSizeHandler
 			double remainSize = (maxSize - imageSize) / (maxSize);
 			if (remainSize < 0.3)
 			{
-				OpenDialogListenerSupport.getSupport().firePropertyChange(null, maxSize, remainSize * maxSize);
+				OpenDialogListenerSupport.getSupport().firePropertyChange(PopupDialog.LOW_PARTITION_SIZE.name(),
+						maxSize, remainSize * maxSize);
 				break;
 			}
 		}

--- a/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.espressif.idf.ui/OSGI-INF/l10n/bundle.properties
@@ -68,3 +68,4 @@ command.name.PartitionTableEditor = ESP-IDF: Partition Table Editor
 command.label.nsvTableEditor = ESP-IDF: NVS Table Editor
 command.name.nvsTableEditor = ESP-IDF: NVS Table Editor
 command.tooltip.nvsTableEditor = NVS Editor can help you to easily edit NVS CSV, generate encrypted and non-encrypted partitions through GUI, without interacting directly with the csv files. 
+build_hints.name = Build Hints

--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -638,6 +638,15 @@
             id="com.espressif.idf.ui.category"
             name="%views_category.name">
       </category>
+      <view
+            allowMultiple="false"
+            category="com.espressif.idf.ui.category"
+            class="com.espressif.idf.ui.dialogs.BuildView"
+            icon="icons/Hints_View.png"
+            id="com.espressif.idf.ui.views.buildhints"
+            name="%build_hints.name"
+            restorable="true">
+      </view>
    </extension>
    <extension
          point="org.eclipse.ui.intro">

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -5,7 +5,6 @@
 package com.espressif.idf.ui;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -35,6 +34,7 @@ import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.build.Messages;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
+import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.resources.ResourceChangeListener;
 import com.espressif.idf.core.toolchain.ESPToolChainManager;
 import com.espressif.idf.core.util.StringUtil;
@@ -65,24 +65,18 @@ public class InitializeToolsStartup implements IStartup
 	@Override
 	public void earlyStartup()
 	{
-		OpenDialogListenerSupport.getSupport().addPropertyChangeListener(new PropertyChangeListener()
-		{
-
-			@Override
-			public void propertyChange(PropertyChangeEvent evt)
+		OpenDialogListenerSupport.getSupport().addPropertyChangeListener((evt) -> {
+			PopupDialog popupDialog = PopupDialog.valueOf(evt.getPropertyName());
+			switch (popupDialog)
 			{
-				Display.getDefault().asyncExec(new Runnable()
-				{
-					@Override
-					public void run()
-					{
-						MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
-								Messages.IncreasePartitionSizeTitle,
-								MessageFormat.format(Messages.IncreasePartitionSizeMessage, evt.getNewValue(),
-										evt.getOldValue(), DOC_URL));
-					}
-				});
-
+			case LOW_PARTITION_SIZE:
+				openLowPartitionSizeDialog(evt);
+				break;
+			case AVAILABLE_HINTS:
+				openAvailableHintsDialog(evt);
+				break;
+			default:
+				break;
 			}
 		});
 		ILaunchBarListener launchBarListener = new LaunchBarListener();
@@ -196,6 +190,24 @@ public class InitializeToolsStartup implements IStartup
 		{
 			Logger.log(e);
 		}
+	}
+
+	private void openAvailableHintsDialog(PropertyChangeEvent evt)
+	{
+		Display.getDefault().asyncExec(() ->
+				MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(), "Available Hints", MessageFormat
+						.format("Detected errors and hints for them: {0}", evt.getNewValue()))
+		);
+
+	}
+
+	private void openLowPartitionSizeDialog(PropertyChangeEvent evt)
+	{
+		Display.getDefault().asyncExec(() ->
+				MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
+						Messages.IncreasePartitionSizeTitle, MessageFormat.format(Messages.IncreasePartitionSizeMessage,
+								evt.getNewValue(), evt.getOldValue(), DOC_URL))
+			);
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -232,7 +232,7 @@ public class InitializeToolsStartup implements IStartup
 				.findView(BUILDHINTS_ID));
 		if (view != null)
 		{
-			view.setReHintsPairs(erroHintPairs);
+			view.updateReHintsPairs(erroHintPairs);
 		}
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -51,7 +51,7 @@ import com.espressif.idf.ui.update.InstallToolsHandler;
 public class InitializeToolsStartup implements IStartup
 {
 
-	private static final String BUILDHINTS_ID = "com.espressif.idf.ui.views.buildhints";
+	private static final String BUILDHINTS_ID = "com.espressif.idf.ui.views.buildhints"; //$NON-NLS-1$
 
 	/**
 	 * esp-idf.json is file created by the installer

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -204,6 +204,13 @@ public class InitializeToolsStartup implements IStartup
 	{
 		Display.getDefault().asyncExec(() ->
 		{
+			List<ReHintPair> erroHintPairs = (List<ReHintPair>) evt.getNewValue();
+			// if list is empty we don't want to change focus from the console output
+			if (erroHintPairs.isEmpty())
+			{
+				updateValuesInBuildView(erroHintPairs);
+				return;
+			}
 			try
 			{
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
@@ -213,12 +220,20 @@ public class InitializeToolsStartup implements IStartup
 			{
 				Logger.log(e);
 			}
-			BuildView view = ((BuildView) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
-					.findView(BUILDHINTS_ID));
-			view.setReHintsPairs((List<ReHintPair>) evt.getNewValue());
+			updateValuesInBuildView(erroHintPairs);
 		}
 		);
 
+	}
+
+	private void updateValuesInBuildView(List<ReHintPair> erroHintPairs)
+	{
+		BuildView view = ((BuildView) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+				.findView(BUILDHINTS_ID));
+		if (view != null)
+		{
+			view.setReHintsPairs(erroHintPairs);
+		}
 	}
 
 	private void openLowPartitionSizeDialog(PropertyChangeEvent evt)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
@@ -34,7 +34,7 @@ public class BuildView extends ViewPart
 {
 
 	private TableViewer hintsTableViewer;
-	private final String[] titles = { "Error Message", "Hint" }; //$NON-NLS-1$ //$NON-NLS-2$
+	private final String[] titles = { Messages.BuildView_ErrorMsgLbl, Messages.BuildView_HintMsgLbl };
 	private List<ReHintPair> reHintsPairs;
 	private Composite parent;
 	private Composite container;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
@@ -1,0 +1,141 @@
+package com.espressif.idf.ui.dialogs;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.ViewPart;
+
+import com.espressif.idf.core.build.ReHintPair;
+
+public class BuildView extends ViewPart
+{
+
+	private TableViewer hintsTableViewer;
+	private final String[] titles = { "Error Message", "Hint" }; //$NON-NLS-1$ //$NON-NLS-2$
+	private List<ReHintPair> reHintsPairs;
+	private Composite parent;
+	private Composite container;
+	public BuildView()
+	{
+		reHintsPairs = Collections.emptyList();
+	}
+
+	public void setReHintsPairs(List<ReHintPair> reHintPairs)
+	{
+		this.reHintsPairs = reHintPairs;
+		container.dispose();
+		createPartControl(parent);
+		parent.pack();
+		parent.layout(true);
+	}
+
+	public void createPartControl(Composite parent)
+	{
+		this.parent = parent;
+		container = new Composite(this.parent, SWT.NONE);
+		container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		GridLayout layout = new GridLayout(1, true);
+		container.setLayout(layout);
+		createHintsViewer(container);
+	}
+
+	private void createHintsViewer(Composite container)
+	{
+		hintsTableViewer = new TableViewer(container,
+				SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER);
+		createColumns(container);
+		Table hintsTable = hintsTableViewer.getTable();
+		hintsTable.setHeaderVisible(true);
+		hintsTable.setLinesVisible(true);
+		hintsTableViewer.setContentProvider(new ArrayContentProvider());
+		hintsTableViewer.setInput(reHintsPairs);
+		resizeAllColumns();
+		GridData gridData = new GridData();
+		gridData.verticalAlignment = GridData.FILL;
+		gridData.horizontalSpan = 1;
+		gridData.grabExcessHorizontalSpace = true;
+		gridData.grabExcessVerticalSpace = true;
+		gridData.horizontalAlignment = GridData.FILL;
+		hintsTableViewer.getControl().setLayoutData(gridData);
+
+	}
+
+	private void resizeAllColumns()
+	{
+		for (TableColumn tc : hintsTableViewer.getTable().getColumns())
+		{
+			tc.pack();
+		}
+	}
+
+	private void createColumns(Composite container)
+	{
+		TableViewerColumn col = createTableViewerColumn(titles[0]);
+		col.setLabelProvider(new ColumnLabelProvider()
+		{
+			@Override
+			public Image getImage(Object element)
+			{
+				return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_ERROR_TSK);
+			}
+
+			@Override
+			public String getText(Object element)
+			{
+				return ((ReHintPair) element).getRe();
+			}
+		});
+		col = createTableViewerColumn(titles[1]);
+		col.setLabelProvider(new ColumnLabelProvider()
+		{
+			@Override
+			public Image getImage(Object element)
+			{
+				return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK);
+			}
+
+			@Override
+			public String getText(Object element)
+			{
+				return ((ReHintPair) element).getHint();
+			}
+		});
+		col.getViewer().addDoubleClickListener(event ->
+		{
+				StructuredSelection selection = (StructuredSelection) event.getViewer().getSelection();
+				MessageDialog.openInformation(container.getShell(), Messages.HintDetailsTitle,
+						((ReHintPair) selection.getFirstElement()).getHint());
+
+		});
+	}
+
+	private TableViewerColumn createTableViewerColumn(String title)
+	{
+		TableViewerColumn viewerColumn = new TableViewerColumn(hintsTableViewer, SWT.NONE);
+		TableColumn column = viewerColumn.getColumn();
+		column.setText(title);
+		column.setResizable(true);
+		column.setMoveable(true);
+		return viewerColumn;
+	}
+
+	public void setFocus()
+	{
+	}
+
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
@@ -1,5 +1,11 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
 package com.espressif.idf.ui.dialogs;
 
+import java.io.File;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 
@@ -10,6 +16,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -21,6 +28,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 
 import com.espressif.idf.core.build.ReHintPair;
+import com.espressif.idf.core.util.HintsUtil;
 
 public class BuildView extends ViewPart
 {
@@ -35,7 +43,7 @@ public class BuildView extends ViewPart
 		reHintsPairs = Collections.emptyList();
 	}
 
-	public void setReHintsPairs(List<ReHintPair> reHintPairs)
+	public void updateReHintsPairs(List<ReHintPair> reHintPairs)
 	{
 		this.reHintsPairs = reHintPairs;
 		container.dispose();
@@ -51,7 +59,34 @@ public class BuildView extends ViewPart
 		container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		GridLayout layout = new GridLayout(1, true);
 		container.setLayout(layout);
+		if (reHintsPairs.isEmpty())
+		{
+			if (!new File(HintsUtil.getHintsYmlPath()).exists())
+			{
+				createNoHintsYmlLabel();
+			}
+			else
+			{
+				createNoAvailableHintsLabel();
+			}
+			return;
+		}
 		createHintsViewer(container);
+	}
+
+	private void createNoAvailableHintsLabel()
+	{
+		CLabel infoField = new CLabel(container, SWT.H_SCROLL);
+		infoField.setImage(
+				PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK));
+		infoField.setText(Messages.BuildView_NoAvailableHintsMsg);
+	}
+
+	private void createNoHintsYmlLabel()
+	{
+		CLabel errorField = new CLabel(container, SWT.H_SCROLL);
+		errorField.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_ERROR_TSK));
+		errorField.setText(MessageFormat.format(Messages.HintsYmlNotFoundErrMsg, HintsUtil.getHintsYmlPath()));
 	}
 
 	private void createHintsViewer(Composite container)
@@ -136,6 +171,7 @@ public class BuildView extends ViewPart
 
 	public void setFocus()
 	{
+		// Do nothing
 	}
 
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/BuildView.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -29,12 +31,13 @@ import org.eclipse.ui.part.ViewPart;
 
 import com.espressif.idf.core.build.ReHintPair;
 import com.espressif.idf.core.util.HintsUtil;
+import com.espressif.idf.core.util.StringUtil;
 
 public class BuildView extends ViewPart
 {
 
 	private TableViewer hintsTableViewer;
-	private final String[] titles = { Messages.BuildView_ErrorMsgLbl, Messages.BuildView_HintMsgLbl };
+	private final String[] titles = { Messages.BuildView_ErrorMsgLbl, Messages.BuildView_HintMsgLbl }; 
 	private List<ReHintPair> reHintsPairs;
 	private Composite parent;
 	private Composite container;
@@ -132,7 +135,8 @@ public class BuildView extends ViewPart
 			@Override
 			public String getText(Object element)
 			{
-				return ((ReHintPair) element).getRe();
+				Optional<Pattern> reOptionalPattern = ((ReHintPair) element).getRe();
+				return reOptionalPattern.isPresent() ? reOptionalPattern.get().pattern() : StringUtil.EMPTY;
 			}
 		});
 		col = createTableViewerColumn(titles[1]);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/Messages.java
@@ -5,6 +5,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.dialogs.messages"; //$NON-NLS-1$
+	public static String BuildView_NoAvailableHintsMsg;
 	public static String DeleteResourcesWizard_project_deleteConfigurations;
 	public static String CMakeBuildTab2_AdditionalCMakeArgs;
 	public static String CMakeBuildTab2_BuildCmd;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/Messages.java
@@ -5,6 +5,8 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.dialogs.messages"; //$NON-NLS-1$
+	public static String BuildView_ErrorMsgLbl;
+	public static String BuildView_HintMsgLbl;
 	public static String BuildView_NoAvailableHintsMsg;
 	public static String DeleteResourcesWizard_project_deleteConfigurations;
 	public static String CMakeBuildTab2_AdditionalCMakeArgs;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/messages.properties
@@ -1,3 +1,5 @@
+BuildView_ErrorMsgLbl=Error Message
+BuildView_HintMsgLbl=Hint
 BuildView_NoAvailableHintsMsg=No available hints found
 CMakeBuildTab2_AdditionalCMakeArgs=Additional CMake arguments:
 CMakeBuildTab2_BuildCmd=Build command

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/dialogs/messages.properties
@@ -1,3 +1,4 @@
+BuildView_NoAvailableHintsMsg=No available hints found
 CMakeBuildTab2_AdditionalCMakeArgs=Additional CMake arguments:
 CMakeBuildTab2_BuildCmd=Build command
 CMakeBuildTab2_CleanCmd=Clean command

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -32,6 +32,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	private Text numberLineText;
 	private Text gdbSettingsText;
 	private Button ccacheBtn;
+	private Button automateHintsBtn;
 
 	public EspresssifPreferencesPage()
 	{
@@ -66,7 +67,23 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 
 		addSerialSettings(mainComposite);
 
+		addBuildSettings(mainComposite);
+
 		return mainComposite;
+	}
+
+	private void addBuildSettings(Composite mainComposite)
+	{
+		Group buildGroup = new Group(mainComposite, SWT.SHADOW_ETCHED_IN);
+		buildGroup.setText(Messages.EspresssifPreferencesPage_BuildGroupTxt);
+		buildGroup.setLayout(new GridLayout(1, false));
+
+		automateHintsBtn = new Button(buildGroup, SWT.CHECK);
+		automateHintsBtn.setText(Messages.EspresssifPreferencesPage_SearchHintsCheckBtn);
+		automateHintsBtn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		automateHintsBtn.setToolTipText(Messages.EspresssifPreferencesPage_SearchHintsTooltip);
+		automateHintsBtn
+				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS));
 	}
 
 	private void addccacheControl(Composite mainComposite)
@@ -134,6 +151,9 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 			getPreferenceStore().setValue(NUMBER_OF_LINES, numberOfLines);
 
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, ccacheBtn.getSelection());
+
+			getPreferenceStore().setValue(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS,
+					automateHintsBtn.getSelection());
 		}
 		catch (Exception e)
 		{
@@ -151,6 +171,8 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		numberOfCharsInLineText
 				.setText(Integer.toString(getPreferenceStore().getDefaultInt(NUMBER_OF_CHARS_IN_A_LINE)));
 		ccacheBtn.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS));
+		automateHintsBtn
+				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS));
 	}
 
 	private void initializeDefaults()
@@ -160,5 +182,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		getPreferenceStore().setDefault(NUMBER_OF_LINES, DEFAULT_SERIAL_MONITOR_NUBMER_OF_LINES);
 		getPreferenceStore().setDefault(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS,
 				IDFCorePreferenceConstants.CMAKE_CCACHE_DEFAULT_STATUS);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS,
+				IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
@@ -5,9 +5,12 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.preferences.messages"; //$NON-NLS-1$
+	public static String EspresssifPreferencesPage_BuildGroupTxt;
 	public static String EspresssifPreferencesPage_CCacheToolTip;
 	public static String EspresssifPreferencesPage_EnableCCache;
 	public static String EspresssifPreferencesPage_IDFSpecificPrefs;
+	public static String EspresssifPreferencesPage_SearchHintsCheckBtn;
+	public static String EspresssifPreferencesPage_SearchHintsTooltip;
 	public static String GDBServerTimeoutPage_TimeoutField;
 	public static String SerialMonitorPage_Field_NumberOfLines;
 	public static String SerialMonitorPage_Field_NumberOfCharsInLine;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
@@ -1,6 +1,9 @@
+EspresssifPreferencesPage_BuildGroupTxt=Build Settings
 EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build
 EspresssifPreferencesPage_EnableCCache=Enable CMake cache
 EspresssifPreferencesPage_IDFSpecificPrefs=ESP-IDF Specific Preferences.
+EspresssifPreferencesPage_SearchHintsCheckBtn=Search hints for build errors (may affect build performance)
+EspresssifPreferencesPage_SearchHintsTooltip=If enabled, a Build Hints view will automatically open after a build
 GDBServerTimeoutPage_TimeoutField=GDB server launch timeout(s)
 SerialMonitorPage_Field_NumberOfCharsInLine=Console Line Width (maximum characters):
 SerialMonitorPage_Field_NumberOfLines=Limit Console Output (number of lines):

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
@@ -80,7 +80,7 @@ class EspIdfErrorParserTest
 
 		assertTrue(actualResult);
 		assertEquals(expectedHint, actualReHintPair.get(0).getHint());
-		assertEquals(errorLine, actualReHintPair.get(0).getRe());
+		assertEquals(errorLine, actualReHintPair.get(0).getRe().get().pattern());
 	}
 
 }

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2022-2023 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.build.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import com.espressif.idf.core.build.EspIdfErrorParser;
+import com.espressif.idf.core.build.ReHintPair;
+import com.espressif.idf.core.resources.OpenDialogListenerSupport;
+import com.espressif.idf.core.resources.PopupDialog;
+import com.espressif.idf.core.util.StringUtil;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EspIdfErrorParserTest
+{
+
+	private static final String NON_EXISTING_ERROR_REGEX = "non existing error regex";
+	private static final String ERROR_LINE = "/hello_world/main/hello_world_main.c:14:10: fatal error: spiram.h: No such file or directory";
+	private static final String EXPECTED_HINT = "EXPECTED_HINT";
+	private static final String ERROR_REGEX = "fatal error: (spiram.h|esp_spiram.h): No such file or directory";
+
+	@Test
+	void process_line_returns_true_if_hint_available_for_error_line()
+	{
+		List<ReHintPair> reHintPairs = new ArrayList<>();
+		reHintPairs.add(
+				new ReHintPair(ERROR_REGEX, StringUtil.EMPTY));
+		String errorLine = ERROR_LINE;
+		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);
+
+		boolean actualResult = ep.processLine(errorLine);
+
+		assertTrue(actualResult);
+	}
+
+	@Test
+	void process_line_returns_false_if_no_hint_found_for_error_line()
+	{
+		List<ReHintPair> reHintPairs = new ArrayList<>();
+		reHintPairs.add(
+				new ReHintPair(NON_EXISTING_ERROR_REGEX, StringUtil.EMPTY));
+		String errorLine = ERROR_LINE;
+		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);
+
+		boolean actualResult = ep.processLine(errorLine);
+
+		assertFalse(actualResult);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void shutdown_should_trigger_property_change_listener_with_error_hints_pairs_as_new_value()
+	{
+		List<ReHintPair> actualReHintPair = new ArrayList<>();
+		OpenDialogListenerSupport.getSupport().addPropertyChangeListener(evt -> {
+			PopupDialog popupDialog = PopupDialog.valueOf(evt.getPropertyName());
+			if (popupDialog.equals(PopupDialog.AVAILABLE_HINTS))
+				actualReHintPair.addAll((List<ReHintPair>) evt.getNewValue());
+		});
+		List<ReHintPair> reHintPairs = new ArrayList<>();
+		String expectedHint = EXPECTED_HINT;
+		reHintPairs.add(
+				new ReHintPair(ERROR_REGEX, expectedHint));
+		String errorLine = ERROR_LINE;
+
+		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);
+		boolean actualResult = ep.processLine(errorLine);
+		ep.shutdown();
+
+		assertTrue(actualResult);
+		assertEquals(expectedHint, actualReHintPair.get(0).getHint());
+		assertEquals(errorLine, actualReHintPair.get(0).getRe());
+	}
+
+}

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/HintsUtilTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/HintsUtilTest.java
@@ -66,7 +66,7 @@ class HintsUtilTest
 		assertNotNull(reHintsList);
 		assertEquals(EXPECTED_SIZE, reHintsList.size());
 		assertEquals(expectedFirstHint, reHintsList.get(0).getHint());
-		assertEquals(expectedFirstRe, reHintsList.get(0).getRe());
+		assertEquals(expectedFirstRe, reHintsList.get(0).getRe().get().pattern());
 	}
 
 	@Test
@@ -82,9 +82,9 @@ class HintsUtilTest
 		assertNotNull(reHintsList);
 		assertEquals(EXPECTED_SIZE, reHintsList.size());
 		assertEquals(expectedFirstComplexHint, reHintsList.get(FIRST_SIMPLIFIED_ENTRY_INDEX).getHint());
-		assertEquals(expectedFirstComplexRe, reHintsList.get(FIRST_SIMPLIFIED_ENTRY_INDEX).getRe());
+		assertEquals(expectedFirstComplexRe, reHintsList.get(FIRST_SIMPLIFIED_ENTRY_INDEX).getRe().get().pattern());
 		assertEquals(expectedSecondComplexHint, reHintsList.get(SECOND_SIMPLIFIED_ENTRY_INDEX).getHint());
-		assertEquals(expectedSecondComplexRe, reHintsList.get(SECOND_SIMPLIFIED_ENTRY_INDEX).getRe());
+		assertEquals(expectedSecondComplexRe, reHintsList.get(SECOND_SIMPLIFIED_ENTRY_INDEX).getRe().get().pattern());
 	}
 
 


### PR DESCRIPTION
## Description

Added automated build hints viewer which appears after the build if there are available hints for founded errors. Also, can be turned on manually via Windows -> Show View -> Other... -> Espressif -> Build Hints

Fixes # ([IEP-1018](https://jira.espressif.com:8443/browse/IEP-1018))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How has this been tested?

Test 1:
- Add some errors which will match regular expressions from the hints.yml, for example, `#import spiram.h` 
- After build should appear and focused Build Hints viewer with a suggested hint
Test 2:
- turn off search for hints in the Espressif Preference Page -> close Build Hints viewer and rebuild again -> Build Hints should not be opened automatically

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build 

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added automated build hints functionality to assist users in identifying and resolving ESP-IDF errors. This feature can be enabled or disabled via a new checkbox in the preferences dialog.
- New Feature: Introduced a new UI view, "BuildView", for displaying build hints. The view consists of a table that displays error messages and corresponding hints.
- Refactor: Improved handling of regular expressions in the `ReHintPair` class by using `Pattern` objects instead of `String`.
- Test: Added comprehensive tests for the new `EspIdfErrorParser` class and updated existing tests to accommodate changes in the `ReHintPair` class.
- Chore: Updated various UI elements and tooltips to improve user experience and provide additional information about new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->