### PR TITLE
IEP-928: Workspace hangs if project is closed while indexer is running 

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -127,7 +127,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	public static final String CMAKE_ENV = "cmake.environment"; //$NON-NLS-1$
 	public static final String BUILD_COMMAND = "cmake.command.build"; //$NON-NLS-1$
 	public static final String CLEAN_COMMAND = "cmake.command.clean"; //$NON-NLS-1$
-	private JobGroup jobGroup = new JobGroup("Job...", 1, 1);
+	private JobGroup jobGroup = new JobGroup("Parsing Job...", 1, 1); //$NON-NLS-1$
 	private ILaunchTarget launchtarget;
 	private Map<IResource, IScannerInfo> infoPerResource;
 	/**
@@ -974,11 +974,10 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private void processCompileCommandsFile(IConsole console, IProgressMonitor monitor) throws CoreException
 	{
 		IFile file = getCompileCommandsJsonFile(monitor);
-
 		CompileCommandsJsonParser parser = new CompileCommandsJsonParser(
 				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation, getProject()),
 						CommandLauncherManager.getInstance().getCommandLauncher(this), console));
-		Job parseJob = new Job("Parse Compile Commands File")
+		Job parseJob = new Job("Parse Compile Commands File") //$NON-NLS-1$
 		{
 			protected IStatus run(IProgressMonitor monitor)
 			{
@@ -995,7 +994,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		};
 		parseJob.setJobGroup(jobGroup);
 		parseJob.schedule();
-
 	}
 
 	private IFile getCompileCommandsJsonFile(IProgressMonitor monitor) throws CoreException

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -977,7 +977,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		CompileCommandsJsonParser parser = new CompileCommandsJsonParser(
 				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation, getProject()),
 						CommandLauncherManager.getInstance().getCommandLauncher(this), console));
-		Job parseJob = new Job("Parse Compile Commands File") //$NON-NLS-1$
+		Job parseJob = new Job(Messages.IDFBuildConfiguration_ParseCommand)
 		{
 			protected IStatus run(IProgressMonitor monitor)
 			{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -978,7 +978,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		CompileCommandsJsonParser parser = new CompileCommandsJsonParser(
 				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation, getProject()),
 						CommandLauncherManager.getInstance().getCommandLauncher(this), console));
-		parser.parse(monitor);
 		Job parseJob = new Job("Parse Compile Commands File")
 		{
 			protected IStatus run(IProgressMonitor monitor)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -85,10 +85,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -124,7 +127,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	public static final String CMAKE_ENV = "cmake.environment"; //$NON-NLS-1$
 	public static final String BUILD_COMMAND = "cmake.command.build"; //$NON-NLS-1$
 	public static final String CLEAN_COMMAND = "cmake.command.clean"; //$NON-NLS-1$
-
+	private JobGroup jobGroup = new JobGroup("Job...", 1, 1);
 	private ILaunchTarget launchtarget;
 	private Map<IResource, IScannerInfo> infoPerResource;
 	/**
@@ -976,6 +979,24 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation, getProject()),
 						CommandLauncherManager.getInstance().getCommandLauncher(this), console));
 		parser.parse(monitor);
+		Job parseJob = new Job("Parse Compile Commands File")
+		{
+			protected IStatus run(IProgressMonitor monitor)
+			{
+				try
+				{
+					parser.parse(monitor);
+				}
+				catch (CoreException e)
+				{
+					Logger.log(e);
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		parseJob.setJobGroup(jobGroup);
+		parseJob.schedule();
+
 	}
 
 	private IFile getCompileCommandsJsonFile(IProgressMonitor monitor) throws CoreException

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -23,6 +23,7 @@ public class Messages extends NLS
 	public static String CMakeBuildConfiguration_Failure;
 	public static String CMakeErrorParser_NotAWorkspaceResource;
 	public static String IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile;
+	public static String IDFBuildConfiguration_ParseCommand;
 	public static String IncreasePartitionSizeTitle;
 	public static String IncreasePartitionSizeMessage;
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -15,6 +15,7 @@ CMakeBuildConfiguration_ProcCompJson=Processing compile_commands.json
 CMakeBuildConfiguration_Failure=Failure running cmake: %s\n
 CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource. Did the build run in a container?
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
+IDFBuildConfiguration_ParseCommand=Parse Compile Commands File
 IncreasePartitionSizeTitle=Low Application Partition Size
 IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
 ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file


### PR DESCRIPTION
## Description

Workspace hangs sometimes if we try to close the project while the indexer is running. Fixed by encapsulating the parsing process into separate Job. 

Fixes # ([IEP-928](https://jira.espressif.com:8443/browse/IEP-928))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Build the project in multiple scenarios. Try to close the project during the build or indexer process. 


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build
- Indexer

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced asynchronous parsing of the compile commands file in IDFBuildConfiguration. This change improves the responsiveness of the IDE during build configuration by offloading potentially time-consuming operations to a separate thread.
- Refactor: Added a new JobGroup instance variable to manage jobs related to the build configuration process, enhancing code organization and job management.
- Chore: Added new string constants for better message handling and internationalization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->