### PR TITLE
IEP-1076: Removed the unwanted doc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,6 @@ ESP-IDF Serial Monitor will allow you to configure the default settings of the s
 <a name="debugging"></a>
 # Debugging the Project
 
-## GDB Hardware Debugging
-
-Please refer to <a href ="https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/jtag-debugging/index.html" > GDB Hardware Debugging guide</a>.
-
 ## GDB OpenOCD Debugging
 
 Please refer to <a href="https://github.com/espressif/idf-eclipse-plugin/tree/master/docs/OpenOCD%20Debugging.md">GDB OpenOCD Debugging</a>.

--- a/docs/OpenOCD Debugging.md
+++ b/docs/OpenOCD Debugging.md
@@ -1,6 +1,6 @@
-## ESP-IDF GDB OpenOCD Debugging
+# ESP-IDF GDB OpenOCD Debugging
 
-# Create a new debug configuration
+## Create a new debug configuration
 Please follow the below steps to create a new debug configuration.
 * Right-click on the project
 * `Debug As > Debug Configurations...` This will launch a debug configuration window

--- a/docs/OpenOCD Debugging.md
+++ b/docs/OpenOCD Debugging.md
@@ -1,11 +1,5 @@
 ## ESP-IDF GDB OpenOCD Debugging
 
-Before you get started with the GDB OpenOCD Debugging, please make sure you've already installed `Embedded C/C++ OpenOCD Debugging` plugin while updating the IDF Eclipse Plugin and your [JTAG interface is configured and connected](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html#configure-and-connect-jtag-interface).
-
-To get the latest changes of the idf eclipse plugin, please check this [here](https://github.com/espressif/idf-eclipse-plugin#GettingStarted)
-
-![](images/OpenOCDDebug_1.png)
-
 # Create a new debug configuration
 Please follow the below steps to create a new debug configuration.
 * Right-click on the project


### PR DESCRIPTION
## Description

Fixes # ([IEP-1076](https://jira.espressif.com:8443/browse/IEP-1076))

## Type of change

Please delete options that are not relevant.
- This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the ESP-IDF Serial Monitor documentation to focus on GDB OpenOCD Debugging.
	- Streamlined the OpenOCD Debugging guide by removing the installation steps for plugins and outdated image references, allowing users to quickly proceed to creating a new debug configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->