### PR TITLE
[WIP] IEP-1042: Run the installer action with the publishing of release on idf-eclipse-plugin github page

### DIFF
--- a/.github/workflows/run_idf_installer_build.yml
+++ b/.github/workflows/run_idf_installer_build.yml
@@ -50,3 +50,4 @@ jobs:
                    "python_version": "3.11"
               }
             }'
+

--- a/.github/workflows/run_idf_installer_build.yml
+++ b/.github/workflows/run_idf_installer_build.yml
@@ -1,0 +1,21 @@
+name: run_idf_installer_build
+
+on:
+  release:
+    types:
+      - published
+  pull_request:
+  
+jobs:
+  run-idf-installer-build:
+    name: IDF Installer Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Trigger the Receiver Action
+        run: |
+           curl -XPOST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+           -H "Accept: application/vnd.github.everest-preview+json" \
+           "https://api.github.com/repos/espressif/idf-installer/dispatches" \
+           -d '{"event_type": "trigger-action", "client_payload": {"input_name": "value_here"}}'

--- a/.github/workflows/run_idf_installer_build.yml
+++ b/.github/workflows/run_idf_installer_build.yml
@@ -38,8 +38,15 @@ jobs:
 
       - name: Trigger the Receiver Action
         run: |
-          curl -XPOST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          "https://api.github.com/repos/espressif/idf-installer/dispatches" \
-          -d "{\"event_type\": \"trigger-action\", \"client_payload\": {\"ide_version\": \"$IDE_VERSION\", \"idf_version\" : \"$IDF_VERSION\"}}"
-
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/espressif/idf-installer/actions/workflows/build-espressif-ide-installer.yml/dispatches \
+            -d '{
+               "ref": "main",
+              "inputs": {
+                   "espressif_ide_version": "'$IDE_VERSION'",
+                   "esp_idf_version": "'$IDF_VERSION'",
+                   "python_version": "3.11"
+              }
+            }'

--- a/.github/workflows/run_idf_installer_build.yml
+++ b/.github/workflows/run_idf_installer_build.yml
@@ -10,12 +10,36 @@ jobs:
   run-idf-installer-build:
     name: IDF Installer Build
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Get IDE version from release tag
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          IDE_VERSION=${TAG#v}
+          echo "IDE Version is $IDE_VERSION"
+          echo "IDE_VERSION=$IDE_VERSION" >> $GITHUB_ENV
+
+      - name: Get latest release from espressif/esp-idf
+        run: |
+            RESPONSE=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/espressif/esp-idf/releases/latest)
+  
+            TAG_NAME=$(echo "$RESPONSE" | jq -r '.tag_name')
+            IDF_VERSION=${TAG_NAME#v}
+            echo "Latest IDF Version is: $IDF_VERSION"
+            echo "IDF_VERSION=$IDF_VERSION" >> $GITHUB_ENV
+  
+
       - name: Trigger the Receiver Action
         run: |
-           curl -XPOST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-           -H "Accept: application/vnd.github.everest-preview+json" \
-           "https://api.github.com/repos/espressif/idf-installer/dispatches" \
-           -d '{"event_type": "trigger-action", "client_payload": {"input_name": "value_here"}}'
+          curl -XPOST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          "https://api.github.com/repos/espressif/idf-installer/dispatches" \
+          -d "{\"event_type\": \"trigger-action\", \"client_payload\": {\"ide_version\": \"$IDE_VERSION\", \"idf_version\" : \"$IDF_VERSION\"}}"
+

--- a/.github/workflows/run_idf_installer_build.yml
+++ b/.github/workflows/run_idf_installer_build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
             RESPONSE=$(curl -L \
               -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+              -H "Authorization: Bearer ${{ secrets.REPO_ACCESS_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/espressif/esp-idf/releases/latest)
   
@@ -39,7 +39,7 @@ jobs:
       - name: Trigger the Receiver Action
         run: |
           curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.REPO_ACCESS_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/espressif/idf-installer/actions/workflows/build-espressif-ide-installer.yml/dispatches \
             -d '{


### PR DESCRIPTION
## Description

Run the installer action with the publishing of release on idf-eclipse-plugin github page

Fixes # ([IEP-1042](https://jira.espressif.com:8443/browse/IEP-1042))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Running and testing the action first by PR and then after merge via a release



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Automated build process for the IDF (Espressif IoT Development Framework) installer to ensure compatibility with the latest IDE and ESP-IDF releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->