### PR TITLE
IEP-1035: SWTBot Project Clean / FullClean, Python Clean test cases. 

### DIFF
--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.launchbar.core,
  com.espressif.idf.core.test;bundle-version="0.0.1",
  org.eclipse.jface,
- slf4j.api
+ slf4j.api,
+ com.espressif.idf.ui;bundle-version="1.0.1"
 Bundle-ActivationPolicy: lazy
 Import-Package: com.espressif.idf.core.util,
  org.eclipse.launchbar.ui,

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
@@ -6,7 +6,10 @@ package com.espressif.idf.ui.test.executable.cases.project;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -21,7 +24,6 @@ import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -30,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
+import com.espressif.idf.ui.handlers.Messages;
 import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.resources.DefaultFileContentsReader;
@@ -172,7 +175,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.thenProjectHasTheFile("dfu.bin", "/build");
 		Fixture.turnOffDfu();
 	}
-	
+
 	@Test
 	public void givenNewProjectCreatedThenInstallNewComponent() throws Exception
 	{
@@ -182,6 +185,39 @@ public class NewEspressifIDFProjectTest
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.whenInstallNewComponentUsingContextMenu();
 		Fixture.checkIfNewComponentIsInstalledUsingContextMenu();
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltAndThenProjectCleanUsingContextMenu() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectCleanTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenProjectCleanUsingContextMenu();
+		Fixture.checkIfProjectCleanedFilesInBuildFolder();
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltAndThenProjectFullCleanUsingContextMenu() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectFullCleanTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenProjectFullCleanUsingContextMenu();
+		Fixture.checkIfProjectFullCleanedFilesInBuildFolder();
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltAndThenProjectPythonCleanUsingContextMenu() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectPythonCleanTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenProjectPythonCleanUsingContextMenu();
+		Fixture.checkPythonCLeanCommandDeleteFolder();
 	}
 
 	private static class Fixture
@@ -281,7 +317,7 @@ public class NewEspressifIDFProjectTest
 			ProjectTestOperations.waitForProjectBuild(bot);
 			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
 		}
-		
+
 		private static void whenInstallNewComponentUsingContextMenu() throws IOException
 		{
 			ProjectTestOperations.openProjectNewComponentUsingContextMenu(projectName, bot);
@@ -289,13 +325,22 @@ public class NewEspressifIDFProjectTest
 			bot.button("Install").click();
 			ProjectTestOperations.waitForProjectNewComponentInstalled(bot);
 			bot.editorByTitle(projectName).close();
-		    ProjectTestOperations.refreshProjectUsingContextMenu(projectName, bot);
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+		}
+
+		private static void checkPythonCLeanCommandDeleteFolder() throws IOException
+		{
+			String pathtoexe = System.getProperty("user.home");
+			Path p = Paths.get(pathtoexe + "\\esp-idf\\tools\\__pycache__");
+			String folderPATH = p.toAbsolutePath().toString();
+			File folder = new File(folderPATH);
+			assertTrue(ProjectTestOperations.checkFolderExistanceAfterPythonClean(folder));
 		}
 
 		private static void checkIfNewComponentIsInstalledUsingContextMenu() throws IOException
 		{
 			ProjectTestOperations.openProjectComponentYMLFileInTextEditorUsingContextMenu(projectName, bot);
-			ProjectTestOperations.checkTextEditorContentForPhrase("espressif/mdns", bot);
+			assertTrue(ProjectTestOperations.checkTextEditorContentForPhrase("espressif/mdns", bot));
 		}
 
 		private static void thenAllConfigurationsAreDeleted()
@@ -402,6 +447,40 @@ public class NewEspressifIDFProjectTest
 				// do nothing
 			}
 
