### PR TITLE
Update application tracing part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,8 +673,7 @@ Additional information, including common errors and known issues, is mentioned i
 <a name="appLvlTracing"></a>
 # Application Level Tracing
 
-ESP-IDF provides a useful feature for program behavior analysis called [Application Level Tracing](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?). IDF-Eclipse plugin has UI, that allows using `start tracing`, `stop tracing` commands and process received data. To familiarize yourself with this library, you can use the [app_trace_to_host](https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host) project. This project can be created from the plugin itself:
-
+ESP-IDF provides a useful feature for program behavior analysis called [Application Level Tracing](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?). IDF-Eclipse plugin has UI, that allows the use of start, and stop tracing commands and process received data. To familiarize yourself with this library, you can use the [app_trace_to_host](https://github.com/espressif/esp-idf/tree/release/v5.0/examples/system/app_trace_to_host) project or the [app_trace_basic](https://github.com/espressif/esp-idf/tree/release/v5.1/examples/system/app_trace_basic) project if you are using esp-idf 5.1 and higher. These projects can be created from the plugin itself:
 ![](docs/images/AppLvlTracing_1.png)
 
 Before you start using application-level tracing, it is important to create a debug configuration for the project where you must select the board you are using in order to successfully start the OpenOCD server.


### PR DESCRIPTION
## Description

small update of application tracing docs. The default project on esp-idf 5.1 has changed from app_trace_to_host to app_trace_basic
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated links to example projects for Application Level Tracing in ESP-IDF.
	- Added instructions for creating a debug configuration before using application-level tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->