### PR TITLE
IEP-1058 Incorrect toolchain list after updating esp-idf version

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
@@ -146,13 +146,10 @@ public class ESPToolChainManager
 
 	public File findDebugger(String target)
 	{
-		return toolchainElements
-		.values()
-		.stream()
-		.filter(espToolChainElement -> espToolChainElement.name.equals(target))
-		.map(espToolChainElement -> findToolChain(getAllPaths(), espToolChainElement.debuggerPattern))
-		.findFirst()
-		.orElse(null);
+		return toolchainElements.values().stream()
+				.filter(espToolChainElement -> espToolChainElement.name.equals(target))
+				.map(espToolChainElement -> findToolChain(getAllPaths(), espToolChainElement.debuggerPattern))
+				.findFirst().orElse(null);
 	}
 
 	public File findToolChain(List<String> paths, String filePattern)
@@ -174,10 +171,7 @@ public class ESPToolChainManager
 
 	private Path[] getDirectories(String path)
 	{
-		return Arrays.stream(path.split(File.pathSeparator))
-				.map(String::trim)
-				.map(Paths::get)
-				.toArray(Path[]::new);
+		return Arrays.stream(path.split(File.pathSeparator)).map(String::trim).map(Paths::get).toArray(Path[]::new);
 	}
 
 	private File findMatchingFile(Path dir, String filePattern)
@@ -204,7 +198,6 @@ public class ESPToolChainManager
 		return null;
 	}
 
-
 	public void removePrevInstalledToolchains(IToolChainManager manager)
 	{
 		try
@@ -224,15 +217,34 @@ public class ESPToolChainManager
 	{
 		try
 		{
-			if (!isToolChainExist(manager, toolChainElement))
+			if (isToolChainExist(manager, toolChainElement))
 			{
-				manager.addToolChain(new ESPToolchain(toolchainProvider, compilerFile.toPath(), toolChainElement));
+				removeMatchedToolChain(manager, toolChainElement);
 			}
+
+			manager.addToolChain(new ESPToolchain(toolchainProvider, compilerFile.toPath(), toolChainElement));
 		}
 		catch (CoreException e)
 		{
 			CCorePlugin.log(e.getStatus());
 		}
+	}
+
+	private void removeMatchedToolChain(IToolChainManager manager, ESPToolChainElement toolChainElement)
+	{
+		Map<String, String> props = new HashMap<>();
+		props.put(IToolChain.ATTR_OS, toolChainElement.name);
+		props.put(IToolChain.ATTR_ARCH, toolChainElement.arch);
+		props.put(TOOLCHAIN_ATTR_ID, toolChainElement.fileName);
+		try
+		{
+			manager.getToolChainsMatching(props).forEach(toolchain -> manager.removeToolChain(toolchain));
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
 	}
 
 	private boolean isToolChainExist(IToolChainManager manager, ESPToolChainElement toolChainElement)


### PR DESCRIPTION
## Description

To reproduce. Clean .espressif folder. Install 4.4.3 esp-idf and tools via IDE. After that install esp-idf master -> Toolchains are not updated properly

Fixes # ([IEP-1058](https://jira.espressif.com:8443/browse/IEP-1058))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Test 1:
- install two different esp-idf versions with different toolchains. For example esp-idf 4.4.3 and esp-idf master. 
- After switching versions, toolchains must be changed accordingly.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Install Tools
- Toolchains

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Refactor: Improved the efficiency of the ESPToolChainManager with a more streamlined code structure. This update enhances the software's performance by optimizing the methods used to find and manage toolchains.
- New Feature: Introduced a new function to remove a matched toolchain from the manager. This feature provides users with more control over their toolchain management, improving the overall usability of the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->