### PR TITLE
sync cn and en readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-[![GitHub release](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
+[![GitHub release](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest)
 
-[中文](./README_CN.md) 
+[中文](./README_CN.md)
 
 # ESP-IDF Eclipse Plugin
-ESP-IDF Eclipse Plugin brings developers an easy-to-use Eclipse-based development environment for developing ESP32 based IoT applications.
-It provides better tooling capabilities, which simplifies and enhances standard Eclipse CDT for developing and debugging ESP32 IoT applications. It offers advanced editing, compiling, flashing and debugging features with the addition of Installing the tools, SDK configuration and CMake editors. 
+
+ESP-IDF Eclipse Plugin brings developers an easy-to-use Eclipse-based development environment for developing ESP32-based IoT applications.
+It provides better tooling capabilities, which simplifies and enhances standard Eclipse CDT for developing and debugging ESP32 IoT applications. It offers advanced editing, compiling, flashing and debugging features with the addition of Installing the tools, SDK configuration and CMake editors.
 
 The plug-in runs on `macOS`, `Windows` and `Linux` platforms.
 
@@ -15,12 +16,12 @@ The plug-in runs on `macOS`, `Windows` and `Linux` platforms.
 
 > **Note:** It supports ESP-IDF CMake based projects (4.x and above) with `esp32`,`esp32s2`, `esp32s3` and `esp32c3` boards.
 
-To get a quick understanding about ESP-IDF and Eclipse plugin features check our session which was presented in <a href= "https://youtu.be/CbPX3q7LeBc">EclipseCon 2020</a>
+To get a quick understanding of ESP-IDF and Eclipse plugin features, check our session which was presented in <a href= "https://youtu.be/CbPX3q7LeBc">EclipseCon 2020</a>.
 
 # Table Of Contents
 <details open>
   <summary>Get Started</summary>
-  
+
 * [ Installation](#Installation) <br>
 * [ Creating a new Project ](#NewProjectUsingDefault)<br>
 * [ Configuring Launch Target ](#ConfigureLaunchTarget)<br>
@@ -32,7 +33,7 @@ To get a quick understanding about ESP-IDF and Eclipse plugin features check our
 * <a href ="https://github.com/espressif/idf-eclipse-plugin/blob/master/FAQ.md#FAQ">FAQ</a>
 </details>
 
-<details>
+<details open>
   <summary>Other IDE Features</summary>
 
 * [ Installing ESP-IDF and Tools via Tools Installation Wizard ](#InstallToolsWizard) <br>
@@ -60,18 +61,18 @@ To get a quick understanding about ESP-IDF and Eclipse plugin features check our
 * [ NVS Table Editor](#nvsTableEditor)<br>
 * [ Changing Language ](#changeLanguage)<br>
 * [ Wokwi Simulator](#wokwisimulator)<br>
-
 </details>
 
 <a name="Installation"></a>
 # Installing Prerequisites
-The minimum requirements for running the IDF Eclipse plug-ins are below. 
 
-* **Java 17 and above** : Download and install Java SE from <a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">here</a>
-* **Python 3.6 and above** : Download and install Python from <a href="https://www.python.org/downloads/">here</a>
-* **Eclipse IDE for C/C++ Developers 2023-03** : Download and install Eclipse CDT package from <a href= "https://www.eclipse.org/downloads/packages/release/2023-03/r/eclipse-ide-cc-developers">here </a>
-*  **Git** : Get the latest git from <a href ="https://git-scm.com/downloads">here</a>
-*  **ESP-IDF 4.0 and above** : Clone the ESP-IDF repo from <a href ="https://github.com/espressif/esp-idf/releases">here</a>
+The minimum requirements for running the IDF Eclipse plug-ins are below.
+
+* **Java 17 and above** : Download and install Java SE from <a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">here</a>.
+* **Python 3.6 and above** : Download and install Python from <a href="https://www.python.org/downloads/">here</a>.
+* **Eclipse IDE for C/C++ Developers 2023-03** : Download and install Eclipse CDT package from <a href= "https://www.eclipse.org/downloads/packages/release/2023-03/r/eclipse-ide-cc-developers">here </a>.
+*  **Git** : Get the latest git from <a href ="https://git-scm.com/downloads">here</a>.
+*  **ESP-IDF 4.0 and above** : Clone the ESP-IDF repo from <a href ="https://github.com/espressif/esp-idf/releases">here</a>.
 
 > **Note:** Make sure Java, Python and Git are available on the system environment PATH.
 
@@ -82,17 +83,18 @@ More details on the Espressif-IDE can be found <a href="https://github.com/espre
 <a name="GettingStarted"></a>
 
 # Installing IDF Plugin using update site URL
+
 You can install the IDF Eclipse plugin into an existing Eclipse CDT installation using the update site URL. You first need to add the release repository URL as follows:
 
-1. Go to `Help` > `Install New Software`
+1. Go to `Help` > `Install New Software`.
 1. Click `Add…`, and in the pop-up window:
 	* Enter `Name` as `Espressif IDF Plugin for Eclipse`
 	* Enter `Location` of the repository:
 		* Stable releases: https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/
 		* Beta versions: https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/
 		* Nightly build: https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/
-	* Click `Add`
-1. Select `Espressif IDF` from the list and proceed with the installation 
+	* Click `Add`.
+1. Select `Espressif IDF` from the list and proceed with the installation.
 
 > **Note:** Though screenshots are captured from `macOS`, installation instructions are applicable for `Windows`, `Linux` and `macOS`.
 
@@ -100,35 +102,37 @@ You can install the IDF Eclipse plugin into an existing Eclipse CDT installation
 
 <a name="InstallTools"></a>
 # Installing ESP-IDF
-To install ESP-IDF directly from the Eclipse
 
-1. Go to `Espressif` > `Download and Configure ESP-IDF`
-1. From the `Download ESP-IDF` section, choose ESP-IDF version and directory to download
-1. Click on `Finish`
+To install ESP-IDF directly from the Eclipse:
 
-To configure an existing ESP-IDF
+1. Go to `Espressif` > `Download and Configure ESP-IDF`.
+1. From the `Download ESP-IDF` section, choose ESP-IDF version and directory to download.
+1. Click on `Finish`.
 
-1. Go to `Espressif` > `Download and Configure ESP-IDF`
-1. Check `Use an existing ESP-IDF directory from the file system`
-1. Choose an existing ESP-IDF directory from the file system
-1. Click on `Finish`
+To configure an existing ESP-IDF:
 
-This will download a specified esp-idf version and configures `IDF_PATH` in the Eclipse CDT build environment variables.
+1. Go to `Espressif` > `Download and Configure ESP-IDF`.
+1. Check `Use an existing ESP-IDF directory from the file system`.
+1. Choose an existing ESP-IDF directory from the file system.
+1. Click on `Finish`.
+
+This will download a specified ESP-IDF version and configure `IDF_PATH` in the Eclipse CDT build environment variables.
 
 ![](docs/images/espidf_download.png)
 
 # Installing ESP-IDF Tools
+
 ESP-IDF requires some prerequisite tools to be installed so you can build firmware for the ESP32. The prerequisite tools include Python, Git, cross-compilers, menuconfig tool, CMake and Ninja build tools.
 
 For this getting started guide, follow the instructions below.
 
-1. Navigate to `Espressif` > `ESP-IDF Tools Manager` > `Install Tools`
-1. Provide the `ESP-IDF Directory` path
+1. Navigate to `Espressif` > `ESP-IDF Tools Manager` > `Install Tools`.
+1. Provide the `ESP-IDF Directory` path.
 1. Provide `Git` and `Python` executable locations if they are not auto-detected.
 1. Click on `Install Tools` to proceed with the installation process. Check the Console for the installation details.
-1. Installation might take a while if you're doing it for the first time since it has to download and install xtensa-esp32-elf, esp32ulp-elf, cmake, openocd-esp32 and ninja tools.
+1. Installation might take a while if you're doing it for the first time since it has to download and install `xtensa-esp32-elf`, `esp32ulp-elf`, Cmake, `openocd-esp32` and Ninja tools.
 
-> **Note:** Make sure you run this step even if you've already installed the required tools, since it sets the `IDF_PATH`, `PATH`, `OPENOCD_SCRIPTS` and `IDF_PYTHON_ENV_PATH` to the Eclipse CDT build environment based on the idf_tools.py export command.
+> **Note:** Make sure you run this step even if you've already installed the required tools, since it sets the `IDF_PATH`, `PATH`, `OPENOCD_SCRIPTS` and `IDF_PYTHON_ENV_PATH` to the Eclipse CDT build environment based on the `idf_tools.py export` command.
 
 ![](docs/images/install_tools.png)
 
@@ -138,13 +142,13 @@ ESP-IDF Directory selection dialog:
 
 <a name="NewProjectUsingDefault"></a>
 # Create a new Project
-1. Make sure you are in `C/C++ Perspective`
-1. Go to `File` > `New` > `Espressif IDF Project` (If you don't see this, please reset the perspective from `Window` > `Perspective` > `Reset Perspective...`)
-1. Provide the `Project name` (The ESP-IDF build system does not support spaces in the project path)
-1. Click `Finish`
 
-To create a project using existing esp-idf templates, please refer to [this](#NewProjectUsingTemplates)
+1. Make sure you are in `C/C++ Perspective`.
+1. Go to `File` > `New` > `Espressif IDF Project` (If you don't see this, please reset the perspective from `Window` > `Perspective` > `Reset Perspective...`).
+1. Provide the `Project name` (The ESP-IDF build system does not support spaces in the project path).
+1. Click `Finish`.
 
+To create a project using existing ESP-IDF templates, please refer to [this](#NewProjectUsingTemplates).
 
 > **Note:** You will see a lot of unresolved inclusion errors in the editor and those will be resolved only after the build.
 
@@ -152,27 +156,30 @@ To create a project using existing esp-idf templates, please refer to [this](#Ne
 
 <a name="ConfigureLaunchTarget"></a>
 # Configuring Launch target
-Next, we need to tell CDT to use the toolchain for our project so that all the headers will be indexed and resolved. This is accomplished through the Launch Bar, the new widget set you see on the far left of the toolbar. This will be shown only when you have a project in the project explorer.
 
-1. Click on the third dropdown window from the top bar
-1. Select `New Launch Target`
-1. Select `ESP Target`
+Next, we need to tell CDT to use the toolchain for our project so that all the headers will be indexed and resolved. This is accomplished through the Launch Bar, the new widget set you see on the far left of the toolbar. This will be shown only when you have a project in the `Project Explorer`.
+
+1. Click on the third dropdown window from the top bar.
+1. Select `New Launch Target`.
+1. Select `ESP Target`.
 1. Provide properties for the target where you would like to launch the application. Enter a `Name` for the target and select the `Serial Port` your ESP device is connected to on your machine.
 
 ![](docs/images/8_launch_target.png)
 
 <a name="BuildApplication"></a>
 # Compiling the Project
-1. Select a project from the `Project Explorer`
-1. Select `Run` from the first drop-down, which is called `Launch Mode`
-1. Select your application from the second drop-down, which is called `Launch Configuration`(Auto-detected)
-1. Select target from the third drop-down, which is called `Launch Target`
-1. Now click on the `Build` button widget which you see on the far left of the toolbar
+
+1. Select a project from the `Project Explorer`.
+1. Select `Run` from the first drop-down, which is called `Launch Mode`.
+1. Select your application from the second drop-down, which is called `Launch Configuration`(Auto-detected).
+1. Select a target from the third drop-down, which is called `Launch Target`.
+1. Now click on the `Build` button widget which you see on the far left of the toolbar.
 
 ![](docs/images/9_cmake_build.png)
 
 <a name="FlashApplication"></a>
 # Flashing the Project
+
 ESP-IDF has a tool called `idf.py` which is a wrapper around `make flash` command with some handy operations. Flash operation can be initiated with just a click of a launch button (second button from the left on the top bar) and it's auto-configured to flash the application with the default flash command i.e, `idf.py -p PORT flash`.
 
 To provide the customized flash arguments, please follow [this](#customizeLaunchConfig) link for further instructions.
@@ -181,41 +188,48 @@ To configure flashing via JTAG, please refer to this <a href="https://github.com
 
 <a name="ConfigureLaunchTerminal"></a>
 # Viewing Serial Output
-To see the serial output in Eclipse, we need to configure the `ESP-IDF Serial Monitor` to connect to the serial port. This is integrated with the `IDF Monitor`. Please check more details <a href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-monitor.html#idf-monitor">here</a>. 
 
-1. Click on the `Open a Terminal` icon from the toolbar
-1. Choose `ESP-IDF Serial Monitor` from the terminal drop-down
-1. Select `Serial Port` for your board if it's not detected
-1. Configure serial monitor filter options for output filtering
-1. Click on `OK` to launch the terminal, which will listen to the USB port
+To see the serial output in Eclipse, we need to configure the `ESP-IDF Serial Monitor` to connect to the serial port. This is integrated with the `IDF Monitor`. Please check more details <a href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-monitor.html#idf-monitor">here</a>.
+
+1. Click on the `Open a Terminal` icon from the toolbar.
+1. Choose `ESP-IDF Serial Monitor` from the terminal drop-down.
+1. Select `Serial Port` for your board if it's not detected.
+1. Configure serial monitor filter options for output filtering.
+1. Click on `OK` to launch the terminal, which will listen to the USB port.
 
 ![](docs/images/10_serial_terminal.png)
 
 ### ESP-IDF Serial Monitor Settings
-ESP-IDF Serial Monitor will allow you to configure the default settings of the serial monitor character limit and number of lines. 
-1. Navigate to `Espressif` from the Eclipse Preferences
-1. Click on `ESP-IDF Serial Monitor Settings`
-1. Provide `Console Line Width` and `Limit Console Output`
+
+ESP-IDF Serial Monitor will allow you to configure the default settings of the serial monitor character limit and number of lines.
+
+1. Navigate to `Espressif` from the Eclipse Preferences.
+1. Click on `ESP-IDF Serial Monitor Settings`.
+1. Provide `Console Line Width` and `Limit Console Output`.
 
 <a name="debugging"></a>
 # Debugging the Project
 
-* <a href ="https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/jtag-debugging/index.html" > GDB Hardware Debugging</a>
-* <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/OpenOCD%20Debugging.md">GDB OpenOCD Debugging</a>
-* [Core Dump Debugging](#core-dump-debugging)
-* [GDB Stub Debugging](#gdbStubDebugging)
+## GDB Hardware Debugging
+
+Please refer to <a href ="https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/jtag-debugging/index.html" > GDB Hardware Debugging guide</a>.
+
+## GDB OpenOCD Debugging
+
+Please refer to <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/OpenOCD%20Debugging.md">GDB OpenOCD Debugging</a>.
 
 # Other IDE Features
 
 <a name="NewProjectUsingTemplates"></a>
 ## Create a new project using ESP-IDF Templates
-1. Make sure you're in `C/C++ Perspective`
-1. Go to `File` > `New` > `Espressif IDF Project` (If you don't see this, please reset the perspective from `Window` > `Perspective` > `Reset Perspective..`)
-1. Provide the `Project name`
-1. Click `Next`
-1. Check `Create a project using one of the templates`
-1. Select the required template from the tree
-1. Click `Finish`
+
+1. Make sure you're in `C/C++ Perspective`.
+1. Go to `File` > `New` > `Espressif IDF Project` (If you don't see this, please reset the perspective from `Window` > `Perspective` > `Reset Perspective..`).
+1. Provide the `Project name`.
+1. Click `Next`.
+1. Check `Create a project using one of the templates`.
+1. Select the required template from the tree.
+1. Click `Finish`.
 
 > **Note:** You will see a lot of unresolved inclusion errors in the editor and those will be resolved only after the build.
 
@@ -223,56 +237,61 @@ ESP-IDF Serial Monitor will allow you to configure the default settings of the s
 
 <a name="InstallToolsWizard"></a>
 # Tools Installation Wizard
-You can use the install tools wizard to manage the tools installation via a wizard. The advantage of this method over the exisitng installation is that you can easily manage the whole flow via wizard and install the tools in ESP-IDF framework that you only need.<br/>
 
-For getting started:
-1. Navigate to `Espressif` > `ESP-IDF Tools Manager` > `Tools Installation Wizard (Preview)`
+You can use the Tools Installation Wizard to manage the tools installation via a wizard. The advantage of this method over the existing installation is that you can easily manage the whole flow via the wizard and install the tools in ESP-IDF framework that you only need.<br/>
+
+To get started:
+
+1. Navigate to `Espressif` > `ESP-IDF Tools Manager` > `Tools Installation Wizard (Preview)`.
 ![](docs/images/ToolsManager/install_tools_manager.png)
 
-
-2. The wizard will start and you can select the location for the Git and Python, if they are already present on the system PATH or registry the tools will be populated. After selection you can click `Next`.
+1. The wizard will start and you can select the location for the Git and Python, if they are already present on the system PATH or registry the tools will be populated. After selection, you can click `Next`.
 ![](docs/images/ToolsManager/git_python_selection.png)
 
-3. Next page will let you select the folder for existing ESP-IDF or you can also select from the drop down list to download the available versions. You can also select master from the list to clone the master for ESP-IDF from github
+1. Next page will let you select the folder for existing ESP-IDF or you can also select from the drop down list to download the available versions. You can also select master from the list to clone the master for ESP-IDF from GitHub.
 ![](docs/images/ToolsManager/select_or_download_new_esp_idf.png)
 
-
 1. After you select `Next` you will see the list of all the available tools in the selected ESP-IDF version, this page lets you select only the recommended tools or you can select the tools you want to. You can also filter out the tools via the filter text box or based on the target. The wizard page is the last page and will Install and Download if necessary all the selected tools required. After you have installed all the tools you can finish the wizard and start creating projects.
-
 ![](docs/images/ToolsManager/manage_tools_installation.png)
 
 <a name="projectconfigure"></a>
-
 # SDK Configuration editor
+
 Project configuration is held in a single file called `sdkconfig` in the root directory of the project. This configuration file can be modified using `SDK Configuration Editor`
 
 To launch the SDK Configuration editor:
 
-1. Navigate to `sdkconfig` file
-1. Double click on the file to launch the SDK configuration editor
-1. Use `Ctrl+S` or  `Command+S` based on the OS environment to save the changes. You can also use Eclipse `Save` button from the toolbar
-1. To revert the sdkconfig editor changes, you can either close the editor without saving them or you can right click on the `sdkconfig` file and select `Load sdkconfig` menu option to revert the changes from the editor.
+1. Navigate to `sdkconfig` file.
+1. Double-click on the file to launch the SDK configuration editor.
+1. Use `Ctrl+S` or  `Command+S` based on the OS environment to save the changes. You can also use Eclipse `Save` button from the toolbar.
+1. To revert the sdkconfig editor changes, you can either close the editor without saving them or you can right-click on the `sdkconfig` file and select `Load sdkconfig` menu option to revert the changes from the editor.
 
 ![](docs/images/13_sdkconfig_editor.png)
 
 <a name="cmakeproject"></a>
 # CMake Editor
+
 CMake Editor Plug-in is integrated with IDF Plugin for editing CMake files such as CMakeLists.txt. It provides syntax coloring, CMake command content assist, and code templates.
 
 ![](docs/images/cmake_editor_ca.png)
 
-CMake editor preferences can be controlled using `Eclipse` > `Preferences` > `CMakeEd`
+CMake editor preferences can be controlled using `Eclipse` > `Preferences` > `CMakeEd`.
 
 ![](docs/images/cmake_editor_preferences.png)
 
 <a name="sizeanalysiseditor"></a>
 # ESP-IDF Application Size Analysis
-Application Size Analysis editor provides a way to analyze the static memory footprint of your application. It has two sections - Overview and Details. The **Overview** section provides a summary of the application memory usage and the **Details** section will have in-depth details about components and per-symbol level memory information.
 
-Details table viewer also provides you with searching and sorting capabilities on various columns.
+The Application Size Analysis editor provides a way to analyze the static memory footprint of your application. It has two sections:
+- The **Overview** section provides a summary of the application's memory usage;
+- The **Details** section will have in-depth details about components and per-symbol level memory information.
+
+**Details** table viewer also provides you with searching and sorting capabilities on various columns.
+
 To launch the Application Size Analysis editor:
-1. Right-click on the project
-1. Select `ESP-IDF: Application Size Analysis` menu option to launch the editor
+
+1. Right-click on the project.
+1. Select `ESP-IDF: Application Size Analysis` menu option to launch the editor.
 
 **Application Size Analysis - Overview**
 
@@ -284,44 +303,49 @@ To launch the Application Size Analysis editor:
 
 <a name="idfterminal"></a>
 # ESP-IDF Terminal
-This would launch a local terminal with all the environment variables which are set under `Preferences > C/C++ > Build > Environment`. The default working directory would be either the currently selected project or IDF_PATH if there is no project selected. 
+
+This would launch a local terminal with all the environment variables which are set under `Preferences` > `C/C++` > `Build` > `Environment`. The default working directory would be either the currently selected project or IDF_PATH if there is no project selected.
 
 The terminal PATH is also configured with `esptool`, `espcoredump`, `partition_table`, and `app_update` component paths so that it will be handy to access them directly from the ESP-IDF terminal.
 
 To launch the ESP-IDF Terminal:
-* Click on the `Open a Terminal` icon from the toolbar
-* Choose `ESP-IDF Terminal` from the terminal drop-down and click `OK` to launch a terminal
+
+* Click on the `Open a Terminal` icon from the toolbar.
+* Choose `ESP-IDF Terminal` from the terminal drop-down and click `OK` to launch a terminal.
 
 ![](docs/images/idf_terminal.png)
 
 <a name="espidfcomponents"></a>
 # Installing ESP-IDF Components
-You can install the ESP-IDF Components directly into your project from the available components online. Follow the steps below.
 
-* Right click on the project from project explorer in which you want to add the component to and Select `Install ESP-IDF Components`
+You can install the ESP-IDF Components directly into your project from the available components online. Follow the steps below:
+
+* Right-click on the project from `Project Explorer` in which you want to add the component to and Select `Install ESP-IDF Components`.
+
   ![](docs/images/ESP-IDF_Components/install_components.png)
 
   A new window will open up showing all the available component to be installed.
 
-* From the window you can click on `Install` button to add that component to the project. To get to the readme file for that component you can click on `More Info` which will open the browser link to the readme file of that component.
+* From the window, you can click on `Install` button to add that component to the project. To get to the readme file for that component you can click on `More Info` which will open the browser link to the readme file of that component.
   ![](docs/images/ESP-IDF_Components/components_window.png)
 
 Already added components are also shown but the `Install` button changes text to `Already Added` and is disabled.
 
 <a name="configureEnvironmentVariables"></a>
 # Configuring Environment Variables
-Eclipse auto configures the required environment variables in the `Preferences` > `C/C++ Build` > `Environment` section if IDF Tools are installed using `Espressif` > `ESP-IDF Tools Manager` > `Install Tools` menu option.
 
-Required environment variables:
+Eclipse configures automatically the required environment variables in the `Preferences` > `C/C++ Build` > `Environment` section if IDF Tools are installed using `Espressif` > `ESP-IDF Tools Manager` > `Install Tools` menu option. Required environment variables:
+
 * `IDF_PATH`
 * `PATH`
 * `OPENOCD_SCRIPTS`
 * `IDF_PYTHON_ENV_PATH`
 
-If the required environment variables are not configured for any reason, please follow the step by step instructions below.
-* Click on the `Environment` preference page under `C/C++ Build`. 
-* Click `Add…` again, and enter name `IDF_PATH`. The value should be the full path where ESP-IDF is installed.
-* Similarly we should configure `OPENOCD_SCRIPTS`, `IDF_PYTHON_ENV_PATH` and `PATH` environment variables
+If the required environment variables are not configured for any reason, please follow the step-by-step instructions below.
+
+1. Click on the `Environment` preference page under `C/C++ Build`.
+1. Click `Add…` again, and enter name `IDF_PATH`. The value should be the full path where ESP-IDF is installed.
+1. Similarly, we should configure `OPENOCD_SCRIPTS`, `IDF_PYTHON_ENV_PATH` and `PATH` environment variables.
 
 This is how they should look:
 
@@ -340,65 +364,67 @@ This is how they should look:
 ![](docs/images/2_environment_pref.png)
 
 # Configuring Toolchains
-We need to tell Eclipse CDT what core build toolchain and CMake toolchain need to be used to build the project. However, this will be auto-detected if you've installed the tools using the `Espressif` > `ESP-IDF Tools Manager` > `Install Tools` option from the Eclipse.
 
-If these toolchains are not detected for any reason, please follow the step by step instructions below to add a new toolchain.
+We need to tell Eclipse CDT what core build toolchain and CMake toolchain to use to build the project. However, this will be auto-detected if you've installed the tools using the `Espressif` > `ESP-IDF Tools Manager` > `Install Tools` option from Eclipse.
+
+If these toolchains are not detected for any reason, please follow the step-by-step instructions below to add a new toolchain.
 
 <a name="ConfigureToolchains"></a>
 # Configuring Core Build Toolchains
 
-1. Open Eclipse Preferences
-1. Navigate to `C/C++` > `Core Build Toolchains` preference page
-1. Click on `Add..` from the User defined Toolchains tables
-1. Select `GCC` as a toolchain type
-1. Click on `Next`
-1. Provide the GCC Toolchain Settings:
+1. Open Eclipse Preferences.
+1. Navigate to `C/C++` > `Core Build Toolchains` preference page.
+1. Click on `Add..` from the user-defined toolchains tables.
+1. Select `GCC` as a toolchain type.
+1. Click on `Next`.
+1. Provide the GCC toolchain settings:
 
-**Compiler:** /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc,
-**Operating System:** esp32,
-**CPU Architecture:** xtensa
+	* **Compiler:** /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc,
+	* **Operating System:** esp32,
+	* **CPU Architecture:** xtensa
 
 ![](docs/images/6_core_build_toolchains.png)
 
 <a name="ConfigureCMakeToolchain"></a>
 # Configuring CMake Toolchain
+
 We now need to tell CDT which toolchain to use when building the project. This will pass the required arguments to CMake when generating the Ninja files.
 
-1. Navigate to `C/C++` > `CMake` preference page
-1. Click `Add...` and this will launch the New CMake Toolchain configuration dialog
-1. Browse CMake toolchain `Path`. Example: `/Users/user-name/esp/esp-idf/tools/cmake/toolchain-esp32.cmake`
-1. Select GCC Xtensa Toolchain compiler from the drop-down list. Example: `esp32 xtensa /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc`
+1. Navigate to `C/C++` > `CMake` preference page.
+1. Click `Add...` and this will launch the New CMake toolchain configuration dialog.
+1. Browse CMake toolchain `Path`. Example: `/Users/user-name/esp/esp-idf/tools/cmake/toolchain-esp32.cmake`.
+1. Select GCC Xtensa toolchain compiler from the drop-down list. Example: `esp32 xtensa /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc`.
 
-> **NOTE:**  Eclipse CDT has a bug in saving the toolchain preferences, hence it's recommended to restart Eclipse before we move further configuring the launch target.
+> **Note:**  Eclipse CDT has a bug in saving the toolchain preferences, hence it's recommended to restart Eclipse before we move further configuring the launch target.
 
 ![](docs/images/7_cmake_toolchain.png)
 
 <a name="SelectDifferentToolchain"></a>
 # Selecting Clang Toolchain
-With ESP-IDF Eclipse Plugin v2.7.0 and higher you can build your project with Clang Toolchain
 
-1. After updating/installing the ESP-IDF Eclipse plugin to v2.7.0 or higher,  you need to run `Espressif -> ESP-IDF Tools Manager -> Install Tools` to update the toolchain list and environment variables, that are necessary for Clang Toolchain.
-1. After creating a new project, edit project's configuration
+With ESP-IDF Eclipse Plugin v2.7.0 and higher you can build your project with the Clang toolchain
+
+1. After updating/installing the ESP-IDF Eclipse plugin to v2.7.0 or higher, you need to run `Espressif` > `ESP-IDF Tools Manager` > `Install Tools` to update the toolchain list and environment variables, that are necessary for Clang toolchain.
+1. After creating a new project, edit the project configuration
 ![image](https://user-images.githubusercontent.com/24419842/194882285-9faadb5d-0fe2-4012-bb6e-bc23dedbdbd2.png)
 1. Go to `Build Settings` tab and select clang toolchain there:
 ![image](https://user-images.githubusercontent.com/24419842/194882462-3c0fd660-b223-4caf-964d-58224d91b518.png)
 
-> **NOTE:** Clang Toolchain now is an experimental feature and you may face some build issues due to the incompatibility of esp-idf. Below is a description of how to fix the most common build issue on the current esp-idf master (ESP-IDF v5.1-dev-992-gaf28c1fa21-dirty)
-
-To work around clang build errors please refer to [this](https://github.com/espressif/idf-eclipse-plugin/blob/master/WORKAROUNDS.md#clang-toolchain-buid-errors).
+> **Note:** Clang toolchain now is an experimental feature and you may face some build issues due to the incompatibility of esp-idf. Below is a description of how to fix the most common build issue on the current ESP-IDF master (ESP-IDF v5.1-dev-992-gaf28c1fa21-dirty). To work around clang build errors please refer to [this](https://github.com/espressif/idf-eclipse-plugin/blob/master/WORKAROUNDS.md#clang-toolchain-buid-errors).
 
 <a name="customizeLaunchConfig"></a>
 # Launch Configuration
-To provide the customized launch configuration and flash arguments, please follow the step by step instructions below.
 
-1. Click on the `Launch Configuration` edit button
-1. Switch to the `Main` tab
-1. Specify the `Location` where this application has to run. Since `idf.py` is a python file, will configure the python system path. Example:`${system_path:python}`
-1. Specify `Working directory` of the application. Example: `${workspace_loc:/hello_world}`
-1. In additional arguments, provide a flashing command which will run in the specified working directory
-1. Flash command looks like this: `/Users/user-name/esp/esp-idf/tools/idf.py -p /dev/cu.SLAB_USBtoUART flash`
-1. Click OK to save the settings
-1. Click on the `Launch` icon to flash the application to the selected board 
+To provide the customized launch configuration and flash arguments, please follow the step-by-step instructions below.
+
+1. Click on the `Launch Configuration` edit button.
+1. Switch to the `Main` tab.
+1. Specify the `Location` where this application has to run. Since `idf.py` is a python file, will configure the python system path. Example:`${system_path:python}`.
+1. Specify `Working directory` of the application. Example: `${workspace_loc:/hello_world}`.
+1. In additional arguments, provide a flashing command which will run in the specified working directory.
+1. Flash command looks like this: `/Users/user-name/esp/esp-idf/tools/idf.py -p /dev/cu.SLAB_USBtoUART flash`.
+1. Click OK to save the settings.
+1. Click on the `Launch` icon to flash the application to the selected board.
 
 ![](docs/images/11_launch_configuration.png)
 
@@ -406,24 +432,27 @@ To provide the customized launch configuration and flash arguments, please follo
 
 <a name="changeLanguage"></a>
 # Changing Language
-To change the plugin language a menu is provided to show the list of available languages for the plugin. Remember this will only change the language of the eclipse if the required language bundles for the selected language are installed or else only the plugin interfaces will be changed.
 
-1. Click on the `Espressif` menu from menu bar
-1. Select the `Change Language` from the menu drop down
-1. From the sub menu select the language you want
-1. Eclipse will restart with selected language
+To change the plugin language a menu is provided to show the list of available languages for the plugin.
+
+1. Click on the `Espressif` menu from the menu bar.
+1. Select the `Change Language` from the drop-down menu.
+1. From the sub menu select the language you want.
+1. Eclipse will restart with selected language.
 
 ![](docs/images/change_language.png)
 
+Remember this will only change the language of the Eclipse if the required language bundles for the selected language are installed or else only the plugin interfaces will be changed.
+
 <a name="troubleshooting"></a>
-# Troubleshooting 
+# Troubleshooting
 
-## Suggestions for solving errors from ESP-IDF by hints viewer
+## Suggestions for Solving Errors from ESP-IDF by Hints Viewer
 
-If you run into a problem during a build, chances are that there is a hint for this error in the esp-idf hint database, which is stored in `tools/idf_py_actions/hints.yml` of ESP-IDF. The ESP-IDF Eclipse plugin provides a hint viewer where you can type an error message and find a hint for it. 
-Prerequisites for it is to have `hints.yml`, which is available from esp-idf v5.0 and higher. If you are using lower version of the esp-idf, you can still use the hints viewer. To do it, you have manually download the hints.yml file from [here](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/hints.yml) and put it to your `esp-idf/tools/idf_py_actions/` path. To download a file from the github, right click the `Raw` button and then `Save as...`
+If you run into a problem during a build, chances are that there is a hint for this error in the ESP-IDF hint database, which is stored in `tools/idf_py_actions/hints.yml` of ESP-IDF. The ESP-IDF Eclipse plugin provides a hint viewer where you can type an error message and find a hint for it.
+Prerequisites for it is to have `hints.yml`, which is available from ESP-IDF v5.0 and higher. If you are using lower versions of ESP-IDF, you can still use the hints viewer. To do it, you have to manually download the hints.yml file from [here](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/hints.yml) and put it to your `esp-idf/tools/idf_py_actions/` path. To download a file from GitHub, right-click the `Raw` button and then `Save as...`.
 
-To open hints viewer go to `Windows -> Show View -> Other... -> Espressif -> Hints`. You will see the following view:
+To open the hints viewer go to `Windows` -> `Show View` -> `Other...` -> `Espressif` -> `Hints`. You will see the following view:
 ![image](https://user-images.githubusercontent.com/24419842/189666994-78cc8b24-b934-426f-9df5-79af28c50c55.png)
 
 Now you can type or copy paste some error from the build log, for example:
@@ -431,12 +460,13 @@ Now you can type or copy paste some error from the build log, for example:
 
 ![image](https://user-images.githubusercontent.com/24419842/189672552-994624f3-c0c5-48e6-aa2c-61e4ed8915e5.png)
 
-Double clicking on the row will give you a hint message so you can clearly see it if it doesn't fit on your screen in the table view.
+Double-clicking on the row will give you a hint message, so you can clearly see it if it doesn't fit on your screen in the table view.
 
 ![image](https://user-images.githubusercontent.com/24419842/189673174-8ce40cda-6933-4dc4-a555-5d2ca617256e.png)
 
 ## Error Log
-The Error Log view captures all the warnings and errors logged by plug-ins. The underlying log file is a .log file stored in the .metadata subdirectory of the workspace. 
+
+The Error Log view captures all the warnings and errors logged by plug-ins. The underlying log file is a .log file stored in the .metadata subdirectory of the workspace.
 
 The Error Log view is available in `Window` > `Show View` > `Error Log`.
 
@@ -447,17 +477,20 @@ Always provide an error log when reporting an issue.
 ![](docs/images/export_log.png)
 
 ## Console View Log
+
 The Console View provides all the warnings and errors related to the current running process or build. To access the console view.
 
-From the menu bar, `Window` > `Show View` > `Console`. 
+From the menu bar, `Window` > `Show View` > `Console`.
 
 ![](docs/images/CDT_Build_Console.png)
 
 ## CDT Global Build Log
+
 Go to `Preferences > C/C++ > Build > Logging`
 
 ## Espressif IDF Tools Console
-The Espressif IDF Tools Console is part of Console view, this will be opened only during the installation of IDF tools from the Eclipse. 
+
+The Espressif IDF Tools Console is part of the Console view, this will be opened only during the installation of IDF tools from the Eclipse.
 
 If you encounter any issue while installing the IDF tools using `Espressif` > `ESP-IDF Tools Manager` > `Install tools`, please check the Espressif IDF Tools Console to see the errors reported.
 
@@ -466,28 +499,31 @@ If this is not active, it can be switched by clicking on the `Display Selected C
 ![](docs/images/IDF_tools_console.png)
 
 ## Heap Tracing
+
 Please refer to <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/HeapTracing.md">this</a> doc.
 
 <a name="installPluginsFromMarketPlace"></a>
 # Installing IDF Eclipse Plugin from Eclipse Market Place
 
 Please follow the steps below to install IDF Eclipse Plugin from the Eclipse Market Place.
-1. In Eclipse, choose `Help` > `Eclipse Market Place...`
-1. Enter `ESP-IDF Eclipse Plugin` in the search box to find the plugin
+
+1. In Eclipse, choose `Help` > `Eclipse Market Place...`.
+1. Enter `ESP-IDF Eclipse Plugin` in the search box to find the plugin.
 1. Click on `Install` to follow the installation instructions.
-1. Restart the Eclipse
+1. Restart the Eclipse.
 
 ![](docs/images/market_place.png)
 
 <a name="installPluginsUsingLocalFile"></a>
 # Installing IDF Eclipse Plugin from Local Archive
-1. Download the latest update site archive for IDF Eclipse Plugin here - https://github.com/espressif/idf-eclipse-plugin/releases
-1. In Eclipse, choose `Help` > `Install New Software`
-1. Click `Add…` button
-1. Select `Archive` from Add repository dialog and select the file `com.espressif.idf.update-vxxxxxxx.zip`
-1. Click `Add`
-1. Select `Espressif IDF` from the list and proceed with the installation 
-1. Restart the Eclipse
+
+1. Download the latest update site archive for IDF Eclipse Plugin here - https://github.com/espressif/idf-eclipse-plugin/releases.
+1. In Eclipse, choose `Help` > `Install New Software`.
+1. Click `Add…` button.
+1. Select `Archive` from Add repository dialog and select the file `com.espressif.idf.update-vxxxxxxx.zip`.
+1. Click `Add`.
+1. Select `Espressif IDF` from the list and proceed with the installation.
+1. Restart the Eclipse.
 
 ![](docs/images/1_idffeature_install.png)
 
@@ -495,15 +531,17 @@ Please follow the steps below to install IDF Eclipse Plugin from the Eclipse Mar
 # How do I upgrade my existing IDF Eclipse Plugin?
 
 If you are installing IDF Eclipse Plugin into your Eclipse for the first time, you first need to add the new release's repository as follows:
-1. `Window` > `Preferences` > `Install/Update` > `Available Software Sites`
-1. Click `Add`
-1. Enter the URL of the new repository https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/
-1. Click `Ok`
 
-If you've already installed IDF Eclipse Plugin using update site URL, you can get the latest changes using below
-1. `Help` > `Check for Updates`
-1. If updates are found, select `Espressif IDF Plugins for Eclipse` and deselect all other items
-1. Click `Next` to proceed with the installation
+1. `Window` > `Preferences` > `Install/Update` > `Available Software Sites`.
+1. Click `Add`.
+1. Enter the URL of the new repository https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/.
+1. Click `Ok`.
+
+If you've already installed IDF Eclipse Plugin using `update site URL`, you can get the latest changes by following the steps below:
+
+1. `Help` > `Check for Updates`.
+1. If updates are found, select `Espressif IDF Plugins for Eclipse` and deselect all other items.
+1. Click `Next` to proceed with the installation.
 
 ![](docs/images/Update_plugins.png)
 
@@ -511,13 +549,13 @@ If you've already installed IDF Eclipse Plugin using update site URL, you can ge
 # Importing an existing IDF Project
 
 1. Make sure you're in `C/C++ Perspective`.
-1. Right click in the Project Explorer
-1. Select `Import..` Menu
-1. Select `Existing IDF Project` from `Espressif` import wizard menu list
-1. Click `Next`
-1. Click on `Browse...` to choose an existing project location directory
-1. Provide `Project name` if you wish you have a different name
-1. Click `Finish` to import the selected project into eclipse workspace as a CMake project
+1. Right-click in the `Project Explorer`.
+1. Select `Import..` Menu.
+1. Select `Existing IDF Project` from `Espressif` import wizard menu list.
+1. Click `Next`.
+1. Click on `Browse...` to choose an existing project location directory.
+1. Provide `Project name` if you wish you have a different name.
+1. Click `Finish` to import the selected project into Eclipse workspace as a CMake project.
 
 ![](docs/images/5_import_project.png)
 
@@ -525,69 +563,85 @@ If you've already installed IDF Eclipse Plugin using update site URL, you can ge
 # Importing an existing Debug launch configuration
 
 To import an existing launch configuration into Eclipse:
-1. Select `Import...` from the `File` menu
-1. In the Import dialog box, expand the `Run/Debug` group and select `Launch Configurations`
-1. Click on `Next`
-1. Click on `Browse...` to select the required location in the local file system
-1. Select the folder containing the launch files and then click `OK`
-1. Select the checkboxes for the required folder and launch file
-1. If you are replacing an existing configuration with the same name then select `Overwrite existing launch configurations without warning`
-1. Click on `Finish`
+
+1. Select `Import...` from the `File` menu.
+1. In the Import dialog box, expand the `Run/Debug` group and select `Launch Configurations`.
+1. Click on `Next`.
+1. Click on `Browse...` to select the required location in the local file system.
+1. Select the folder containing the launch files and then click `OK`.
+1. Select the checkboxes for the required folder and launch file.
+1. If you are replacing an existing configuration with the same name then select `Overwrite existing launch configurations without warning`.
+1. Click on `Finish`.
 
 <a name="gdbStubDebugging"></a>
 # GDBStub Debugging
-You can now use the gdb stub debugging inside our eclipse plugin to help you diagnose and debug issues on chip via eclipse when it is in panic mode.
 
-To enable gdb stub debugging for a project you need to enable it first in the sdkconfig. Launch the sdkconfig in project root by double clicking on it which will open the configuration editor.
+You can now use the GDBStub debugging inside our Eclipse plugin to help you diagnose and debug issues on chips via Eclipse when it is in panic mode.
+
+To enable GDBStub debugging for a project:
+
+1. Launch the `sdkconfig` in project root by double-clicking on it which will open the configuration editor.
 ![](docs/images/GDBStubDebugging/sdkconfig_editor.png)
 
-Expand the `Component Config` section and select `ESP System Settings`. From the settings on the right for `Panic Handler behaviour` select the `GDBStub on Panic option` from the list
+1. Expand the `Component Config` section and select `ESP System Settings`. From the settings on the right for `Panic Handler behaviour` select the `GDBStub on Panic option` from the list.
 ![](docs/images/GDBStubDebugging/sdkconfig_editor_panic_behavior.png)
 
+Now you will be taken to the GDBStub debugger automatically when you connect the serial monitor and there is a panic for this example.
 
-Now you will be taken to the gdbstub debugger automatically when you connect the serial monitor and there is a panic for this example. 
+To use the GDBStub debugging for a project:
 
-Create a template `hello_world` project and add the following lines in the main c file.
+1. Create a template `hello_world` project and add the following lines in the main c file.
 
-```
-This is a global variable<br/>
-COREDUMP_DRAM_ATTR uint8_t global_var;
-```
+	```
+	This is a global variable<br/>
+	COREDUMP_DRAM_ATTR uint8_t global_var;
+	```
 
-Now add these two lines just above `esp_restart()` function<br/>
-`global_var = 25;`<br/>
-`assert(0);`<br/>
-The final file should be something like this
+1. Now add these two lines just above the `esp_restart()` function
+
+	```
+	global_var = 25;
+	assert(0);
+	```
+
+The final file should be something like this:
 ![](docs/images/GDBStubDebugging/code_example.png)
 
-Build and flash the project and launch the serial monitor. On the line number 45 we are signaling for a failing assert which will put the chip in panic mode and when that line reaches you will be prompted to switch the perspective to debug mode and the chip will be halted, remember that this is a panic mode and you cannot continue the execution from here you will have to stop and restart the chip through idf commands or simply restart the serial monitor.
+Build and flash the project and launch the serial monitor. On line number 45, we are signaling for a failing assert which will put the chip in panic mode and when that line reaches, you will be prompted to switch the perspective to debug mode and the chip will be halted.
+
+Remember that this is a panic mode and you cannot continue the execution from here, you will have to stop and restart the chip through IDF commands or simply restart the serial monitor.
+
 ![](docs/images/GDBStubDebugging/debug_panic_mode.png)
 
-You can view the registers stack trace and even view the value of variables in stack frame. To exit the debug session simply press stop button.
+You can view the registers stack trace and even view the value of variables in the stack frame.
 
+To exit the debug session simply press `stop` button.
 
 <a name="coreDumpDebugging"></a>
 
 # Core Dump Debugging
 
-The idf eclipse plugin allows you to debug the core dump if any crash occurs on the chip and the configurations are set. Currently only the UART core dump capture and debugging is supported.
+The IDF-Eclipse plugin allows you to debug the core dump if any crash occurs on the chip and the configurations are set. Currently only the UART core dump capture and debugging is supported.
 
-To enable core dump debugging for a project you need to enable it first in the sdkconfig. Launch the sdkconfig in project root by double clicking on it which will open the configuration editor.
-<br/>
-Click on the the `Core Dump` from the settings on the left. and select Data Destination as `UART`.
+To enable core dump debugging for a project:
+
+1. You need to enable it first in `sdkconfig`. Launch the `sdkconfig` in the project root by double-clicking on it which will open the configuration editor
+
+1. Click on the `Core Dump` from the settings on the left and select `Data Destination` as `UART`.
 ![](docs/images/CoreDumpDebugging/sdkconfig_editor.png)
 
-This will enable the core dump debugging and whenever you connect a serial monitor for that project if any crash occurs it will load the dump and open a debug perspective in eclipse to let you diagnose the dump where you can view all the information in the core dump.
+This will enable the core dump debugging and whenever you connect a serial monitor for that project if any crash occurs it will load the dump and open a debug perspective in Eclipse to let you diagnose the dump where you can view all the information in the core dump.
 
-You can view the registers stack trace and even view the value of variables in stack frame. To exit the debug session simply press stop button.
+You can view the registers stack trace and even view the value of variables in stack frame.
+
+To exit the debug session: simply press stop button.
 
 <a name="deviceFirmwareUpgrade"></a>
-
 # Device Firmware Upgrade (DFU) through USB
 
-Device Firmware Upgrade (DFU) is a mechanism for upgrading the firmware of devices through Universal Serial Bus (USB). There are a few  requirements that need to be met:
+Device Firmware Upgrade (DFU) is a mechanism for upgrading the firmware of devices through Universal Serial Bus (USB). There are a few requirements that need to be met:
 
-- DFU is supported by ESP32-S2 and  ESP32-S3 chips. 
+- DFU is supported by ESP32-S2 and ESP32-S3 chips.
 - You will need to do some electrical connection work (Here is a [guide](https://blog.espressif.com/dfu-using-the-native-usb-on-esp32-s2-for-flashing-the-firmware-b2c4af3335f1) for the ESP32-S2 board). The necessary connections for the USB peripheral are shown in the following table.
 
 | GPIO | USB         |
@@ -597,46 +651,46 @@ Device Firmware Upgrade (DFU) is a mechanism for upgrading the firmware of devic
 | GND  |  GND (black)|
 | +5V  |  +5V (red)  |
 
-- The chip needs to be in bootloader mode for the detection as a DFU device and flashing. This can beachieved by pulling GPIO0 down (e.g. pressing the BOOT button), pulsing RESET down for a moment and releasing GPIO0.
-- Install USB drivers (Windows only). The drivers can be installed by the [Zadig tool](https://zadig.akeo.ie/>). The manual installation of the driver in Device Manager of Windows is not recommended because the flashing might not work properly. Please make sure that the device is in
-download mode before running the tool and that it detects the device before installing the drivers. The Zadig
-tool might detect several USB interfaces of the target. Please install the WinUSB driver for only that interface for
-which there is no driver installed (probably it is Interface 2) and don't re-install the driver for the other interface. 
+After meeting the above requirements:
 
-After meeting requirements you are free to build and flash via DFU. How to use DFU:
+1. The chip needs to be in bootloader mode for the detection as a DFU device and flashing. This can be achieved by pulling GPIO0 down (e.g. pressing the BOOT button), pulsing RESET down for a moment and releasing GPIO0.
+1. Install USB drivers (Windows only). The drivers can be installed by the [Zadig tool](https://zadig.akeo.ie/>).
+	- Please make sure that the device is in download mode before running the tool and that it detects the device before installing the drivers.
+	- The Zadig tool might detect several USB interfaces of the target. Please install the WinUSB driver for only that interface for which there is no driver installed (probably it is Interface 2) and don't re-install the driver for the other interface.
+	- The manual installation of the driver in Device Manager of Windows is not recommended because the flashing might not work properly.
 
-- Edit the active launch configuration.
-- In the main tab, select the 'Flash over DFU' option.
-- Select a suitable IDF target for DFU
-- Now, if you use the build command, an extra file (dfu.bin) will be created, which can be used later for flashing.
+After meeting the above requirements, you are free to build and flash via DFU. How to use DFU:
+
+1. Edit the active launch configuration.
+1. In the main tab, select the `Flash over DFU` option.
+1. Select a suitable IDF target for DFU
+1. Now, if you use the build command, an extra file (dfu.bin) will be created, which can be used later for flashing.
 
 ![DFU actions](https://user-images.githubusercontent.com/24419842/226182180-286099d3-9c1c-4394-abb0-212d43054529.png)
-
 
 Additional information, including common errors and known issues, is mentioned in this [guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/dfu.html#usb-drivers-windows-only).
 
 <a name="appLvlTracing"></a>
-
 # Application Level Tracing
 
-ESP-IDF provides a useful feature for program behavior analysis called [Application Level Tracing](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?). IDF-Eclipse plugin has UI, that allows using start, stop tracing commands and process received data. To familiarize yourself with this library, you can use the [app_trace_to_host](https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host) project. This project can be created from the plugin itself:
+ESP-IDF provides a useful feature for program behavior analysis called [Application Level Tracing](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?). IDF-Eclipse plugin has UI, that allows using `start tracing`, `stop tracing` commands and process received data. To familiarize yourself with this library, you can use the [app_trace_to_host](https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host) project. This project can be created from the plugin itself:
+
 ![](docs/images/AppLvlTracing_1.png)
 
 Before you start using application-level tracing, it is important to create a debug configuration for the project where you must select the board you are using in order to successfully start the OpenOCD server.
 
 ![](docs/images/AppLvlTracing_3.png)
 
-After debug configuration is created, right click on the project in project explorer and click on `ESP-IDF:Application Level Tracing`:
+After debug configuration is created, right-click on the project in the `Project Explorer` and click on `ESP-IDF:Application Level Tracing`:
 
 ![](docs/images/AppLvlTracing_2.png)
 
 It can take a while to open the application level tracing dialog because the OpenOCD server starts first, so you don't need to start it externally. At the very top of the application-level trace dialog, there are auto-configured fields that you can change for the trace start command.
 
-
 Start command:
 
 * Syntax: `start <outfile> [poll_period [trace_size [stop_tmo [wait4halt [skip_size]]]]`
-* Argument: 
+* Argument:
 	* `outfile`: Path to file to save data from both CPUs. This argument should have the following format: ``file://path/to/file``.
 	* `poll_period`: Data polling period (in ms) for available trace data. If greater than 0 then command runs in non-blocking mode. By default, 1 ms.
 	* `trace_size`: Maximum size of data to collect (in bytes). Tracing is stopped after specified amount of data is received. By default -1 (trace size stop trigger is disabled).
@@ -645,85 +699,96 @@ Start command:
 	* `skip_size`: Number of bytes to skip at the start. By default, 0.
 
 Additional information can be found [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?).
+
 ![](docs/images/AppLvlTracing_4.png)
 
+The next two fields `Trace Processing Script` and `Start Parsing Command` are used to parse the output file.
 
-The next two fields `Trace Processing Script` and `Start Parsing Command` are used to parse the output file. 
+* `Trace Processing Script` is used to provide the path to the parsing script, by default it is logtrace_proc.py from esp-idf.
+* `Start Parsing Command` allows you to check the resulting parsing command and edit it if it's necessary. By default, this field is automatically configured to match `$IDF_PATH/tools/esp_app_trace/logtrace_proc.py/path/to/trace/file/path/to/program/elf/file`.
 
-* `Trace Processing Script` is used to provide the path to the parsing script, by default it is logtrace_proc.py from esp-idf. 
-* `Start Parsing Command` allows you to check the resulting parsing command and edit it if it's necessary. By default, this field is automatically configured to match `$IDF_PATH/tools/esp_app_trace/logtrace_proc.py/path/to/trace/file/path/to/program/elf/file`. Note the `Start parse` button is disabled until a dump file is available. To generate it, click the Start button at the bottom of the dialog box. After you click, the button changes to Stop so that you can stop tracking.
+Note the `Start parse` button is disabled until a dump file is available. To generate it, click the `Start` button at the bottom of the dialog box. After you click, the button changes to Stop so that you can stop tracking.
 
-When output file is generated, you can click on `Start parse` button and you will see parse script output in the eclipse console:
+When the output file is generated, you can click on `Start parse` button, and you will see the parsed script output in the Eclipse console:
+
 ![](docs/images/AppLvlTracing_5.png)
 
 <a name ="updateEspIdfMaster"></a>
-
 # ESP-IDF Master Update
 
 If you are using the master version of ESP-IDF and want to update it, you can do so in the plugin by going to `Espressif -> ESP-IDF Tool Manager` and clicking the `Update ESP-IDF master` command there.
 
 ![image](https://user-images.githubusercontent.com/24419842/182107159-16723759-65e0-4c34-9440-ebe2f536e62a.png)
 
-**Note:** This command is visible only if you are on the master branch in ESP-IDF
+> **Note:** This command is visible only if you are on the master branch in ESP-IDF.
 
 <a name ="partitionTableEditor"></a>
-
 # Partition Table Editor UI for ESP-IDF
 
 `ESP-IDF: Partition Table Editor` command allows to edit your [partition table](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html) in a more convenient way, where you can see the supported types and subtypes and monitor the correctness of the entered data.
 
-> Note: This command is available in the idf-eclipse plugin 2.8.0 and higher
+> Note: This command is available in the IDF-Eclipse plugin 2.8.0 and higher.
 
 Steps:
-1. Open any IDF Project in Project Explorer where you want to have custom partition table.
-2. To use a custom partition table, `Custom partition table CSV' must be set in the sdkconfig like this:
 
-![partition_table_editor](https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png)
+1. Go to `Project Explorer`, open any IDF Project where you want to have a customized partition table.
+1. In `Project Explorer`, right-click on the project and click on `ESP-IDF: Partition Table Editor` command:
 
-3. Right click on project in the Project Explorer and click on `ESP-IDF: Partition Table Editor` command:
+	![partition_table_editor_3](https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png)
 
-![partition_table_editor_3](https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png)
+	When opening the partition table editor for the selected project, you will see the standard editable content. Errors (if any) will be highlighted. You can hover your mouse over it to get a hint of what it is about:
 
-4. When you first open the partition table editor for the selected project, you will see the standard editable content. If there is any error it will be highlighted, you can hover your mouse over it to read a hint what it is about:
-![partition_table_editor_4](https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559-0599f072219f.png)
+	![partition_table_editor_4](https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559-0599f072219f.png)
 
-5. Don't forget to click "Save" or "Save and Quit" to save your changes.
+1. Click "Save" or "Save and Quit" to save your changes.
+
+To use a customized partition table:
+
+1. Go to `sdkconfig` and set `Custom partition table CSV` like below:
+
+	![partition_table_editor](https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png)
 
 <a name ="nvsTableEditor"></a>
-
 # NVS Table Editor
 
 `NVS Table Editor` helps to create a binary file based on key-value pairs provided in a CSV file. The resulting binary file is compatible with NVS architecture defined in [ESP_IDF Non Volatile Storage](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_flash.html). The expected CSV format is:
 
 ```
-key,type,encoding,value     <-- column header (must be the first line)
-namespace_name,namespace,,  <-- First entry must be of type "namespace"
-key1,data,u8,1
-key2,file,string,/path/to/file
+	key,type,encoding,value     <-- column header (must be the first line)
+	namespace_name,namespace,,  <-- First entry must be of type "namespace"
+	key1,data,u8,1
+	key2,file,string,/path/to/file
 ```
-> Note: This is based on ESP-IDF [NVS Partition Generator Utility](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_partition_gen.html). 
+> Note: This is based on ESP-IDF [NVS Partition Generator Utility](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_partition_gen.html).
 
-Steps: 
-1. Right click on project in the Project Explorer
-2. Select the `ESP-IDF: NVS Table Editor` command:
+Steps:
 
-![NVS Table Editor](https://user-images.githubusercontent.com/24419842/216114697-9f231211-f5dd-431b-9432-93ecc656cfec.png)
-> Note: This command is available in the idf-eclipse plugin 2.8.0 and higher
-3. Make desire changes to CSV data.
-4. Save changes by clicking the `Save` button. If everything is ok, you will see an information message at the top of the dialog:
-![NVS_TABLE_EDITOR_2png](https://user-images.githubusercontent.com/24419842/216115906-9bb4fe55-293b-4c6b-8d22-0aa3520581ab.png)
-5. Generate the partition binary (Choose encrypt to encrypt the binary and disable the generate key option to use your own key if desired). You will see an information message at the  top of the dialog about the result of generation the binaries.  you can hover your mouse over it to read the whole message if it's too long:
-![NVS_Table_Editor_4](https://user-images.githubusercontent.com/24419842/216117261-9bee798a-3a9e-4be5-9466-fc9d3847834b.png)
+1. Right-click on project in the `Project Explorer`
+1. Select the `ESP-IDF: NVS Table Editor` command:
 
-Note: If there are any errors, you will see them highlight, hover on the error icon to read more about the error. Also, the error message at the top of the dialog if saving the CSV file is not successful: 
+	![NVS Table Editor](https://user-images.githubusercontent.com/24419842/216114697-9f231211-f5dd-431b-9432-93ecc656cfec.png)
 
-![NVS_Table_editor_5](https://user-images.githubusercontent.com/24419842/216118486-69f819fa-7a95-49ae-805e-473cd2c424e8.png)
+	> Note: This command is available in the IDF-Eclipse plugin 2.8.0 and higher
+
+1. Make desired changes to CSV data
+1. Save changes by clicking the `Save` button. If everything is ok, you will see an information message at the top of the dialog:
+
+	![NVS_TABLE_EDITOR_2png](https://user-images.githubusercontent.com/24419842/216115906-9bb4fe55-293b-4c6b-8d22-0aa3520581ab.png)
+
+1. Generate the partition binary (Choose `encrypt` to encrypt the binary and disable the generate key option to use your own key if desired). You will see an information message at the top of the dialog about the result of generated binaries. You can hover your mouse over it to read the whole message if it's too long:
+
+	![NVS_Table_Editor_4](https://user-images.githubusercontent.com/24419842/216117261-9bee798a-3a9e-4be5-9466-fc9d3847834b.png)
+
+	> Note: If there are any errors, you will see them highlight, hover on the error icon to read more about the error. Also, you will see an error message at the top of the dialog if saving the CSV file is not successful:
+
+	![NVS_Table_editor_5](https://user-images.githubusercontent.com/24419842/216118486-69f819fa-7a95-49ae-805e-473cd2c424e8.png)
 
 After all these steps, you should see `nvs.csv` and `nvs.bin` files in the project directory.
 
 # How to build locally
-1. Install prerequisites Java 11+ and Maven
-2. Run below commands to clone and build
+
+1. Install prerequisites Java 11+ and Maven.
+2. Run the below commands to clone and build.
 
 	```
 	git clone https://github.com/espressif/idf-eclipse-plugin.git
@@ -731,41 +796,48 @@ After all these steps, you should see `nvs.csv` and `nvs.bin` files in the proje
 	mvn clean verify -Djarsigner.skip=true
 	```
 
-This will generate p2 update site artifact in the location `releng/com.espressif.idf.update/target` with name `com.espressif.idf.update-*` and this can be installed using the mechanism mentioned <a href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">here</a>
+This will generate p2 update site artifact:
 
-# How do I get the latest development build 
-1. Go to master branch last commit <a href="https://github.com/espressif/idf-eclipse-plugin/commits/master">here</a> 
-1. Click on a :white_check_mark: green tick mark
-1. Click on Details
-1. Click on Summary on the left
-1. Scroll down to see the artifacts section
-1. Download `com.espressif.idf.update` p2 update site archive and install as per the instructions mentioned <a 
-href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">here</a>
+* Name: `com.espressif.idf.update-*`
+* Location: `releng/com.espressif.idf.update/target`
+
+This artifact can be installed using the mechanism mentioned <a href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">here</a>
+
+# How do I get the latest development build
+
+1. Go to the last commit of the master branch <a href="https://github.com/espressif/idf-eclipse-plugin/commits/master">here</a>.
+1. Click on a :white_check_mark: green tick mark.
+1. Click on `Details`.
+1. Click on `Summary` on the left.
+1. Scroll down to see the `Artifacts` section.
+1. Download `com.espressif.idf.update` p2 update site archive and install as per the instructions mentioned <a
+href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">here</a>.
 
 # Custom IDE Configuration
 ## Custom build directory
-IDE allows configuring a custom build directory to the project: 
- 
-1. Select a project and click on a launch configuration `Edit` button from the top toolbar and this will the launch `Edit Configuration` window
-2. Navigate to the `Build Settings` tab
-3. In the `Additional CMake Arguments` section, provide a custom build directory with arguments `-B <custom build path>` with an absolute path. Custom build directory path could be within the project or a path from the file system. For example: `-B /Users/myUser/esp/generated`
-4. Click on Ok and build the project
+
+IDE allows configuring a custom build directory to the project:
+
+1. Select a project and click on a launch configuration `Edit` button from the top toolbar and this will the launch `Edit Configuration` window.
+2. Navigate to the `Build Settings` tab.
+3. In the `Additional CMake Arguments` section, provide a custom build directory with arguments `-B <custom build path>` with an absolute path. Customized build directory path could be within the project or a path from the file system. For example: `-B /Users/myUser/esp/generated`.
+4. Click on `Ok` and build the project.
 
 Note this configuration changes where all the project build artifacts will be generated.
 
 ![](docs/images/custombuilddir.png)
 
 <a name ="wokwisimulator"></a>
-
 # Wokwi Simulator
-- Install `wokwi-server` as mentioned [here](https://github.com/MabezDev/wokwi-server/)
-- Configure `WOKWI_SERVER_PATH` in the Eclipse CDT build environment variables with the wokwi-server executable path (Preferences > C/C++ > Build > Environment)
-- Create a new Run launch configuration with the `Wokwi Simulator`
-- Choose a project and add the project ID of the Wokwi project. The ID of a Wokwi project can be found in the URL. E.g., the ID of [ESP32 Rust Blinky](https://wokwi.com/projects/345932416223806035) is 345932416223806035.
-- Click Finish to save the changes
-- From the IDE Toolbar, click on the Launch button to launch the Wokwi simulator
-- Wokwi Simulator will be launched in the external browser and observe that serial monitor output also display in the Eclipse CDT build console
-- To kill a Wokwi simulator, click on the Stop button from the toolbar
+
+1. Install `wokwi-server` as mentioned [here](https://github.com/MabezDev/wokwi-server/)
+1. In the Eclipse CDT build environment variables, configure `WOKWI_SERVER_PATH` with the wokwi-server executable path (`Preferences` > `C/C++` > `Build` > `Environment`).
+1. Create a new `Run launch configuration` with the `Wokwi Simulator`.
+1. Choose a project and add the project ID of the Wokwi project. The ID of a Wokwi project can be found in the URL. E.g., the URL of project ESP32 Rust Blinky is [https://wokwi.com/projects/345932416223806035](https://wokwi.com/projects/345932416223806035) and the project ID is 345932416223806035.
+1. Click `Finish` to save the changes.
+1. From the IDE Toolbar, click on the `Launch` button to launch the Wokwi simulator.
+1. Wokwi Simulator will be launched in the external browser. The serial monitor output is also displayed in the Eclipse CDT build console.
+1. To kill a Wokwi simulator, click on the `Stop` button from the toolbar.
 
 # ESP-IDF Eclipse Plugin Compatibility Matrix
 
@@ -777,8 +849,7 @@ Note this configuration changes where all the project build artifacts will be ge
 | IEP 2.2.0 | Eclipse 2021-06, 2021-03, 2020-12 |Java 11 and above | ESP-IDF Tools Windows Installer 2.10| |
 | IEP 2.3.0 | Eclipse 2021-09, 2021-06 |Java 11 and above | ESP-IDF Tools Windows Installer 2.11| ESP-IDF Tools Windows Installer 2.11 comes with IEP 2.2.0 and this need to be updated to 2.3.0|
 
-
-
 <a name="Support"></a>
 # How to raise bugs
-Please raise the issues here https://github.com/espressif/idf-eclipse-plugin/issues with the complete environment details and log.
+
+Please raise the issues [here](https://github.com/espressif/idf-eclipse-plugin/issues) with the complete environment details and log.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,11 +1,13 @@
-[![GitHub 发布](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest) 
+[![GitHub 发布](https://img.shields.io/github/release/espressif/idf-eclipse-plugin.svg)](https://github.com/espressif/idf-eclipse-plugin/releases/latest)
 
 [English](./README.md)
 
 # ESP-IDF Eclipse 插件
-ESP-IDF Eclipse 插件可便利开发人员在 Eclipse 开发环境中开发基于 ESP32 的 IoT 应用程序。本插件集成了编辑、编译、烧录和调试等基础功能，还有安装工具、SDK 配置和 CMake 编辑器等附加功能，可简化并增强开发人员在使用标准 Eclipse CDT 开发和调试 ESP32 IoT 应用程序时的开发体验。
 
-ESP-IDF Eclipse 插件支持 `macOS`、`Window` 和 `Linux` 操作系统。
+ESP-IDF Eclipse 插件可便利开发人员在 Eclipse 开发环境中开发基于 ESP32 的 IoT 应用程序。
+本插件集成了编辑、编译、烧录和调试等基础功能，还有安装工具、SDK 配置和 CMake 编辑器等附加功能，可简化并增强开发人员在使用标准 Eclipse CDT 开发和调试 ESP32 IoT 应用程序时的开发体验。
+
+ESP-IDF Eclipse 插件支持 `macOS`、`Windows` 和 `Linux` 操作系统。
 
 ![](docs/images/macos-logo.png)
 ![](docs/images/windows-logo.png)
@@ -17,24 +19,33 @@ ESP-IDF Eclipse 插件支持 `macOS`、`Window` 和 `Linux` 操作系统。
 快速了解 ESP-IDF 和 Eclipse 插件，请见我们在 <a href= "https://youtu.be/CbPX3q7LeBc">EclipseCon 2020</a> 中的视频介绍。
 
 # 目录
-* [安装依赖资源](#Prerequisites) <br>
-* [安装 IDF Eclipse 插件](#GettingStarted) <br>
-* [安装 ESP-IDF 和相关工具集](#InstallTools) <br>
-* [使用工具安装助手，安装 ESP-IDF 和相关工具](#InstallToolsWizard) <br>
+<details open>
+  <summary>入门指南</summary>
+
+* [安装依赖资源](#Installation) <br>
 * [创建一个新项目](#NewProjectUsingDefault)<br>
 * [配置启动目标](#ConfigureLaunchTarget)<br>
 * [编译项目](#BuildApplication)<br>
 * [烧录项目](#FlashApplication)<br>
 * [查看串口输出](#ConfigureLaunchTerminal)<br>
+* [调试项目](#debugging)<br>
+* [故障排除指南](#troubleshooting)<br>
+* <a href ="https://github.com/espressif/idf-eclipse-plugin/blob/master/FAQ.md#FAQ">FAQ</a>
+</details>
+
+<details open>
+  <summary>其他 IDE 功能</summary>
+
+* [使用工具安装助手，安装 ESP-IDF 和相关工具](#InstallToolsWizard) <br>
 * [使用 sdkconfig 编辑器配置项目](#projectconfigure)<br>
 * [CMake 编辑器](#cmakeproject)<br>
-* [调试项目](#debugging)<br>
 * [ESP-IDF 应用程序内存分析编辑器](#sizeanalysiseditor)<br>
 * [安装 ESP-IDF 组件](#espidfcomponents)<br>
 * [ESP-IDF 终端](#idfterminal)<br>
 * [配置构建环境变量](#configureEnvironmentVariables)<br>
 * [配置核心构建工具链](#ConfigureToolchains)<br>
 * [配置的 CMake 工具链](#ConfigureCMakeToolchain)<br>
+* [选择 Clang 工具链](#SelectDifferentToolchain)<br>
 * [配置烧录参数](#customizeLaunchConfig)<br>
 * [从 Eclipse 市场安装 IDF Eclipse 插件](#installPluginsFromMarketPlace)<br>
 * [使用本地文件安装 IDF Eclipse 插件](#installPluginsUsingLocalFile) <br>
@@ -43,27 +54,27 @@ ESP-IDF Eclipse 插件支持 `macOS`、`Window` 和 `Linux` 操作系统。
 * [导入一个现有的 Debug 启动配置](#importDebugLaunchConfig)<br>
 * [通过 USB 升级设备固件 (DFU)](#deviceFirmwareUpgrade)<br>
 * [GDBStub 调试](#gdbStubDebugging)<br>
+* [Core Dump 调试](#coreDumpDebugging)<br>
 * [应用层追踪](#appLvlTracing)<br>
 * [ESP-IDF master 分支更新](#updateEspIdfMaster)<br>
+* [ESP-IDF 分区表编辑器界面](#partitionTableEditor)<br>
+* [NVS 表编辑器](#nvsTableEditor)<br>
 * [更改语言](#changeLanguage)<br>
-* [故障排除指南](#troubleshooting)<br>
-* [如何提交 bug](#howToRaiseBugs)<br>
-* <a href ="https://github.com/espressif/idf-eclipse-plugin/blob/master/FAQ.md#FAQ">常见问题</a>
+* [Wokwi 模拟器](#wokwisimulator)<br>
+</details>
 
-
-<a name="Prerequisites"></a>
+<a name="Installation"></a>
 # 安装依赖资源
 
 IDF Eclipse 插件的运行环境要求如下。
 
-* **Java 11 及以上**：点击<a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">这里</a>下载并安装 Java SE
-* **Python 3.6 及以上**：点击<a href="https://www.python.org/downloads/">这里</a>下载并安装 Python 
-* **Eclipse IDE C/C++ 开发工具 2022-06（2021-06 及以上）**：点击<a href= "https://www.eclipse.org/downloads/packages/release/2022-06/r/eclipse-ide-cc-developers">这里</a>下载并安装 Eclipse CDT 安装包 
-* **Git**：点击<a href ="https://git-scm.com/downloads">这里</a>获得最新 Git 
-* **ESP-IDF 4.0 及以上**：点击<a href ="https://github.com/espressif/esp-idf/releases">这里</a>克隆 ESP-IDF 仓库
+* **Java 17 及以上**：点击<a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">这里</a>下载并安装 Java SE.。
+* **Python 3.6 及以上**：点击<a href="https://www.python.org/downloads/">这里</a>下载并安装 Python。
+* **Eclipse IDE C/C++ 开发工具 2023-03**：点击<a href= "https://www.eclipse.org/downloads/packages/release/2023-03/r/eclipse-ide-cc-developers">这里</a>下载并安装 Eclipse CDT 安装包。
+* **Git**：点击<a href ="https://git-scm.com/downloads">这里</a>获得最新 Git。
+* **ESP-IDF 4.0 及以上**：点击<a href ="https://github.com/espressif/esp-idf/releases">这里</a>克隆 ESP-IDF 仓库。
 
 > **Note:** 请确保系统环境 `PATH` 可以访问 Java、Python 和 Git。
-
 
 此外，我们还为 Windows 用户提供 `Espressif-IDE 离线安装器`，集成了 OpenJDK、Python、CMake、Git、ESP-IDF、Eclipse IDE、IDF Eclipse 插件及相关构建工具，请见 <a href="https://github.com/espressif/idf-installer#espressif-ide-offline-installer"> Espressif-IDE 离线安装器 </a>。
 
@@ -75,7 +86,7 @@ IDF Eclipse 插件的运行环境要求如下。
 
 您可以使用`更新站点 URL` 将 ESP-IDF Eclipse 插件安装至您的 Eclipse CDT 环境中，具体步骤见下：
 
-1. 前往`帮助`>`安装新软件`
+1. 前往`帮助`>`安装新软件`。
 1. 点击`添加…`，并在弹出的对话窗中：
 	* 输入`名称`为 `乐鑫 ESP-IDF Eclipse 插件`。
 	* 输入`仓库位置`为：
@@ -83,7 +94,7 @@ IDF Eclipse 插件的运行环境要求如下。
 		* 测试版：https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/
 		* 每日构建版：https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/
 	* 点击`添加`。
-1. 从列表中选择`Espressif IDF`，并按照提示完成所有安装步骤。 
+1. 从列表中选择 `Espressif IDF`，并按照提示完成所有安装步骤。
 
 > **Note:** 本文档中的所有截图均来自 `macOS` 操作系统，但安装步骤同时适用于 `Windows`、`Linux` 和 `macOS` 操作系统。
 
@@ -110,6 +121,7 @@ IDF Eclipse 插件的运行环境要求如下。
 ![](docs/images/zh/espidf_download.png)
 
 # 安装 ESP-IDF 工具集
+
 ESP-IDF 在构建固件时需要一些工具，包括 Python、Git、交叉编译器、menuconfig 工具、CMake 和 Ninja 构建工具等。
 
 具体可按照以下步骤，安装 ESP-IDF 工具集。
@@ -128,63 +140,35 @@ ESP-IDF 目录选择对话框：
 
 ![](docs/images/zh/esp_idf_dir.png)
 
-<a name="InstallToolsWizard"></a>
-# 工具安装助手
-您可以使用工具安装助手，安装相关工具，优势在于可以简化安装过程，且仅安装 ESP-IDF 框架下您需要的工具。<br/>
-
-具体步骤如下：
-
-1. 前往 `乐鑫` > `ESP-IDF 工具管理器` > `工具安装助手（预览版）`
-![](docs/images/ToolsManager/install_tools_manager.png)
-
-2. 等待安装助手启动，选择 Git 和 Python 的安装路径（如您已添加系统 PATH，则路径可自动填充）。然后，点击 `下一步`。
-![](docs/images/ToolsManager/git_python_selection.png)
-
-3. 选择本地已安装 ESP-IDF 文件夹，或从下拉菜单中选择不同版本安装 ESP-IDF，比如选择列表中的 master 可以帮您从 github 中克隆 ESP-IDF 的 master 分支。
-![](docs/images/ToolsManager/select_or_download_new_esp_idf.png)
-
-1. 点击 `下一步` 查看针对您的 ESP-IDF 版本的可用工具。此时，您可以选择安装所有推荐工具，或仅选择您需要的工具（可按照工具名称或目标进行筛选）。接着，安装助手将下载并安装所有所需的工具。安装完成后，您就可以创建项目了。
-![](docs/images/ToolsManager/manage_tools_installation.png)
-
-
 <a name="NewProjectUsingDefault"></a>
 # 创建一个新项目
-1. 请首先确保您处于`C/C++ 视图`之下。
+
+1. 请首先确保您处于 `C/C++ 视图`之下。
 1. 前往`文件`>`新建`>`乐鑫 IDF 项目`（如果您未看到该选项，请前往`窗口`>`视图`>`重置视图...`）。
 1. 输入 `项目名称` （注意，ESP-IDF 构建系统路径中不允许空格）。
 1. 点击`完成`。
 
-> **Note:** 完成以上操作后，您将在编辑器中看到许多未解决的 include 错误。这些错误仅在构建后才能解决。
-
-![](docs/images/zh/3_new_project_default.png)
-
-<a name="NewProjectUsingTemplates"></a>
-## 使用 ESP-IDF 模板创建一个新项目
-1. 请首先确保您处于`C/C++ 视图`之下。
-1. 前往`文件`>`新建`>`乐鑫 IDF 项目`（如果您未找到该选项，请前往`窗口`>`视图`>`重置视图...`）。
-1. 输入`项目名称`。
-1. 点击`下一步`。
-1. 勾选`使用其中一个模板创建项目`。
-1. 从目录中选择一个模板。
-1. 点击`完成`。
+如需使用现有 ESP-IDF 模版创建一个新项目，请见[这里](#NewProjectUsingTemplates)。
 
 > **Note:** 完成以上操作后，您将在编辑器中看到许多未解决的 include 错误。这些错误仅在构建完成后才能解决。
 
-![](docs/images/zh/4_new_project_templates.png)
+![](docs/images/zh/3_new_project_default.png)
 
 <a name="ConfigureLaunchTarget"></a>
 # 配置启动目标
+
 接下来，我们需要告诉 CDT 应在项目中使用我们的工具链，确保所有的头文件均可索引和使用。本步骤需在`启动栏`完成。注意，`启动栏`位于工具栏的最左边，仅在`项目管理器`中存在项目时出现。
 
 1. 点击顶部工具栏中左起第三个下拉窗口`启动目标`。
 1. 选择`新的启动目标`。
-1. 选择`ESP 目标`。
+1. 选择 `ESP 目标`。
 1. 提供目标属性，即您希望启动应用程序的位置。输入目标`名称`，并选择您连接 ESP 设备的`串口`。
 
 ![](docs/images/zh/8_launch_target.png)
 
 <a name="BuildApplication"></a>
 # 编译项目
+
 1. 从`项目浏览器`中选择一个项目。
 1. 点击顶部工具栏中左起第一个下拉窗口`启动模式`，选择`运行`。
 1. 点击顶部工具栏中左起第二个下拉窗口`启动配置`，选择您的应用程序（自动检测）。
@@ -195,18 +179,20 @@ ESP-IDF 目录选择对话框：
 
 <a name="FlashApplication"></a>
 # 烧录项目
+
 ESP-IDF 的 `idf.py` 工具可以打包 `make flash` 命令和常用指令。用户只需点击`启动`按钮（顶部工具栏左起第二个按钮）即可启动烧录操作，即使用默认的烧录命令 `idf.py -p PORT flash` 烧录应用程序。
 
-如需使用自定义烧录参数，请前往 [这里](#customizeLaunchConfig) 获取详细步骤。
+如需使用自定义烧录参数，请前往[这里](#customizeLaunchConfig) 获取详细步骤。
 
 如需通过 JTAG 进行烧录，请见 <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/JTAG%20Flashing.md"> JTAG 烧录指南</a>。
 
 <a name="ConfigureLaunchTerminal"></a>
 # 查看串口输出
-为了查看 Eclipse 的串口输出，我们需要在`ESP-IDF 串口监视器`中配置需要监测的串口。本功能已经集成至`IDF 监视器`。更多详情，请见 <a href="https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/tools/idf-monitor.html">这里</a>。 
+
+为了查看 Eclipse 的串口输出，我们需要在`ESP-IDF 串口监视器`中配置需要监测的串口。本功能已经集成至`IDF 监视器`。更多详情，请见 <a href="https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/tools/idf-monitor.html">这里</a>。
 
 1. 点击工具栏中的`打开终端`图标。
-1. 从终端下拉菜单中选择`ESP-IDF 串口监视器`。
+1. 从终端下拉菜单中选择 `ESP-IDF 串口监视器`。
 1. 手动选择开发板连接的`串口`（如未能自动检测）。
 1. 配置`串口监视器`过滤器，对串口输出进行过滤。
 1. 点击 `OK` 启动终端，开始监听 USB 端口。
@@ -215,56 +201,97 @@ ESP-IDF 的 `idf.py` 工具可以打包 `make flash` 命令和常用指令。用
 
 ### ESP-IDF 串口监视器设置
 
-设置 ESP-IDF 串口监视器的字符和行数上限： 
-1. 进入 Eclipse 偏好设置，选择 `乐鑫`
-1. 点击 `ESP-IDF 串口监视器设置`
-1. 配置 `控制台行宽 (Console Line Width)` 和 `控制台输出上限 (Limit Console Output)`
+设置 ESP-IDF 串口监视器的字符和行数上限：
+
+1. 进入 Eclipse 偏好设置，选择 `乐鑫`。
+1. 点击 `ESP-IDF 串口监视器设置`。
+1. 配置 `控制台行宽 (Console Line Width)` 和 `控制台输出上限 (Limit Console Output)`。
+
+<a name="debugging"></a>
+# 调试项目
+
+## GDB 硬件调试
+
+请见 <a href ="https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/jtag-debugging/index.html" >GDB 硬件调试指南</a>。
+
+## GDB OpenOCD 调试
+
+请见 <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/OpenOCD%20Debugging.md">GDB OpenOCD 调试</a>。
+
+# 其他 IDE 功能
+
+<a name="NewProjectUsingTemplates"></a>
+## 使用 ESP-IDF 模板创建一个新项目
+
+1. 请首先确保您处于`C/C++ 视图`之下。
+1. 前往`文件`>`新建`>`乐鑫 IDF 项目`（如果您未找到该选项，请前往`窗口`>`视图`>`重置视图...`）。
+1. 输入`项目名称`。
+1. 点击`下一步`。
+1. 勾选`使用其中一个模板创建项目`。
+1. 从目录中选择一个模板。
+1. 点击`完成`。
+
+> **Note:** 完成以上操作后，您将在编辑器中看到许多未解决的 include 错误。这些错误仅在构建完成后才能解决。
+
+![](docs/images/4_new_project_templates.png)
+
+<a name="InstallToolsWizard"></a>
+# 工具安装助手
+
+您可以使用工具安装助手，安装相关工具，优势在于可以简化安装过程，且仅安装 ESP-IDF 框架下您需要的工具。
+
+具体步骤如下：
+
+1. 前往 `乐鑫` > `ESP-IDF 工具管理器` > `工具安装助手（预览版）`。
+![](docs/images/ToolsManager/install_tools_manager.png)
+
+1. 等待安装助手启动，选择 Git 和 Python 的安装路径（如您已添加系统 PATH，则路径可自动填充）。然后，点击 `下一步`。
+![](docs/images/ToolsManager/git_python_selection.png)
+
+1. 选择本地已安装 ESP-IDF 文件夹，或从下拉菜单中选择不同版本安装 ESP-IDF，比如选择列表中的 master 可以帮您从 GitHub 中克隆 ESP-IDF 的 master 分支。
+![](docs/images/ToolsManager/select_or_download_new_esp_idf.png)
+
+1. 点击 `下一步` 查看针对您的 ESP-IDF 版本的可用工具。此时，您可以选择安装所有推荐工具，或仅选择您需要的工具（可按照工具名称或目标进行筛选）。接着，安装助手将下载并安装所有所需的工具。安装完成后，您就可以创建项目了。
+![](docs/images/ToolsManager/manage_tools_installation.png)
 
 <a name="projectconfigure"></a>
-# 编译项目
-ESP-IDF Eclipse 插件允许用户直接在 Eclipse 环境中配置 `sdkconfig`。
+# SDK 配置编辑器
 
-## SDK 配置编辑器
-项目配置保存在项目根目录下的 `sdkconfig` 配置文件中，用户可通过`SDK 配置编辑器`进行修改。
+ESP-IDF Eclipse 插件允许用户直接在 Eclipse 环境中配置 `sdkconfig`。项目配置保存在项目根目录下的 `sdkconfig` 配置文件中，用户可通过`SDK 配置编辑器`进行修改。
 
-启动`SDK 配置编辑器`：
+启动 `SDK 配置编辑器`：
 
 1. 前往 `sdkconfig` 文件。
 1. 双击文件，启动 SDK 配置编辑器。
 1. 完成更改后，可使用 `Ctrl+S` 或 `Command+S` 保存更改。也可以点击 Eclipse 工具栏中的`保存`按钮进行保存。
-1. 如需撤回对 sdkconfig 编辑器的更改，用户可选择不保存退出编辑器；也可右键 `sdkconfig` 文件并选择`加载 sdkconfig`菜单选项，恢复对编辑器的修改。
+1. 如需撤回对 sdkconfig 编辑器的更改，用户可选择不保存退出编辑器；也可右键 `sdkconfig` 文件并选择`加载 sdkconfig` 菜单选项，恢复对编辑器的修改。
 
 ![](docs/images/13_sdkconfig_editor.png)
 
 <a name="cmakeproject"></a>
 # CMake 编辑器
+
 ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑 CMakeList.txt 等 CMake 文件，支持语法高亮、CMake 命令助手、代码模板等功能。
 
 ![](docs/images/cmake_editor_ca.png)
 
-如需配置 CMake 编辑器，请前往 Eclipse 的`偏好设置` > `CMakeEd`。
+如需配置 CMake 编辑器，请前往 Eclipse 的 `偏好设置` > `CMakeEd`。
 
 ![](docs/images/zh/cmake_editor_preferences.png)
 
-<a name="debugging"></a>
-# 调试项目
-## GDB 硬件调试
-请见 <a href ="https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/jtag-debugging/index.html" >GDB 硬件调试指南</a>。
-
-## GDB OpenOCD 调试
-请见 <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/OpenOCD%20Debugging.md">GDB OpenOCD 调试</a>。
-
-
 <a name="sizeanalysiseditor"></a>
 #  ESP-IDF 应用程序内存分析
-内存分析编辑器可分析应用程序的静态内存使用情况：概述和详情。`概述`选项卡可简要提供应用程序的内存使用情况；`详情`选项卡可详细介绍应用程序中各组件和各符号文件的内存使用情况。
+
+内存分析编辑器可分析应用程序的静态内存使用情况：概述和详情。
+- `概述`选项卡可简要提供应用程序的内存使用情况；
+- `详情`选项卡可详细介绍应用程序中各组件和各符号文件的内存使用情况。
 
 其中，`详情`选项卡还支持搜索和排序功能。
 
 启动`应用程序内存分析编辑器`：
 
-1. 右键点击项目
-1. 选择`ESP-IDF：应用程序内存分析`菜单，启动编辑器
+1. 右键点击项目。
+1. 选择 `ESP-IDF：应用程序内存分析`菜单，启动编辑器。
 
 **应用程序内存分析 - 概述**
 
@@ -276,7 +303,8 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 
 <a name="idfterminal"></a>
 # ESP-IDF 终端
-`ESP-IDF 终端`可为用户在 Eclipse 环境中启动一个本地终端窗口。用户可通过`偏好设置`>`C/C++`>`构建`>`环境`配置所有环境变量。本终端窗口的默认工作目录为当前选定的项目或 `IDF_PATH`（如未选定项目）。 
+
+`ESP-IDF 终端`可为用户在 Eclipse 环境中启动一个本地终端窗口。用户可通过`偏好设置`>`C/C++`>`构建`>`环境`配置所有环境变量。本终端窗口的默认工作目录为当前选定的项目或 `IDF_PATH`（如未选定项目）。
 
 终端 PATH 还将同时配置 `esptool`、`espcoredump`、`partition_table` 和 `app_update` 组件路径，允许用户从 ESP-IDF 终端直接进行访问。
 
@@ -292,7 +320,8 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 
 直接向您的项目中安装 ESP-IDF 组件：
 
-* 从`项目浏览器`中选择需要安装组件的项目，并选择 `安装 ESP-IDF 组件`
+* 从`项目浏览器`中选择需要安装组件的项目，并选择 `安装 ESP-IDF 组件`。
+
   ![](docs/images/ESP-IDF_Components/install_components.png)
 
   查看所有可安装的组件。
@@ -304,18 +333,19 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 
 <a name="configureEnvironmentVariables"></a>
 # 配置环境变量
+
 如您的 IDF 工具是通过`乐鑫`>`ESP-IDF 工具管理器`>`安装工具`菜单选项安装的，则 Eclipse 将帮您自动填充`偏好设置`>`C/C++ 构建`>`环境`配置所需的环境变量，具体包括：
 
-* IDF_PATH
-* PATH
-* OPENOCD_SCRIPTS
-* IDF_PYTHON_ENV_PATH
+* `IDF_PATH`
+* `PATH`
+* `OPENOCD_SCRIPTS`
+* `IDF_PYTHON_ENV_PATH`
 
 如上述环境变量未能自动正确配置，请按照以下步骤操作。
 
-1. 前往`C/C++ 构建`下的`环境`偏好设置页。 
-1. 再次点击`添加...`，并输入`IDF_PATH`，即 ESP-IDF 的完整安装路径。
-1. 按照相同步骤，配置 OPENOCD_SCRIPTS、IDF_PYTHON_ENV_PATH 和 PATH 环境变量
+1. 前往 `C/C++ 构建`下的`环境`偏好设置页。
+1. 再次点击`添加...`，并输入 `IDF_PATH`，即 ESP-IDF 的完整安装路径。
+1. 按照相同步骤，配置 `OPENOCD_SCRIPTS`、`IDF_PYTHON_ENV_PATH` 和 `PATH` 环境变量。
 
 以下均为示例：
 
@@ -331,10 +361,10 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 ##### PATH #####
 `/Users/user-name/.espressif/tools/xtensa-esp32-elf/esp32-2019r1-8.2.0/xtensa-esp32-elf/bin:/Users/user-name/.espressif/tools/esp32ulp-elf/2.28.51.20170517/esp32ulp-elf-binutils/bin:/Users/user-name/.espressif/tools/cmake/3.13.4/CMake.app/Contents/bin:/Users/user-name/.espressif/tools/openocd-esp32/v0.10.0-esp32-20190313/openocd-esp32/bin:/Users/user-name/.espressif/tools/ninja/1.9.0/:/Users/user-name/.espressif/python_env/idf4.0_py3.7_env/bin:/Users/user-name/esp/esp-idf/tools:$PATH`
 
-
 ![](docs/images/zh/2_environment_pref.png)
 
 # 配置工具链
+
 我们需要告诉 Eclipse CDT 在构建项目时需要使用什么核心构建工具链和 CMake 工具链。如您的 IDF 工具是通过`工具`>`ESP-IDF 工具管理器`>`安装工具`菜单选项安装的，则 Eclipse 可自动检测到需要使用的工具链。
 
 如未能自动检测所需工具链，请按照以下步骤操作。
@@ -348,27 +378,43 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 1. 选择 `GCC` 为工具链类型。
 1. 点击`下一步`。
 1. 提供 GCC 工具链设置：
-	**编译器：** /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc,
-	**操作系统：** esp32,
-	**CPU 架构：** xtensa
+
+	* **编译器：** /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc,
+	* **操作系统：** esp32,
+	* **CPU 架构：** xtensa
 
 ![](docs/images/6_core_build_toolchains.png)
 
 <a name="ConfigureCMakeToolchain"></a>
 #  配置 CMake 工具链
+
 现在，我们需要告诉 CDT 在构建项目时需要使用哪种工具链。这可以在生成 Ninja 文件时将所需的参数传递给 CMake。
 
-1. 前往`C/C++`>`CMake`偏好设置页
-1. 点击`添加...`，启动新的 CMake 工具链配置对话框
-1. 浏览 CMake 工具链 `Path`。示例：`/Users/user-name/esp/esp-idf/tools/cmake/toolchain-esp32.cmake`
-1. 从下拉列表中选择`GCC Xtensa 工具链`编译器。示例：`esp32 xtensa /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc`
+1. 前往 `C/C++`>`CMake`偏好设置页。
+1. 点击`添加...`，启动新的 CMake 工具链配置对话框。
+1. 浏览 CMake 工具链 `Path`。示例：`/Users/user-name/esp/esp-idf/tools/cmake/toolchain-esp32.cmake`。
+1. 从下拉列表中选择 `GCC Xtensa 工具链`编译器。示例：`esp32 xtensa /Users/user-name/esp/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc`。
 
 > **Note:** Eclipse CDT 在保存工具链偏好设置时有一个已知 bug。因此，我们建议在进行后续操作前，重新启动 Eclipse。
 
 ![](docs/images/7_cmake_toolchain.png)
 
+<a name="SelectDifferentToolchain"></a>
+# 选择 Clang 工具链
+
+ESP-IDF Eclipse 插件 v2.7.0 及以上版本支持使用 Clang 工具链构建项目。
+
+1. 在升级至或安装 ESP-IDF Eclipse 插件 v2.7.0 或以上版本后，请前往 `乐鑫` > `ESP-IDF 工具管理` > `安装工具` 更新工具链列表及 Clang 工具链所需要的环境变量。
+1. 创建新项目，并编辑项目配置。
+![image](https://user-images.githubusercontent.com/24419842/194882285-9faadb5d-0fe2-4012-bb6e-bc23dedbdbd2.png)
+1. 前往 `构建设置`，并选择 clang 工具链。
+![image](https://user-images.githubusercontent.com/24419842/194882462-3c0fd660-b223-4caf-964d-58224d91b518.png)
+
+> **Note:** Clang 工具链目前仅供研发试用，可能会出现一些与 ESP-IDF 不兼容的构建错误。下方针对目前的 ESP-IDF master 分支 (ESP-IDF v5.1-dev-992-gaf28c1fa21-dirty)，罗列了一些与 Clang 工具链有关的常见问题及解决方法，详情请见[这里](https://github.com/espressif/idf-eclipse-plugin/blob/master/WORKAROUNDS__CN.md#clang-toolchain-buid-errors).
+
 <a name="customizeLaunchConfig"></a>
 # 启动配置
+
 如需使用自定义启动配置和烧录参数，请按照以下步骤操作。
 
 1. 点击`启动配置`编辑按钮。
@@ -386,6 +432,7 @@ ESP-IDF Eclipse 插件中还集成了一个 CMake 编辑器，允许用户编辑
 
 <a name="changeLanguage"></a>
 # 更改语言
+
 IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤操作。
 
 1. 前往菜单栏，点击`乐鑫`。
@@ -398,10 +445,28 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 注意，上述操作仅提供针对插件界面的汉化。如需全部汉化，则请另外安装 Eclipse 汉化包。
 
 <a name="troubleshooting"></a>
-# 故障排除 
+# 故障排除
+
+## 有关借助提示查看器解决 ESP-IDF 常见问题的建议
+
+ESP-IDF 项目构建中的大多数常见错误均可从提示数据库 (`tools/idf_py_actions/hints.yml`) 中找到答案。ESP-IDF Eclipse 插件专门提供了一个提示查看器，允许用户查找错误信息。
+使用提示查看器必须首先拥有 `hints.yml` 文件（ESP-IDF v5.0 及以上版本均支持）。如果你的 ESP-IDF 版本较低，则可从[这里](https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/hints.yml)手动下载 `hints.yml` 并将其保存至 `esp-idf/tools/idf_py_actions/` 目录下。如需从 GitHub 下载文件，请单击 `Raw` 按钮并选择 `Save as...`。
+
+打开提示查看器：前往 `窗口` > `显示视图` > `其他` > `乐鑫` > `提示`，即可打开如下视图：
+![image](https://user-images.githubusercontent.com/24419842/189666994-78cc8b24-b934-426f-9df5-79af28c50c55.png)
+
+现在，你可以直接输入或从构建日志复制粘贴错误信息，比如：
+`ccache error: Failed to create temporary file for esp-idf/libsodium/CMakeFiles/..../....: No such file or directory`
+
+![image](https://user-images.githubusercontent.com/24419842/189672552-994624f3-c0c5-48e6-aa2c-61e4ed8915e5.png)
+
+此外，双击错误信息还可以放大提示信息。
+
+![image](https://user-images.githubusercontent.com/24419842/189673174-8ce40cda-6933-4dc4-a555-5d2ca617256e.png)
 
 ## 错误日志
-`错误日志`视图可以显示插件记录的所有警告和错误，其底层日志文件 (.log 文件) 保存在工作空间的 .metadata 子目录下。 
+
+`错误日志`视图可以显示插件记录的所有警告和错误，其底层日志文件（.log 文件）保存在工作空间的 .metadata 子目录下。
 
 打开`错误日志`视图，请前往`窗口`>`显示视图`>`错误日志`。
 
@@ -412,17 +477,20 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 ![](docs/images/zh/export_log.png)
 
 ## 控制台视图日志
+
 `控制台`视图可显示与当前运行或构建有关的所有警告和错误。
 
-打开`控制台`视图，请前往`窗口`>`显示视图`>`控制台`。 
+打开`控制台`视图，请前往`窗口`>`显示视图`>`控制台`。
 
 ![](docs/images/CDT_Build_Console.png)
 
 ## CDT 全局构建日志
-打开 CDT 全局构建日志，请前往`偏好设置`>`C/C++`>`构建`>`日志`
+
+打开 CDT 全局构建日志，请前往`偏好设置`>`C/C++`>`构建`>`日志`。
 
 ## 乐鑫 IDF 工具集控制台
-`乐鑫 IDF 工具控制台`为`控制台`视图的组成部分，通常仅在通过 Eclipse 安装 IDF 工具集时使用。 
+
+`乐鑫 IDF 工具控制台`为`控制台`视图的组成部分，通常仅在通过 Eclipse 安装 IDF 工具集时使用。
 
 如您在通过`乐鑫`>`ESP-IDF 工具管理器`>`安装工具`方式安装 IDF 工具集时出现任何问题，即可使用本控制台查看错误报告。
 
@@ -431,7 +499,8 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 ![](docs/images/zh/IDF_tools_console.png)
 
 ## 堆栈追踪
-详见 <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/HeapTracing.md">这里</a>。
+
+详见<a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/HeapTracing.md">这里</a>。
 
 <a name="installPluginsFromMarketPlace"></a>
 # 从 Eclipse 市场安装 IDF Eclipse 插件
@@ -453,7 +522,7 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 1. 点击`添加`按钮。
 1. 在`添加`仓库对话框中选择`存档`> `com.espressif.idf.update-vxxxxxxx.zip` 文件。
 1. 点击`添加`。
-1. 从列表中选择`Espressif IDF`，并按照提示完成所有安装步骤。 
+1. 从列表中选择 `Espressif IDF`，并按照提示完成所有安装步骤。
 1. 重启 Eclipse。
 
 ![](docs/images/zh/1_idffeature_install.png)
@@ -470,8 +539,8 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 
 如果您已经使用最新仓库的 URL 安装了 IDF Eclipse 插件，则可以按照以下步骤获取更新。
 
-1. 前往`帮助`>`检查更新`
-1. 如有新的更新，请选择`乐鑫 IDF 插件`，并取消勾选所有其他项目
+1. 前往`帮助`>`检查更新`。
+1. 如有新的更新，请选择`乐鑫 IDF 插件`，并取消勾选所有其他项目。
 1. 点击`下一步`，并按照提示完成所有安装步骤。
 
 ![](docs/images/Update_plugins.png)
@@ -479,9 +548,9 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 <a name="ImportProject"></a>
 #  导入一个现有的 IDF 项目
 
-1. 请首先确保您处于`C/C++ 视图`之下。
+1. 请首先确保您处于 `C/C++ 视图`之下。
 1. 右键点击`项目资源管理器`。
-1. 选择`导入...`菜单
+1. 选择`导入...`菜单。
 1. 前往`乐鑫导入向导`菜单，选择`现有 IDF 项目`。
 1. 点击`下一步`。
 1. 点击`浏览...`，选择一个本地项目的位置。
@@ -492,13 +561,14 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 
 <a name="importDebugLaunchConfig"></a>
 #  导入一个现有的 Debug 启动配置
+
 将一个现有的启动配置导入 Eclipse：
 
 1. 前往`文件`>`导入...`。
 1. 在`导入`对话框中，扩展`运行/调试`组，并选择`启动配置`。
 1. 点击`下一步`。
 1. 点击`浏览...`，选择本地文件系统中所需的位置。
-1. 选择包含启动文件的文件夹，然后点击`OK`。
+1. 选择包含启动文件的文件夹，然后点击 `OK`。
 1. 勾选所需的文件夹并启动文件。
 1. 如果您正在使用新的配置文件替代先前一个相同名称的配置，请选择`覆盖现有启动配置（忽略警告）`。
 1. 点击`完成`。
@@ -527,7 +597,7 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 	COREDUMP_DRAM_ATTR uint8_t global_var;
 	```
 
-1. 接着，在 `esp_restart()` 功能之前插入下方代码 <br/>
+1. 接着，在 `esp_restart()` 功能之前插入下方代码：
 
 	```
 	global_var = 25;<br/>
@@ -545,25 +615,41 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 
 您可以在此界面查看寄存器堆栈踪迹，甚至堆栈框架中变量的值。
 
-退出调试界面：
+退出调试界面，请点击`停止`。
 
-1. 点击 `停止`。
+<a name="coreDumpDebugging"></a>
+
+# Core Dump 调试
+
+乐鑫 ESP-IDF Eclipse 插件允许用户调试芯片崩溃时的 core dump 信息，且无需进行额外配置。目前，仅支持 UART core dump 捕获与调试。
+
+为你的项目打开 core dump 调试功能：
+
+1. 在项目的根目录中打开 `sdkconfig` 文件。此时，你会看到配置编辑器窗口。
+
+1. 在左侧列表中选择 `Core Dump`，并将 `Data Destination` 配置为 `UART`。
+![](docs/images/CoreDumpDebugging/sdkconfig_editor.png)
+
+至此，core dump 功能已经打开。此后，一旦项目发生任何崩溃，仅需打开串口监控器即可查看 core dump 信息，还可在 eclipse 中打开调试视图，方便用户的诊断。
+
+你还可以查看寄存器堆栈追踪，甚至查看堆栈帧中的变量值。
+
+退出调试窗口：点击`停止`按钮。
 
 <a name="deviceFirmwareUpgrade"></a>
-
 # 通过 USB 升级设备固件 (DFU)
 
 设备固件升级 (DFU) 允许用户通过 USB 升级设备固件，但必须满足一些条件：
 
-- DFU 支持仅限 ESP32-S2 和 ESP32-S3 系列。 
+- DFU 支持仅限 ESP32-S2 和 ESP32-S3 系列。
 - 其次，您还需额外链接一些导线，具体见下表。此外，您还可以参考针对 ESP32-S2 开发板的[示例](https://blog.espressif.com/dfu-using-the-native-usb-on-esp32-s2-for-flashing-the-firmware-b2c4af3335f1)。
 
 | GPIO | USB         |
 | -----| ------------|
-| 20   |  D+ （绿）   |
-| 19   |  D- （白）   |
-| GND  |  GND （黑）  |
-| +5V  |  +5V （红）  |
+| 20   |  D+（绿）    |
+| 19   |  D-（白）    |
+| GND  |  GND（黑）   |
+| +5V  |  +5V（红）   |
 
 确认上述条件满足后：
 
@@ -575,19 +661,19 @@ IDF Eclipse 插件可支持不同语言。如需更改，请按照以下步骤�
 
 完成上述步骤后，可通过 DFU 构建烧固件，具体步骤如下：
 
-1. 前往工具栏，并打开 DFU 开关。
-1. 前往目标面板，并选择正确的目标和端口。
+1. 编辑活跃启动配置。
+1. 前往主页面，选择 `Flash over DFU` 选项。
+1. 选择需要的 IDF 目标。
 1. 此时，使用 build 命令会生成一个新文件 (dfu.bin)，可用于后续的烧录。
 
-![DFU actions](https://user-images.githubusercontent.com/24419842/175890153-42bd711e-a916-408e-a568-9b008f86a8b6.png)
+![DFU actions](https://user-images.githubusercontent.com/24419842/226182180-286099d3-9c1c-4394-abb0-212d43054529.png)
 
-更多信息（包括常见错误和已知问题），请见[指南](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/dfu.html#usb-drivers-windows-only)。
+更多信息（包括常见错误和已知问题），请见[指南](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32s3/api-guides/dfu.html#usb-drivers-windows-only)。
 
 <a name="appLvlTracing"></a>
-
 # 应用层追踪
 
-ESP-IDF 的 [应用层追踪](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?) 功能可用于分析程序行为。ESP-IDF Eclipse 插件也特别提供了用户界面，允许通过命令开始/停止追踪，并进行数据处理。具体参考可见 [app_trace_to_host](https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host) 项目，创建方式如下：
+ESP-IDF 的[应用层追踪](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32c3/api-guides/app_trace.html) 功能可用于分析程序行为。ESP-IDF Eclipse 插件也特别提供了用户界面，允许通过命令开始/停止追踪，并进行数据处理。具体参考可见 [app_trace_to_host](https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host) 项目，创建方式如下：
 
 ![](docs/images/AppLvlTracing_1.png)
 
@@ -604,44 +690,105 @@ ESP-IDF 的 [应用层追踪](https://docs.espressif.com/projects/esp-idf/en/lat
 开始命令：
 
 * 语法：`start <outfile> [poll_period [trace_size [stop_tmo [wait4halt [skip_size]]]]`
-* 参数：  
+* 参数：
 	* `outfile`：文件路径（从任一 CPU），格式应满足 `file://path/to/file`。
 	* `poll_period`：可用追踪数据的轮询周期（单位：毫秒）。如果大于 0，则命令以“非阻塞”模式运行。默认值 1（1 毫秒）。
 	* `trace_size`：可追踪数据的最大长度限制（单位：字节）。注意，该参数使能后，追踪数据达到配置的长度后则自动停止。默认值 -1（不限制最大长度）。
 	* `stop_tmo`：超时限制（单位：秒），即如特定期间中未收到数据则停止追踪。默认值 -1（不限制超时）。如需配置，注意应长于两条追踪命令之间的最大间隔。
-	* `wait4halt`：配置为 0 立刻开始追踪，否则等待目标停止后开始追踪（复位后、出现断点等）。默认值 0（立刻开始追踪）
-	* `skip_size`：开始追踪后跳过若干个字节。默认值 0 （跳过 0 个字节）
+	* `wait4halt`：配置为 0 立刻开始追踪，否则等待目标停止后开始追踪（复位后、出现断点等）。默认值 0（立刻开始追踪）。
+	* `skip_size`：开始追踪后跳过若干个字节。默认值 0（跳过 0 个字节）。
 
-更多信息，请见 [这里](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/app_trace.html?)。
+更多信息，请见[这里](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32c3/api-guides/app_trace.html?)。
+
+![](docs/images/AppLvlTracing_4.png)
 
 另外两个参数 `Trace Processing Script` 和 `Start Parsing Command` 用于解析输出文件。
 
-* `Trace Processing Script` 配置解析脚本的存储路径，默认为 esp-idf 中的 logtrace_proc.py
+* `Trace Processing Script` 配置解析脚本的存储路径，默认为 ESP-IDF 中的 logtrace_proc.py
 * `Start Parsing Command` 配置解析结果文件的存储路径，默认为 `$IDF_PATH/tools/esp_app_trace/logtrace_proc.py/path/to/trace/file/path/to/program/elf/file`。
 
 注意，右侧的 `Start parse` 按钮默认将处于禁用状态。此时，可以点击窗口右下方的 `开始` 按钮，这将生成一个 dump 文件，并同时解禁 `Start parse` 按钮。
 
 此后，点击 `Start parse` 按钮，从 Eclipse 控制台查看解析脚本的输出：
+
 ![](docs/images/AppLvlTracing_5.png)
 
 <a name ="updateEspIdfMaster"></a>
-
 # ESP-IDF Master 更新
 
-您如果在使用 ESP-IDF 的 master 分支，并希望进行升级：请打开 Eclipse 插件，前往 `乐鑫` -> `ESP-IDF 工具管理器`，并点击 `更新 ESP-IDF master`。
+您如果在使用 ESP-IDF 的 master 分支，并希望进行升级：请打开 Eclipse 插件，前往 `乐鑫` > `ESP-IDF 工具管理器`，并点击 `更新 ESP-IDF master`。
 
 ![image](https://user-images.githubusercontent.com/24419842/182107159-16723759-65e0-4c34-9440-ebe2f536e62a.png)
 
-**注意：** 该选项仅适用于 ESP-IDF 的 master 分支。
+> **Note:**该选项仅适用于 ESP-IDF 的 master 分支。
 
-<a name="howToRaiseBugs"></a>
-# 如何提交 bug？
-请点击此链接（https://github.com/espressif/idf-eclipse-plugin/issues）提交问题，并提供完整的环境详细信息和日志。
+<a name ="partitionTableEditor"></a>
+# ESP-IDF 分区表编辑器界面
+
+`ESP-IDF: 分区表编辑器`命令允许您以更便捷的方式编辑您的[分区表](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/partition-tables.html)。在此界面中，您可以查看所有支持的类型和子类型，并监控输入数据。
+
+> **Note:**此命令仅支持 IDF-Eclipse 2.8.0 及更高版本中。
+
+具体操作步骤如下：
+
+1. 前往`项目资源管理器`，打开需要自定义分区表的 ESP-IDF 项目。
+1. 在`项目资源管理器`中右键单击项目，并选择 `ESP-IDF: 分区表编辑器`命令：
+
+	![partition_table_editor_3](https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png)
+
+	当首次打开所选项目的分区表编辑器时，您将看到标准的可编辑内容。错误（如果有）将高亮显示。您可以将鼠标悬停错误之上以获得详细提示：
+
+	![partition_table_editor_4](https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559-0599f072219f.png)
+
+1. 单击`保存`或`保存并退出`，以保存您的更改。
+
+要使用自定义的分区表，
+
+1. 前往 `sdkconfig` 并按照下图设置 `Custom partition table CSV`：
+
+   ![partition_table_editor](https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png)
+
+<a name ="nvsTableEditor"></a>
+# NVS 表编辑器
+
+`NVS 表编辑器`可以根据 CSV 文件中提供的键值对，生成二进制文件。生成的二进制文件与 [ESP-IDF 非易失性存储](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/storage/nvs_flash.html) 中定义的 NVS 架构兼容。CSV 文件应满足如下格式：
+
+```
+	key,type,encoding,value     <-- column header (must be the first line)
+	namespace_name,namespace,,  <-- First entry must be of type "namespace"
+	key1,data,u8,1
+	key2,file,string,/path/to/file
+```
+> **Note:** 上述格式基于 ESP-IDF 的 [NVS 分区生成工具](https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/storage/nvs_partition_gen.html)。
+
+具体操作步骤如下：
+
+1. 在`项目资源管理器`中右键单击项目
+1. 选择 `ESP-IDF: NVS 表编辑器`命令：
+
+	![NVS Table Editor](https://user-images.githubusercontent.com/24419842/216114697-9f231211-f5dd-431b-9432-93ecc656cfec.png)
+
+	> **Note:**此命令仅支持 IDF-Eclipse 2.8.0 及更高版本中。
+
+1. 根据需求，更改 CSV 数据
+1. 点击`保存`按钮保存更改。如果一切正常，您将在对话框顶部看到信息消息：
+
+	![NVS_TABLE_EDITOR_2png](https://user-images.githubusercontent.com/24419842/216115906-9bb4fe55-293b-4c6b-8d22-0aa3520581ab.png)
+
+1. 生成分区二进制文件（如果需要加密二进制文件，请选择 `encrypt`；如果需要使用自己的密钥，请禁用 `generate key` 选项）。您可在对话框顶部，查看有关二进制文件的生成结果。如内容过长不能全部显示，您可以将鼠标悬停，以查看完整消息：
+
+	![NVS_Table_Editor_4](https://user-images.githubusercontent.com/24419842/216117261-9bee798a-3a9e-4be5-9466-fc9d3847834b.png)
+
+	> **Note:** 错误（如果有）将高亮显示。您可以将鼠标悬停错误之上以获得详细提示。此外，如 CSV 文件保存失败，您可在对话框顶部查看错误消息：
+
+	![NVS_Table_editor_5](https://user-images.githubusercontent.com/24419842/216118486-69f819fa-7a95-49ae-805e-473cd2c424e8.png)
+
+完成上述所有步骤后，您将在项目目录中看到 `nvs.csv` 和 `nvs.bin` 文件。
 
 # 如何进行本地构建
 
-1. 完成准备工作：安装 Java 11+ 和 Maven
-2. 运行以下命令，进行克隆和构建
+1. 完成准备工作：安装 Java 11+ 和 Maven。
+2. 运行以下命令，进行克隆和构建。
 
 	```
 	git clone https://github.com/espressif/idf-eclipse-plugin.git
@@ -650,18 +797,20 @@ ESP-IDF 的 [应用层追踪](https://docs.espressif.com/projects/esp-idf/en/lat
 	```
 
 以上命令将生成 p2 更新站点 artifact：
+
 * 名称：`com.espressif.idf.update-*`
 * 存储路径：`releng/com.espressif.idf.update/target`
 
 后续可按照 <a href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">介绍</a> 进行安装。
 
 # 如何获得最新的开发构建
+
 1. 前往最新 master 分支，找到 <a href="https://github.com/espressif/idf-eclipse-plugin/commits/master">最新 commit</a> 。
 1. 点击最新 commit 处的 :white_check_mark:。
 1. 点击 `Details`。
 1. 点击左侧 `Summary`。
 1. 下滑至页面底部，找到 `Artifacts`。
-1. 下载 `com.espressif.idf.update`，并按照 <a 
+1. 下载 `com.espressif.idf.update`，并按照 <a
 href="https://github.com/espressif/idf-eclipse-plugin#installPluginsUsingLocalFile">介绍</a> 进行安装。
 
 # 自定义 IDE 配置
@@ -672,20 +821,35 @@ IDE 支持配置自定义构架目录：
 1. 选择您的项目，从顶部工具栏打开配置 `Edit` 界面。
 2. 选择 `Build Settings` 选项卡。
 3. 在 `Additional CMake arguments` 选项框提供自定义目录，可以选择项目中的某个文件夹，也可以选择项目外的某个文件夹，格式为 `-B <custom build path>`，例 `-B /Users/myUser/esp/generated`。
-4. 点击 `OK`开始构建项目
+4. 点击 `OK` 开始构建项目。
 
 注意，此配置将改变所有项目构建 artifact 的保存路径。
 
 ![](docs/images/custombuilddir.png)
 
+<a name ="wokwisimulator"></a>
+# Wokwi 模拟器
+
+1. 按照[此处](https://github.com/MabezDev/wokwi-server/)说明，安装 `wokwi-server`。
+2. 在 Eclipse CDT 的构建环境变量中配置 `WOKWI_SERVER_PATH` 为 `wokwi-server` 可执行文件的路径（`Preferences` > `C/C++` > `Build` > `Environment`）。
+3. 创建一个新的`运行启动配置`，选择 `Wokwi 模拟器`。
+4. 选择一个项目，并添加 Wokwi 项目的`项目 ID`。该项目 ID 可在 URL 中找到。例如，ESP32 Rust Blinky 项目的 URL 为 [https://wokwi.com/projects/345932416223806035](https://wokwi.com/projects/345932416223806035)，项目 ID 则为 URL 中的 345932416223806035。
+5. 点击 `完成` 以保存更改。
+6. 前往 IDE 工具栏，点击 `启动` 按钮来启动 Wokwi 模拟器。
+7. Wokwi 模拟器将在外部浏览器中启动。串行监视器的输出也会显示在 Eclipse CDT 构建控制台中。
+8. 要终止 Wokwi 模拟器，前往工具栏并点击 `停止` 按钮。
+
 # ESP-IDF Eclipse 插件兼容情况
 
-| IEP | Eclipse | Java | 工具安装器| 描述 |
+ IEP | Eclipse | Java | 工具安装器 | 描述 |
 | ------ | ------ | ------ |------ | ------ |
-| IEP 2.3.0 | Eclipse 2021-09, 2021-06 |Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.11| ESP-IDF 工具安装器 (Windows) 2.11 集成 IEP 2.2.0，需升级至 2.3.0|
-| IEP 2.2.0 | Eclipse 2021-06, 2021-03, 2020-12 |Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.10| |
-| IEP 2.1.2 | Eclipse 2021-06, 2021-03, 2020-12, 2020-09 |Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.9| IEP 2.1.2 增加了对 Eclipse 2021-06 的支持|
-| IEP 2.1.1 | Eclipse 2021-03, 2020-12, 2020-09 | Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.8 | ESP-IDF 工具安装器 (Windows) 集成 IEP 2.1.0，需升级至 2.1.1
-| IEP 2.1.0 | Eclipse 2021-03, 2020-12, 2020-09 | Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.6 beta | IEP 2.1.0 增加了对 Eclipse 2021-03 的支持|
-| IEP 2.0.0 | Eclipse 2020-12, 2020-09, 2020-06 | Java 11 及以上 | ESP-IDF 工具安装器 (Windows) 2.6 beta  || 
-| IEP 1.2.4 | Eclipse 2020-12, 2020-09, 2020-06, 2020-03 | Java 1.8 及以上 | 不支持 | IEP 1.2.4 增加了对 Eclipse 2020-12 的支持|
+| IEP 2.10.0 | Eclipse 2022-09, 2022-12, 2023-03 |Java 17 及以上 | [espressif-ide-setup-2.10.0-with-esp-idf-5.0.1.exe](https://github.com/espressif/idf-installer/releases/download/untagged-52aeb689780472c126c1/espressif-ide-setup-2.10.0-with-esp-idf-5.0.1.exe)|
+| IEP 2.9.1 | Eclipse 2022-09 和 Eclipse  2022-12 |Java 17 及以上 | [espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.9.0-esp-idf-5.0.1/espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe) | Windows 用户建议使用离线 Windows 安装器并升级至最新的 IEP v2.9.1 插件|
+| IEP 2.9.0 | Eclipse 2022-09 |Java 17 及以上 | [espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.9.0-esp-idf-5.0.1/espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe) | Windows 用户建议使用离线 Windows 安装器|
+| IEP 2.2.0 | Eclipse 2021-06, 2021-03, 2020-12 |Java 11 及以上 | ESP-IDF 工具 Windows 安装器 2.10| |
+| IEP 2.3.0 | Eclipse 2021-09, 2021-06 |Java 11 及以上 | ESP-IDF 工具 Windows 安装器 2.11| ESP-IDF 工具 Windows 安装器 2.11 默认搭配 IEP 2.2.0，需手动升级为 2.3.0|
+
+<a name="Support"></a>
+# 如何提交 bug？
+
+请点击[此链接](https://github.com/espressif/idf-eclipse-plugin/issues)提交问题，并提供完整的环境详细信息和日志。

--- a/WORKAROUNDS_CN.md
+++ b/WORKAROUNDS_CN.md
@@ -1,10 +1,10 @@
-# Workarounds for build errors
+# 构建错误的临时解决方法
 
-[中文](./WORKAROUNDS_CN.md)
+[English](./WORKAROUNDS.md)
 
-## Clang Toolchain Build Errors
+## Clang 工具链构建错误
 
-1. `error: __cxa_guard_release(abort)` is missing exception specification `throw()`. Edit a file `esp-idf/components/cxx/cxx_guards.cpp`
+1. ``error: `__cxa_guard_release(abort)` is missing exception specification `throw()``。编辑文件 `esp-idf/components/cxx/cxx_guards.cpp`
 
 ```diff
 -extern "C" void __cxa_guard_release(__guard* pg)
@@ -22,7 +22,7 @@
      const auto scheduler_started = xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED;
 ```
 
-2. `error: variable 'usec' set but not used [-Werror,-Wunused-but-set-variable] int sec, usec`. Edit a file `esp-idf/CMakeLists.txt`.
+2. `error: variable 'usec' set but not used [-Werror,-Wunused-but-set-variable] int sec, usec`。编辑文件 `esp-idf/CMakeLists.txt`.
 
 ```diff
      list(APPEND compile_options "-Wno-atomic-alignment")
@@ -34,7 +34,7 @@
 +    list(APPEND compile_options "-Wno-unknown-warning-option")
 ```
 
-3. `error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]`. Edit a file `esp-idf/CMakeLists.txt`.
+3. `error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]`。编辑文件 `esp-idf/CMakeLists.txt`.
 
 ```diff
     list(APPEND compile_options "-Wno-unused-but-set-variable")
@@ -43,14 +43,14 @@
 +   list(APPEND compile_options "-Wno-parentheses-equality")
 endif()
 ```
-4. Windows specific issue saying clang++ file is missing from the toolchain folder:
+4. Windows 特殊问题：工具链文件夹中找不到 clang++ 文件：
 
 ```
  The CMAKE_CXX_COMPILER:
 clang++
   is not a full path and was not found in the PATH.
 ```
-To fix this you can use clang instead of clang++. Edit a file `esp-idf\tools\cmake\toolchain-clang-esp32.cmake`:
+可尝试使用 clang，而非 clang++。编辑文件 `esp-idf\tools\cmake\toolchain-clang-esp32.cmake`：
 
 ```diff
 set(CMAKE_C_COMPILER clang)


### PR DESCRIPTION
This PR:

syncd up the Chinese and English versions of:
readme.md
workaround.md
aligned the line numbers between en/cn files.
fixed some violations against [EMOS](https://espressifsystems.sharepoint.com/sites/Documentation/SitePages/Document-Template.aspx)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Addressed build errors in the Clang toolchain by modifying exception specifications in `cxx_guards.cpp` and adding compile options to suppress warnings.
- Chore: Updated `CMakeLists.txt` to set the CMAKE_CXX_COMPILER to `clang`, improving compatibility with different environments.
- Documentation: Provided workarounds for specific build issues in both English and Chinese versions of the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->