+		}
+
+		private static void whenProjectCleanUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: Project Clean");
+			ProjectTestOperations.joinJobByName(Messages.ProjectCleanCommandHandler_RunningProjectCleanJobName);
+			ProjectTestOperations.waitForProjectClean(bot);
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+		}
+
+		private static void whenProjectFullCleanUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: Project Full Clean");
+			ProjectTestOperations.joinJobByName(Messages.ProjectFullCleanCommandHandler_RunningFullcleanJobName);
+			ProjectTestOperations.waitForProjectClean(bot);
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+		}
+
+		private static void whenProjectPythonCleanUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: Python Clean");
+			ProjectTestOperations.joinJobByName(Messages.PythonCleanCommandHandler_RunningPythonCleanJobName);
+			ProjectTestOperations.waitForProjectClean(bot);
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+		}
+
+		private static void checkIfProjectCleanedFilesInBuildFolder() throws IOException
+		{
+			assertTrue(ProjectTestOperations.findProjectCleanedFilesInBuildFolder(projectName, bot));
+		}
+
+		private static void checkIfProjectFullCleanedFilesInBuildFolder() throws IOException
+		{
+			assertTrue(ProjectTestOperations.findProjectFullCleanedFilesInBuildFolder(projectName, bot));
 		}
 	}
 }

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -152,7 +152,6 @@ public class ProjectTestOperations
 		if (projectItem != null)
 		{
 			projectItem.select();
-			projectItem.expand();
 			projectItem.getNode("build").expand();
 
 			boolean fileToBeAbsentItem = isFileAbsent(projectItem.getNode("build"), ".elf");
@@ -172,7 +171,6 @@ public class ProjectTestOperations
 		if (projectItem != null)
 		{
 			projectItem.select();
-			projectItem.expand();
 			projectItem.getNode("build").expand();
 
 			boolean fileToBeAbsentItem = isFileAbsent(projectItem.getNode("build"), ".elf");
@@ -504,7 +502,7 @@ public class ProjectTestOperations
 		SWTBotView consoleView = viewConsole("Espressif IDF Tools Console", bot);
 		consoleView.show();
 		consoleView.setFocus();
-		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 5000);
+		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 0);
 	}
 
 	public static void joinJobByName(String jobName)

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -504,7 +504,7 @@ public class ProjectTestOperations
 		SWTBotView consoleView = viewConsole("Espressif IDF Tools Console", bot);
 		consoleView.show();
 		consoleView.setFocus();
-		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 0);
+		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 5000);
 	}
 
 	public static void joinJobByName(String jobName)

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -495,6 +495,15 @@ public class ProjectTestOperations
 			projectItem.select();
 			projectItem.contextMenu(contextMenuLabel).click();
 		}
+		try
+		{
+			Thread.sleep(2000);
+		}
+		catch (InterruptedException e)
+		{
+			logger.error(e.getMessage(), e);
+		}
+
 	}
 
 	public static void waitForProjectClean(SWTWorkbenchBot bot) throws IOException

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -4,10 +4,13 @@
  *******************************************************************************/
 package com.espressif.idf.ui.test.operations;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
@@ -19,8 +22,10 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarDropDownButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+
 /**
  * Class to contain the common operations related to project setup. The class can be used in different test classes to
  * setup the required projects
@@ -30,7 +35,7 @@ import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
  */
 public class ProjectTestOperations
 {
-	
+
 	private static final String DEFAULT_PROJECT_BUILD_WAIT_PROPERTY = "default.project.build.wait";
 
 	/**
@@ -46,6 +51,8 @@ public class ProjectTestOperations
 		{
 			projectItem.select();
 			projectItem.contextMenu("Build Project").click();
+			projectItem.expand();
+			projectItem.select("build");
 		}
 	}
 
@@ -57,13 +64,13 @@ public class ProjectTestOperations
 	 */
 	public static void waitForProjectBuild(SWTWorkbenchBot bot) throws IOException
 	{
-		SWTBotView consoleView = viewConsole("CDT Build Console", bot); //bot.viewById("org.eclipse.ui.console.ConsoleView");
+		SWTBotView consoleView = viewConsole("CDT Build Console", bot);
 		consoleView.show();
 		consoleView.setFocus();
 		TestWidgetWaitUtility.waitUntilViewContains(bot, "Build complete", consoleView,
 				DefaultPropertyFetcher.getLongPropertyValue(DEFAULT_PROJECT_BUILD_WAIT_PROPERTY, 600000));
 	}
-	
+
 	public static void waitForProjectNewComponentInstalled(SWTWorkbenchBot bot) throws IOException
 	{
 		SWTBotView consoleView = viewConsole("ESP-IDF Console", bot);
@@ -83,7 +90,7 @@ public class ProjectTestOperations
 		view.setFocus();
 		return view;
 	}
-	
+
 	public static void createDebugConfiguration(String projectName, SWTWorkbenchBot bot)
 	{
 		SWTBotView projectExplorerBotView = bot.viewByTitle("Project Explorer");
@@ -97,69 +104,134 @@ public class ProjectTestOperations
 			bot.tree().getTreeItem("ESP-IDF GDB OpenOCD Debugging").doubleClick();
 			bot.button("Close").click();
 		}
-		
+
 	}
-	
-	public static void refreshProjectUsingContextMenu(String projectName, SWTWorkbenchBot bot)
+
+	public static void openProjectComponentYMLFileInTextEditorUsingContextMenu(String projectName, SWTWorkbenchBot bot)
 	{
 		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
 		if (projectItem != null)
 		{
 			projectItem.select();
-			projectItem.contextMenu("Refresh").click();
+			projectItem.expand();
+			projectItem.getNode("main").expand();
+
+			int maxAttempts = 2;
+			for (int attempt = 0; attempt <= maxAttempts; attempt++)
+			{
+				SWTBotTreeItem fileToOpenItem = findTreeItem(projectItem.getNode("main"), "idf_component.yml");
+
+				if (fileToOpenItem != null)
+				{
+					fileToOpenItem.select();
+					fileToOpenItem.doubleClick();
+					return;
+				}
+
+				else
+				{
+					try
+					{
+						Thread.sleep(3000);
+					}
+					catch (InterruptedException e)
+					{
+						Logger.log(e);
+					}
+				}
+			}
 		}
 	}
