### PR TITLE
feat: Enable Tracing plugin with espressif-ide

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/GdbServerBackend.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/GdbServerBackend.java
@@ -139,8 +139,13 @@ public class GdbServerBackend extends GnuMcuGdbServerBackend {
 
 	@Override
 	public int getServerLaunchTimeoutSeconds() {
-		return Platform.getPreferencesService().getInt(IDFCorePlugin.PLUGIN_ID, Activator.GDB_SERVER_LAUNCH_TIMEOUT,
+		 int timeout = Platform.getPreferencesService().getInt(IDFCorePlugin.PLUGIN_ID, Activator.GDB_SERVER_LAUNCH_TIMEOUT,
 				fGdbServerLaunchDefaultTimeout, null);
+		 
+		 if (Activator.getInstance().isDebugging()) {
+				System.out.println("Gdb Server Timeout:" + timeout);
+			}
+		 return timeout;
 	}
 
 	public String getServerName() {

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.embedcdt.ui,
  org.eclipse.ltk.ui.refactoring,
  org.eclipse.ltk.core.refactoring,
- org.eclipse.epp.mpc.ui
+ org.eclipse.epp.mpc.ui,
+ org.eclipse.ui.trace;resolution:=optional
 Automatic-Module-Name: com.espressif.idf.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-1106](https://jira.espressif.com:8443/browse/IEP-1106))

## Type of change
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Launch espressif-ide
- Go to preferences > General > Tracing

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Preferences

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Refactor:
- Modified the `getServerLaunchTimeoutSeconds()` method in `bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/GdbServerBackend.java`. This change improves the efficiency and performance of the code by retrieving the timeout value from preferences and assigning it to a variable. It also includes a debug mode print statement for the timeout value. These changes do not impact end-users directly but contribute to the overall stability and maintainability of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->