### PR TITLE
IEP-1110 NPE when trying to create new launch configuration

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -783,11 +783,15 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 	private String getLaunchTarget()
 	{
 		launchBarManager = Activator.getService(ILaunchBarManager.class);
-		String selectedTarget = ""; //$NON-NLS-1$
+		String selectedTarget = StringUtil.EMPTY;
 		try
 		{
-			selectedTarget = launchBarManager.getActiveLaunchTarget().getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET,
-					""); //$NON-NLS-1$
+			if (launchBarManager.getActiveLaunchConfiguration() != null)
+			{
+				selectedTarget = launchBarManager.getActiveLaunchTarget()
+						.getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, StringUtil.EMPTY);
+			}
+
 		}
 		catch (CoreException e)
 		{

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -78,7 +78,7 @@ public class TabMain extends CMainTab2
 			IProject project = cElement.getCProject().getProject();
 			String name = project.getName();
 			ICProjectDescription projDes = CCorePlugin.getDefault().getProjectDescription(project);
-			if (projDes != null)
+			if (projDes != null && projDes.getActiveConfiguration() != null)
 			{
 				String buildConfigName = projDes.getActiveConfiguration().getName();
 				name = name + " " + buildConfigName; //$NON-NLS-1$

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -308,7 +308,9 @@ public class CMakeMainTab2 extends GenericMainTab {
 
 		Optional<String> suitableTarget = Stream.of(targetsWithDfuSupport).filter(t -> {
 			try {
-				return t.contentEquals(launchBarManager.getActiveLaunchTarget().getId());
+				if (launchBarManager.getActiveLaunchConfiguration() != null) {
+					return t.contentEquals(launchBarManager.getActiveLaunchTarget().getId());
+				}
 			} catch (CoreException e) {
 				Logger.log(e);
 			}
@@ -803,8 +805,10 @@ public class CMakeMainTab2 extends GenericMainTab {
 	private String getLaunchTarget() {
 		String selectedTarget = StringUtil.EMPTY;
 		try {
-			selectedTarget = launchBarManager.getActiveLaunchTarget().getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET,
-					StringUtil.EMPTY);
+			if (launchBarManager.getActiveLaunchConfiguration() != null) {
+				selectedTarget = launchBarManager.getActiveLaunchTarget()
+						.getAttribute(IDFLaunchConstants.ATTR_IDF_TARGET, StringUtil.EMPTY);
+			}
 		} catch (CoreException e) {
 			Logger.log(e);
 		}

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -492,7 +492,7 @@ public class CMakeMainTab2 extends GenericMainTab {
 			config.setMappedResources(new IResource[] { project });
 
 			ICProjectDescription projDes = CCorePlugin.getDefault().getProjectDescription(project);
-			if (projDes != null) {
+			if (projDes != null && projDes.getActiveConfiguration() != null) {
 				String buildConfigID = projDes.getActiveConfiguration().getId();
 				config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_BUILD_CONFIG_ID, buildConfigID);
 			}


### PR DESCRIPTION
## Description

To reproduce: create project -> build project -> Close project -> try to create new Launch Config -> get error -> close window -> restart -> try to create new Launch Config -> get error -> restart ->  try to create new Launch Config -> get error -> Open Project -> try to create new Launch Config -> get error: 

Fixes # ([IEP-1110](https://jira.espressif.com:8443/browse/IEP-1110))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?


Test 1:
- verified steps mentioned in the description


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch configuration
- Debug configuration

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved robustness of the application by adding conditional checks to prevent potential null pointer exceptions when accessing active launch configurations and targets.
	- Enhanced stability by ensuring active project configuration is not null before appending its name to the project name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->