### PR TITLE
IEP-1109 Target provided based on target's id and not IDF target property

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -100,6 +100,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 	// ------------------------------------------------------------------------
 
+	private static final String LAUNCH_TARGET_NAME_ATTR = "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
 	private static final int JOB_DELAY_MS = 100;
 	private static final String TAB_NAME = "Debugger"; //$NON-NLS-1$
 	private static final String TAB_ID = Activator.PLUGIN_ID + ".ui.debuggertab"; //$NON-NLS-1$
@@ -274,7 +275,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 					{
 						ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
 						ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
-								.filter(target -> target.getId().contentEquals((targetName))).findFirst()
+								.filter(target -> target.getAttribute(LAUNCH_TARGET_NAME_ATTR,
+										StringUtil.EMPTY).equals(targetName))
+								.findFirst()
 								.orElseGet(() -> null);
 						launchBarManager.setActiveLaunchTarget(selectedTarget);
 					}
@@ -547,7 +550,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 						for (ILaunchTarget target : targets)
 						{
-							String idfTarget = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
+							String idfTarget = target.getAttribute(LAUNCH_TARGET_NAME_ATTR,
 									null);
 							String targetSerialPort = target
 									.getAttribute(SerialFlashLaunchTargetProvider.ATTR_SERIAL_PORT, ""); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -85,6 +85,7 @@ import com.espressif.idf.ui.LaunchBarListener;
 
 @SuppressWarnings("restriction")
 public class CMakeMainTab2 extends GenericMainTab {
+	private static final String LAUNCH_TARGET_NAME_ATTR = "com.espressif.idf.launch.serial.core.idfTarget"; //$NON-NLS-1$
 	private static final int JOB_DELAY_MS = 100;
 	private static final String EMPTY_CONFIG_OPTIONS = "%s" + File.separator + "%s -s %s"; //$NON-NLS-1$ //$NON-NLS-2$
 	private Combo flashOverComboButton;
@@ -742,7 +743,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 					ILaunchTarget suitableTarget = null;
 
 					for (ILaunchTarget target : targets) {
-						String idfTarget = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", null); //$NON-NLS-1$
+						String idfTarget = target.getAttribute(LAUNCH_TARGET_NAME_ATTR, null);
 						String targetSerialPort = target.getAttribute(SerialFlashLaunchTargetProvider.ATTR_SERIAL_PORT,
 								StringUtil.EMPTY);
 						if (idfTarget.contentEquals(selectedItem)) {
@@ -869,9 +870,10 @@ public class CMakeMainTab2 extends GenericMainTab {
 							.getAttribute(IDFLaunchConstants.TARGET_FOR_JTAG, StringUtil.EMPTY);
 					if (!targetName.isEmpty()) {
 						ILaunchTargetManager launchTargetManager = Activator.getService(ILaunchTargetManager.class);
-						ILaunchTarget selectedTarget = Stream.of(launchTargetManager.getLaunchTargets())
-								.filter(target -> target.getId().contentEquals((targetName))).findFirst()
-								.orElseGet(() -> null);
+						ILaunchTarget selectedTarget = Stream
+								.of(launchTargetManager.getLaunchTargets()).filter(target -> target
+										.getAttribute(LAUNCH_TARGET_NAME_ATTR, StringUtil.EMPTY).equals(targetName))
+								.findFirst().orElseGet(() -> null);
 						launchBarManager.setActiveLaunchTarget(selectedTarget);
 					}
 


### PR DESCRIPTION
## Description

To reproduce this issue: edit the launch target. For example for the esp32 target select the esp32s2 target and edit the esp32s2 target for esp32. After that edit the launch or debug configuration and change the target to esp32s2 or esp32 -> after finishing the dialog you will receive notification about incorrect target for jtag flashing

Fixes # ([IEP-1109](https://jira.espressif.com:8443/browse/IEP-1109))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?


Test 1:
- verified steps that mentioned in description

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- launch configuration target
- debug configuration target

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code readability and maintainability by introducing a new constant for attribute names and replacing hardcoded attribute names with this constant in various places.
- **Chores**
	- Updated the `run` method to filter launch targets based on attribute value, enhancing the code's efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->