### PR TITLE
feat: Add support for Eclipse 4.30(Eclipse 2023-12)

### DIFF
--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.eclipse.core.runtime,
  com.espressif.idf.core;visibility:=reexport,
  org.eclipse.cdt.cmake.core,
  org.eclipse.cdt.cmake.ui,
- org.eclipse.tools.templates.ui,
  org.eclipse.swt;visibility:=reexport,
  org.eclipse.ui;visibility:=reexport,
  org.eclipse.jface,
@@ -37,11 +36,14 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.cdt.native.serial,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.ui.intro,
- org.eclipse.tools.templates.freemarker,
  org.eclipse.embedcdt.ui,
  org.eclipse.ltk.ui.refactoring,
  org.eclipse.ltk.core.refactoring,
- org.eclipse.epp.mpc.ui
+ org.eclipse.epp.mpc.ui,
+ org.eclipse.tools.templates.core,
+ org.eclipse.tools.templates.ui,
+ org.freemarker.freemarker,
+ org.eclipse.tools.templates.freemarker
 Automatic-Module-Name: com.espressif.idf.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/releng/com.espressif.idf.configuration/pom.xml
+++ b/releng/com.espressif.idf.configuration/pom.xml
@@ -114,4 +114,12 @@
 			</plugin>
 		</plugins>
 	</build>
+	<dependencies>
+		<dependency>
+			<!-- bundle: org.freemarker.freemarker -->
+			<groupId>org.freemarker</groupId>
+			<artifactId>freemarker</artifactId>
+			<version>2.3.32</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -3,7 +3,7 @@
 <target name="com.espressif.idf.target" sequenceNumber="25">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.28"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.30"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
@@ -19,7 +19,7 @@
 
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2023-09"/>
+			<repository location="https://download.eclipse.org/releases/2023-12"/>
 			<unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -87,6 +87,9 @@
    <bundle id="org.apache.httpcomponents.httpclient">
       <category name="com.espressif.idf"/>
    </bundle>
+   <bundle id="org.freemarker.freemarker">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>
          ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications


### PR DESCRIPTION
## Description

Add support for Eclipse 4.30(Eclipse 2023-12)

Fixes # ([IEP-1132](https://jira.espressif.com:8443/browse/IEP-1132))

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?
- Creating a new project: https://jira.espressif.com:8443/browse/IEP-1129


**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

As this is a new Eclipse, we need to verify all the functionality

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated dependencies related to template management and freemarker integration.

- **Chores**
  - Upgraded repository URLs in the project configuration to align with the latest Eclipse updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->