### PR TITLE
IEP-1111 Possible clang toolchain when gcc expected

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -246,7 +246,7 @@ config-only component and an interface library is created instead."
   <extension point="com.espressif.idf.core.toolchain">
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32-elf-gcc(\.exe)?"
+           compilerPattern="xtensa-esp32-elf[\\/]+bin[\\/]+xtensa-esp32-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32-elf-gdb(\.exe)?"
            fileName="toolchain-esp32.cmake"
            id="xtensa-esp32-elf"
@@ -254,7 +254,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32s2-elf-gcc(\.exe)?"
+           compilerPattern="xtensa-esp32s2-elf[\\/]+bin[\\/]+xtensa-esp32s2-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32s2-elf-gdb(\.exe)?"
            fileName="toolchain-esp32s2.cmake"
            id="xtensa-esp32s2-elf"
@@ -262,7 +262,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32s3-elf-gcc(\.exe)?"
+           compilerPattern="xtensa-esp32s3-elf[\\/]+bin[\\/]+xtensa-esp32s3-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32s3-elf-gdb(\.exe)?"
            fileName="toolchain-esp32s3.cmake"
            id="xtensa-esp32s3-elf"
@@ -270,7 +270,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="riscv32"
-           compilerPattern="riscv32-esp-elf-gcc(\.exe)?"
+           compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
            debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
            fileName="toolchain-esp32c2.cmake"
            id="riscv32-esp-elf"
@@ -278,7 +278,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="riscv32"
-           compilerPattern="riscv32-esp-elf-gcc(\.exe)?"
+           compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
            debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
            fileName="toolchain-esp32c3.cmake"
            id="riscv32-esp-elf"
@@ -286,7 +286,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="riscv32"
-           compilerPattern="riscv32-esp-elf-gcc(\.exe)?"
+           compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
            debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
            fileName="toolchain-esp32c6.cmake"
            id="riscv32-esp-elf"
@@ -294,7 +294,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
           <ToolChain
            arch="riscv32"
-           compilerPattern="riscv32-esp-elf-gcc(\.exe)?"
+           compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
            debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
            fileName="toolchain-esp32h2.cmake"
            id="riscv32-esp-elf"

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
@@ -183,8 +183,8 @@ public class ESPToolChainManager
 			{
 				if (Files.isRegularFile(file))
 				{
-					Matcher matcher = pattern.matcher(file.getFileName().toString());
-					if (matcher.matches())
+					Matcher matcher = pattern.matcher(file.toAbsolutePath().toString());
+					if (matcher.find())
 					{
 						return file.toFile();
 					}


### PR DESCRIPTION
## Description

We searched for toolchains based on the regex that matched the name of the executable, but the same executable exists in the clang folder, so it's possible to get the clang toolchain when gcc is expected.

Fixes # ([IEP-1111](https://jira.espressif.com:8443/browse/IEP-1111))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1: 
- install tools on fresh environment or restart the eclipse 
- build projects with different target -> building with expected toolchains

Test 2:
- check Preference -> Cmake table if toolchain files have according toolchains

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the file matching process in the toolchain management to enhance the accuracy of toolchain file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->