-	
-	public static void openProjectComponentYMLFileInTextEditorUsingContextMenu(String projectName, SWTWorkbenchBot bot) 
+
+	public static boolean findProjectCleanedFilesInBuildFolder(String projectName, SWTWorkbenchBot bot)
 	{
-	    SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
-	    if (projectItem != null) {
-	        projectItem.select();
-	        projectItem.expand();
-	        projectItem.getNode("main").expand();
+		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
+		if (projectItem != null)
+		{
+			projectItem.select();
+			projectItem.expand();
+			projectItem.getNode("build").expand();
 
-	        int maxAttempts = 2;
-	        for (int attempt = 0; attempt <= maxAttempts; attempt++) {
-	            SWTBotTreeItem fileToOpenItem = findTreeItem(projectItem.getNode("main"), "idf_component.yml");
-
-	            if (fileToOpenItem != null) {
-	            	fileToOpenItem.select();
-	            	fileToOpenItem.doubleClick();
-	                return;
-	            }
-
-	            else {
-	                try {
-	                    Thread.sleep(3000);
-	                } catch (InterruptedException e) {
-	                    e.printStackTrace();
-	                }
-	            }
-	        }
-	        throw new RuntimeException("The 'idf_component.yml' file was not found in the 'main' subfolder.");
-	    }
+			boolean fileToBeAbsentItem = isFileAbsent(projectItem.getNode("build"), ".elf");
+			SWTBotTreeItem fileToFindItem = findTreeItem(projectItem.getNode("build"), "bootloader");
+			if (fileToFindItem != null && fileToBeAbsentItem)
+			{
+				return true;
+			}
+			return false;
+		}
+		return false;
 	}
 
