### PR TITLE
fix: Remove slf4j plugin dependency

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
@@ -18,8 +18,7 @@ Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",
  com.espressif.idf.ui,
  com.espressif.idf.serial.monitor,
  org.eclipse.cdt.core.native,
- org.eclipse.ui.console,
- org.slf4j.api
+ org.eclipse.ui.console
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -112,7 +112,7 @@
 			<unit id="org.eclipse.nebula.widgets.xviewer.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp/master/"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-1.0/"/>
 			<unit id="org.eclipse.cdt.lsp.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Helps to fix Eclipse 2023-09 update error

## Description

Remove slf4j plugin dependency

Fixes # ([IEP-1025](https://jira.espressif.com:8443/browse/IEP-1025))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Install PR update site build on Eclipse 2023-09 and Eclipse 2023-06,

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Updat site

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated dependencies in `com.espressif.idf.terminal.connector.serial` project. Removed dependency on `org.slf4j.api` and added a new dependency on `org.eclipse.ui.console` for enhanced console functionality.
- Chore: Changed the repository location for `org.eclipse.cdt.lsp.feature.feature.group` in `com.espressif.idf.target` project. The new location points to the stable release of CDT Language Server Protocol (LSP) instead of the master build, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->