### PR TITLE
IEP-1037: Fix for the confserver handling of the hex values

### DIFF
--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/SDKConfigurationEditor.java
@@ -635,8 +635,10 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 				textControl.setToolTipText(helpInfo);
 				if (configValue != null)
 				{
-					textControl.setText(newConfigValue != null ? Long.toString((long) newConfigValue)
-							: Long.toString((long) configValue));
+					String hexText = newConfigValue != null ? Long.toHexString((long) newConfigValue)
+							: Long.toHexString((long) configValue);
+					textControl.setText("0x" + hexText.toUpperCase());
+
 				}
 				textControl.addModifyListener(addModifyListener(configKey, textControl));
 				addTooltipImage(kConfigMenuItem);
@@ -851,9 +853,11 @@ public class SDKConfigurationEditor extends MultiPageEditorPart
 			@Override
 			public void modifyText(ModifyEvent e)
 			{
+				String text = textControl.getText().toLowerCase();
+				boolean isHex = text.startsWith("0x");
 				isDirty = true;
 				editorDirtyStateChanged();
-				modifiedJsonMap.put(configKey, textControl.getText().trim());
+				modifiedJsonMap.put(configKey, isHex ? Long.parseLong(text.substring(2), 16) : textControl.getText().trim());
 			}
 		};
 	}


### PR DESCRIPTION
## Description

Fixed the conf server so hex values are shown properly and are handled gracefully as hex values
Original reported issue that can be used for testing is ([here](https://github.com/espressif/idf-eclipse-plugin/issues/831))

Fixes # ([IEP-1037](https://jira.espressif.com:8443/browse/IEP-1037))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- 
## How has this been tested?

Open the sdkconfig and try to see the hex value properties like Partition Table -> Offset of partition table. It should be shown in Hex format and any change must be saved and reflected once you close and open the sdkconfig editor.
Please see that other hex properties are also safely saved as well. You can verify the changed value in menuconfig via terminal to see that correct hex is stored

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): any

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