-	private static SWTBotTreeItem findTreeItem(SWTBotTreeItem parent, String itemName) {
-	    for (SWTBotTreeItem child : parent.getItems()) {
-	        if (child.getText().equals(itemName)) {
-	            return child;
-	        }
-	        SWTBotTreeItem found = findTreeItem(child, itemName);
-	        if (found != null) {
-	            return found;
-	        }
-	    }
-	    return null;
-	}
-	
-	public static void checkTextEditorContentForPhrase(String phrase, SWTWorkbenchBot bot) {
-	    SWTBotEditor textEditor = bot.activeEditor();
-	    String editorText = textEditor.toTextEditor().getText();
+	public static boolean findProjectFullCleanedFilesInBuildFolder(String projectName, SWTWorkbenchBot bot)
+	{
+		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
+		if (projectItem != null)
+		{
+			projectItem.select();
+			projectItem.expand();
+			projectItem.getNode("build").expand();
 
-	    if (!editorText.contains(phrase)) {
-	        throw new RuntimeException("The specified phrase '" + phrase + "' was not found in the text editor.");
-	    }
+			boolean fileToBeAbsentItem = isFileAbsent(projectItem.getNode("build"), ".elf");
+			boolean fileToBeAbsentItem1 = isFileAbsent(projectItem.getNode("build"), "bootloader");
+			if (fileToBeAbsentItem && fileToBeAbsentItem1)
+			{
+				return true;
+			}
+			return false;
+		}
+		return false;
+	}
+
+	private static SWTBotTreeItem findTreeItem(SWTBotTreeItem parent, String itemName)
+	{
+		for (SWTBotTreeItem child : parent.getItems())
+		{
+			if (child.getText().equals(itemName))
+			{
+				return child;
+			}
+			SWTBotTreeItem found = findTreeItem(child, itemName);
+			if (found != null)
+			{
+				return found;
+			}
+		}
+		return null;
+	}
+
+	private static boolean isFileAbsent(SWTBotTreeItem parent, String itemName)
+	{
+		for (SWTBotTreeItem child : parent.getItems())
+		{
+			if (child.getText().contains(itemName))
+			{
+				return false; // File found, return false
+			}
+			if (!isFileAbsent(child, itemName))
+			{
+				return false; // File found in a child, return false
+			}
+		}
+		return true; // File not found, return true
+	}
+
+	public static boolean checkFolderExistanceAfterPythonClean(File folderExists)
+	{
+		boolean folder = folderExists.exists();
+		if (folder == false)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean checkTextEditorContentForPhrase(String phrase, SWTWorkbenchBot bot)
+	{
+		SWTBotEditor textEditor = bot.activeEditor();
+		String editorText = textEditor.toTextEditor().getText();
+
+		return editorText.contains(phrase);
 	}
 
 	public static void openProjectNewComponentUsingContextMenu(String projectName, SWTWorkbenchBot bot)
@@ -245,7 +317,8 @@ public class ProjectTestOperations
 	 * @param bot            current SWT bot reference
 	 * @param deleteFromDisk delete from disk or only delete from workspace
 	 */
-	public static void deleteProject(String projectName, SWTWorkbenchBot bot, boolean deleteFromDisk, boolean deleteRelatedConfigurations)
+	public static void deleteProject(String projectName, SWTWorkbenchBot bot, boolean deleteFromDisk,
+			boolean deleteRelatedConfigurations)
 	{
 		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
 		if (projectItem != null)
@@ -255,8 +328,8 @@ public class ProjectTestOperations
 			{
 				bot.checkBox("Delete project contents on disk (cannot be undone)").click();
 			}
-			
-			if (deleteRelatedConfigurations) 
+
+			if (deleteRelatedConfigurations)
 			{
 				bot.checkBox("Delete all related configurations").click();
 			}
@@ -292,7 +365,7 @@ public class ProjectTestOperations
 	{
 		ProjectTestOperations.deleteProject(projectName, bot, true, false);
 	}
-	
+
 	public static void deleteProjectAndAllRelatedConfigs(String projectName, SWTWorkbenchBot bot)
 	{
 		ProjectTestOperations.deleteProject(projectName, bot, true, true);
@@ -410,6 +483,43 @@ public class ProjectTestOperations
 		catch (WidgetNotFoundException widgetNotFoundException)
 		{
 			// logging will be added to show no projects were found
+		}
+	}
+
+	public static void launchCommandUsingContextMenu(String projectName, SWTWorkbenchBot bot, String contextMenuLabel)
+	{
+		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
+		if (projectItem != null)
+		{
+			projectItem.select();
+			projectItem.contextMenu(contextMenuLabel).click();
+		}
+	}
+
+	public static void waitForProjectClean(SWTWorkbenchBot bot) throws IOException
+	{
+		SWTBotView consoleView = viewConsole("Espressif IDF Tools Console", bot);
+		consoleView.show();
+		consoleView.setFocus();
+		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 0);
+	}
+
+	public static void joinJobByName(String jobName)
+	{
+		Job[] jobs = Job.getJobManager().find(null);
+		@SuppressWarnings("restriction")
+		Optional<Job> lookingJob = Stream.of(jobs).filter(job -> job.getName().equals(jobName)).findAny();
+
+		if (lookingJob.isPresent())
+		{
+			try
+			{
+				lookingJob.get().join();
+			}
+			catch (InterruptedException e)
+			{
+				Logger.log(e);
+			}
 		}
 	}
 }

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -21,8 +21,9 @@ import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarDropDownButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
 
@@ -37,6 +38,8 @@ public class ProjectTestOperations
 {
 
 	private static final String DEFAULT_PROJECT_BUILD_WAIT_PROPERTY = "default.project.build.wait";
+
+	private static final Logger logger = LoggerFactory.getLogger(ProjectTestOperations.class);
 
 	/**
 	 * Build a project using the context menu by right clicking on the project
@@ -136,7 +139,7 @@ public class ProjectTestOperations
 					}
 					catch (InterruptedException e)
 					{
-						Logger.log(e);
+						logger.error(e.getMessage(), e);
 					}
 				}
 			}
@@ -261,7 +264,7 @@ public class ProjectTestOperations
 		shell.activate();
 		bot.tree().expandNode(category).select(subCategory);
 		bot.button("Finish").click(); // Finish for the project wizard from eclipse
-		
+
 		bot.textWithLabel("Project name:").setText(projectName);
 		bot.checkBox("Create a project using one of the templates").click();
 		SWTBotTreeItem templateItem = SWTBotTreeOperations.getTreeItem(bot.tree(), templatePath);
@@ -518,7 +521,7 @@ public class ProjectTestOperations
 			}
 			catch (InterruptedException e)
 			{
-				Logger.log(e);
+				logger.error(e.getMessage(), e);
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Add test cases for next features: 
- Project Clean
- Project Full Clean
- Python Clean 

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-1035))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Run tests on Windows 10 machine. 

## Checklist
- [x] PR Self Reviewed
- [x] Verified on all platforms - Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added new test methods for project clean operations using context menu and checking for cleaned files in the build folder.
    - Added a new method for checking if the Python clean command deletes a specific folder.
    - Modified existing methods for project build and installing new components using context menu. The new methods cover project cleaning, full project cleaning, and Python cleaning using context menus.
    - Added a new bundle dependency `com.espressif.idf.ui` with version "1.0.1" in the `MANIFEST.MF` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->