### PR TITLE
IEP-1108 Incorrect toolchain file after editing launch target

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,7 @@ import com.google.gson.Gson;
 public class IDFBuildConfiguration extends CBuildConfiguration
 {
 
+	private static final String LAUNCH_TARGET_NAME_ATTR = "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
 	private static final ActiveLaunchConfigurationProvider LAUNCH_CONFIG_PROVIDER = new ActiveLaunchConfigurationProvider();
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
@@ -629,7 +631,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 		if (launchtarget != null)
 		{
-			String idfTargetName = launchtarget.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
+			String idfTargetName = launchtarget.getAttribute(LAUNCH_TARGET_NAME_ATTR, //$NON-NLS-1$
 					StringUtil.EMPTY);
 			if (!idfTargetName.isEmpty())
 			{
@@ -841,7 +843,11 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		String typeId = getProperty(TOOLCHAIN_TYPE);
 		String id = getProperty(TOOLCHAIN_ID);
 		IToolChainManager toolChainManager = CCorePlugin.<IToolChainManager>getService(IToolChainManager.class);
-		return toolChainManager.getToolChain(typeId, id);
+		ILaunchBarManager launchBarManager = CCorePlugin.getService(ILaunchBarManager.class);
+		Collection<IToolChain> matchedToolChains = toolChainManager.getToolChainsMatching(
+				Map.of(IToolChain.ATTR_OS, launchBarManager.getActiveLaunchTarget().getAttribute(
+						LAUNCH_TARGET_NAME_ATTR, StringUtil.EMPTY), TOOLCHAIN_TYPE, typeId));
+		return matchedToolChains.stream().findAny().orElse(toolChainManager.getToolChain(typeId, id));
 	}
 
 	private static IPath getComponentsPath()

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -118,7 +118,6 @@ import com.google.gson.Gson;
 public class IDFBuildConfiguration extends CBuildConfiguration
 {
 
-	private static final String LAUNCH_TARGET_NAME_ATTR = "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
 	private static final ActiveLaunchConfigurationProvider LAUNCH_CONFIG_PROVIDER = new ActiveLaunchConfigurationProvider();
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
@@ -631,8 +630,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 		if (launchtarget != null)
 		{
-			String idfTargetName = launchtarget.getAttribute(LAUNCH_TARGET_NAME_ATTR, //$NON-NLS-1$
-					StringUtil.EMPTY);
+			String idfTargetName = launchtarget.getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, StringUtil.EMPTY);
 			if (!idfTargetName.isEmpty())
 			{
 				command.add("-DIDF_TARGET=" + idfTargetName); //$NON-NLS-1$
@@ -844,9 +842,9 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		String id = getProperty(TOOLCHAIN_ID);
 		IToolChainManager toolChainManager = CCorePlugin.<IToolChainManager>getService(IToolChainManager.class);
 		ILaunchBarManager launchBarManager = CCorePlugin.getService(ILaunchBarManager.class);
-		Collection<IToolChain> matchedToolChains = toolChainManager.getToolChainsMatching(
-				Map.of(IToolChain.ATTR_OS, launchBarManager.getActiveLaunchTarget().getAttribute(
-						LAUNCH_TARGET_NAME_ATTR, StringUtil.EMPTY), TOOLCHAIN_TYPE, typeId));
+		Collection<IToolChain> matchedToolChains = toolChainManager
+				.getToolChainsMatching(Map.of(IToolChain.ATTR_OS, launchBarManager.getActiveLaunchTarget()
+						.getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, StringUtil.EMPTY), TOOLCHAIN_TYPE, typeId));
 		return matchedToolChains.stream().findAny().orElse(toolChainManager.getToolChain(typeId, id));
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -44,10 +44,10 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 	@Override
 	public boolean performFinish() {
 		ILaunchTargetManager manager = Activator.getService(ILaunchTargetManager.class);
+
 		String typeId = IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE;
 		String id = page.getTargetName();
-		ILaunchTarget target = getLaunchTarget();
-		target = manager.addLaunchTarget(typeId, id);
+		ILaunchTarget target = manager.addLaunchTarget(typeId, id);
 		ILaunchTargetWorkingCopy wc = target.getWorkingCopy();
 		wc.setId(id);
 		wc.setAttribute(ILaunchTarget.ATTR_OS, page.getOS());
@@ -55,7 +55,6 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard {
 		wc.setAttribute(SerialFlashLaunchTargetProvider.ATTR_SERIAL_PORT, page.getSerialPortName());
 		wc.setAttribute(SerialFlashLaunchTargetProvider.ATTR_IDF_TARGET, page.getIDFTarget());
 		wc.save();
-
 		storeLastUsedSerialPort();
 		return true;
 	}


### PR DESCRIPTION
## Description

To reproduce: edit the launch target or create a custom launch target and switch idf target there -> Click build.
To fix that, we have to get the toolchain based on the properties of the active launch target, not the launch configuration

Fixes # ([IEP-1108](https://jira.espressif.com:8443/browse/IEP-1108))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
- create a project and build it with esp32 target
- edit es32 launch target via launch bar edit button and select different idf target there -> delete build confirmation click Yes
- build project -> expected same cmake file and target

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced code maintainability by replacing hard-coded strings with constants in the build configuration.
	- Improved the method for retrieving the active launch target and finding matching tool chains.
- **Chores**
	- Removed unnecessary lines of code in the new serial flash target wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->