### PR TITLE
SWTBot: 'ESP-IDF Install New Component' test case

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
@@ -186,6 +186,17 @@ public class NewEspressifIDFProjectTest
 		Fixture.thenProjectHasTheFile("dfu.bin", "/build");
 		Fixture.turnOffDfu();
 	}
+	
+	@Test
+	public void givenNewProjectCreatedThenInstallNewComponent() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenInstallNewComponentUsingContextMenu();
+		Fixture.checkIfNewComponentIsInstalledUsingContextMenu();
+	}
 
 	private static class Fixture
 	{
@@ -283,6 +294,22 @@ public class NewEspressifIDFProjectTest
 			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
 			ProjectTestOperations.waitForProjectBuild(bot);
 			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
+		}
+		
+		private static void whenInstallNewComponentUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.openProjectNewComponentUsingContextMenu(projectName, bot);
+			bot.editorByTitle(projectName).show();
+			bot.button("Install").click();
+			ProjectTestOperations.waitForProjectNewComponentInstalled(bot);
+			bot.editorByTitle(projectName).close();
+		    ProjectTestOperations.refreshProjectUsingContextMenu(projectName, bot);
+		}
+
+		private static void checkIfNewComponentIsInstalledUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.openProjectComponentYMLFileInTextEditorUsingContextMenu(projectName, bot);
+			ProjectTestOperations.checkTextEditorContentForPhrase("espressif/mdns", bot);
 		}
 
 		private static void thenAllConfigurationsAreDeleted()


### PR DESCRIPTION
## Description

Added 'ESP-IDF Install New Component' test case. 
Test case install New Component (mdns) - checks the console for the presence of the correct message - checks the idf_component.yml file for the presence of component record (espressif/mdns) 


Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-1038))

## Type of change

- New SWT Bot test case

**Test Configuration**:
* ESP-IDF Version: v5.1.1
* OS (Windows,Linux and macOS): Windows 10



## Checklist
- [X] PR Self Reviewed
- [X] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced testing capabilities for the Espressif IDF project. This includes the ability to simulate the creation of a new project, build the project, install a new component, and verify the installation.
- Improvement: Added several helper methods to streamline project operations. These include waiting for a project build, refreshing a project, opening and checking the content of a project's component file, and opening a new component.
  
These updates aim to improve the reliability of the software by enhancing testing capabilities and making project operations more efficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->