### PR TITLE
ci: Restrict IEP plugin build with 2023-09

### DIFF
--- a/bundles/com.espressif.idf.core/pom.xml
+++ b/bundles/com.espressif.idf.core/pom.xml
@@ -10,24 +10,4 @@
 		<artifactId>com.espressif.idf.bundles</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.13.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-			<version>4.1</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -3,7 +3,7 @@
 <target name="com.espressif.idf.target" sequenceNumber="25">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/latest"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.28"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
@@ -19,7 +19,7 @@
 
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/latest"/>
+			<repository location="https://download.eclipse.org/releases/2023-09"/>
 			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
## Description

As eclipse [2023-12](https://download.eclipse.org/eclipse/updates/4.29/) R-builds is available , IEP plugin builds are failing due to dependency issues and API issues. In this PR, will try to strict our CI builds to Eclipse 2023-09 builds until we have the IEP support for the Eclipse 2023-12.

Fixes # ([IEP-1125](https://jira.espressif.com:8443/browse/IEP-1125))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Verify the master build is successful or not, see if they have created with the Eclipse CDT 2023-09 buid.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site Installation
- Espressif-IDE Installation and update

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
