### PR TITLE
fix: add freemarker new plugin to idf.target

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -103,8 +103,8 @@
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -121,6 +121,16 @@
 			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="6.4.0.202307251916"/>
 			<unit id="org.eclipse.embedcdt.feature.group" version="6.4.0.202307251916"/>
 			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.4.0.202307251916"/>
+		</location>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.freemarker</groupId>
+					<artifactId>freemarker</artifactId>
+					<version>2.3.32</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
## Description

idf.target is not resolving org.freemarker.freemarker plugin.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
Espressif-IDE v2.11.1+ PR Update site > Install Tools > Create a new project
Test 2:
Eclipse CDT 2023-09 + PR Update site > Install Tools > Create a new project

**Test Configuration**:
* ESP-IDF Version:master
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- Update site


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved XML configuration formatting for better readability and consistency.
- **New Features**
  - Integrated new Maven dependency for ASM within the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->