### PR TITLE
IEP-1041: Parse Compile Commands File exception when using multiple esp-idf versions

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -1245,6 +1245,10 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				pathtolookfor = getIdfToolsPath();
 				startIndex = sourceFile.indexOf(pathtolookfor);
 			}
+			if (startIndex == -1) // source file still not found means it was part of another esp-idf
+			{
+				return null;
+			}
 			String relativePath = sourceFile.substring(startIndex + pathtolookfor.length() + 1);
 
 			IPath projectPath = getComponentsPath().append(relativePath);


### PR DESCRIPTION
## Description

added one additional check which ignores the issue when switching esp-idf versions

Fixes # ([IEP-1041](https://jira.espressif.com:8443/browse/IEP-1041))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?


Test 1:
- downgrade esp-idf version from the IDE -> try rebuilding project without cleaning build folder -> expected no parse compile commands error


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Improved the reliability of the build process in the IDF (IoT Development Framework). The software now checks if a required source file is present before attempting to build. If the file is not found, the build process is halted gracefully, preventing potential errors or crashes. This change enhances the stability and predictability of the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->