### PR TITLE
fix: IEP Update site naming convention

### DIFF
--- a/features/com.espressif.idf.feature/feature.xml
+++ b/features/com.espressif.idf.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="com.espressif.idf.feature"
-      label="Espressif IDF Plugins for Eclipse"
+      label="ESP-IDF Plugins for Eclipse"
       version="2.11.1.qualifier"
       provider-name="ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD"
       plugin="com.espressif.idf.branding">
@@ -98,7 +98,7 @@ You may add additional accurate notices of copyright ownership.
    </license>
 
    <url>
-      <update label="Espressif IDF Plugins Update Site" url="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/"/>
+      <update label="ESP-IDF Eclipse Plugin Update Site" url="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/"/>
    </url>
 
    <requires>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -87,7 +87,11 @@
    <bundle id="org.apache.httpcomponents.httpclient">
       <category name="com.espressif.idf"/>
    </bundle>
-   <category-def name="com.espressif.idf" label="Espressif IDF"/>
+   <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
+      <description>
+         ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications
+      </description>
+   </category-def>
    <category-def name="Eclipse CDT-LSP Preview" label="Eclipse CDT-LSP Preview">
       <description>
          Additional features which can be used with the Espressif-IDE


### PR DESCRIPTION
## Description

Update site name has changed from "Espressif IDF" to "ESP-IDF Eclipse Plugin" and description has updated.

Fixes # ([IEP-1086](https://jira.espressif.com:8443/browse/IEP-1086))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Use the PR update site
- Verify that update site name has changed from "Espressif IDF" to "ESP-IDF Eclipse Plugin" and also description has updated.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Update site

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
