### PR TITLE
IEP-1022: Improve sdkconfig search functionality

### DIFF
--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationFilter.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationFilter.java
@@ -10,12 +10,12 @@ public class SDKConfigurationFilter extends PatternFilter
 	@Override
 	protected boolean isLeafMatch(Viewer viewer, Object element)
 	{
-
 		if (element instanceof KConfigMenuItem)
 		{
 			KConfigMenuItem highLevelElem = (KConfigMenuItem) element;
 
-			return wordMatches(highLevelElem.getTitle()) || recursiveMatch(highLevelElem);
+			return wordMatches(highLevelElem.getTitle()) || wordMatches(highLevelElem.getName())
+					|| recursiveMatch(highLevelElem);
 		}
 
 		return false;
@@ -25,12 +25,12 @@ public class SDKConfigurationFilter extends PatternFilter
 	{
 		if (parent.getChildren().isEmpty())
 		{
-			return wordMatches(parent.getName());
+			return wordMatches(parent.getName()) || wordMatches(parent.getTitle());
 		}
 
 		for (KConfigMenuItem child : parent.getChildren())
 		{
-			if (wordMatches(child.getName()) || recursiveMatch(child))
+			if (wordMatches(child.getName()) || wordMatches(child.getTitle()) || recursiveMatch(child))
 			{
 				return true;
 			}


### PR DESCRIPTION
## Description

Improved sdkconfig filter functionality. Now filtering allows compare not only the Kconfig elements' title but their names (UI labels) as well.

Fixes # ([IEP-1022](https://jira.espressif.com:8443/browse/IEP-1022))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

open sdkconfig editor. Try to search different components by label's name. For example "After flashing" gives 
![image](https://github.com/espressif/idf-eclipse-plugin/assets/24419842/c66a86df-9ab0-4d36-86c2-f4d3ea2ae05c)

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- sdkconfig

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the search functionality in the SDK Configuration UI. Users can now search for `KConfigMenuItem` objects not only by their `title` property but also by their `name` property, providing a more comprehensive and flexible search experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->