### PR TITLE
IEP-1074: Python dropdown removed

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
@@ -4,6 +4,8 @@
  *******************************************************************************/
 package com.espressif.idf.ui.update;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.Map;
 
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
@@ -296,8 +298,10 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 		try
 		{
 			Process process = new ProcessBuilder(path, "--version").start();
+			BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+	        String output = reader.readLine();
 			int exitCode = process.waitFor();
-			return exitCode == 0;
+			return exitCode == 0 && output.startsWith("Python");
 		}
 		catch (Exception e)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/DirectorySelectionDialog.java
@@ -199,8 +199,15 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 		pythonExecutablePath = pythonLocationtext.getText();
 
 		gitPath = gitLocationtext.getText();
-
-		if (StringUtil.isEmpty(pythonExecutablePath) || StringUtil.isEmpty(gitPath) || StringUtil.isEmpty(idfDirPath))
+		
+		boolean isValidPythonPath = validatePythonExecutable(pythonExecutablePath);
+		
+		if (!isValidPythonPath)
+		{
+			setErrorMessage(Messages.DirectorySelectionDialog_InvalidPythonPath);
+			getButton(IDialogConstants.OK_ID).setEnabled(false);
+		}
+		else if (StringUtil.isEmpty(pythonExecutablePath) || StringUtil.isEmpty(gitPath) || StringUtil.isEmpty(idfDirPath))
 		{
 			setErrorMessage(Messages.DirectorySelectionDialog_CantbeEmpty);
 			getButton(IDialogConstants.OK_ID).setEnabled(false);
@@ -282,5 +289,19 @@ public class DirectorySelectionDialog extends TitleAreaDialog
 	private Preferences getPreferences()
 	{
 		return ConfigurationScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID).node("preference"); //$NON-NLS-1$
+	}
+	
+	private boolean validatePythonExecutable(String path)
+	{
+		try
+		{
+			Process process = new ProcessBuilder(path, "--version").start();
+			int exitCode = process.waitFor();
+			return exitCode == 0;
+		}
+		catch (Exception e)
+		{
+			return false;
+		}
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
@@ -24,6 +24,7 @@ public class Messages extends NLS
 	public static String DirectorySelectionDialog_PyExecutableLocation;
 	public static String DirectorySelectionDialog_PyExeLocation;
 	public static String DirectorySelectionDialog_SelectIDFDirMessage;
+	public static String DirectorySelectionDialog_InvalidPythonPath;
 	public static String IDFToolsHandler_ToolsManagerConsole;
 	public static String InstallToolsHandler_AutoConfigureToolchain;
 	public static String InstallToolsHandler_ConfiguredBuildEnvVarMsg;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
@@ -6,6 +6,7 @@ AbstractToolsHandler_ExecutingMsg=Executing
 AbstractToolsHandler_RunningCommandFormatString=Running command: %s
 DirectorySelectionDialog_Browse=Browse...
 DirectorySelectionDialog_CantbeEmpty=Fields can't be empty\!
+DirectorySelectionDialog_InvalidPythonPath=Invalid Python Path
 DirectorySelectionDialog_CheckTools=Check Tools
 DirectorySelectionDialog_ChoosePyVersion=Choose Python version:
 DirectorySelectionDialog_GitExecutableLocation=Git Executable Location


### PR DESCRIPTION
## Description
Python dropdown was causing some confusions to the users so it is now removed on Windows and a simple text box that points to the executable path of the python is kept

Fixes # ([IEP-1074](https://jira.espressif.com:8443/browse/IEP-1074))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Tested on windows with install tools.

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): Test on windows and also verify on Linux and Mac for normal workiing

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new field for specifying the Python executable location in the Directory Selection Dialog.
  - Implemented validation for the Python executable path.

- **Refactor**
  - Removed outdated Python version selection functionality.

- **Documentation**
  - Added user-facing messages for invalid Python path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->