### PR TITLE
IEP-1130 Renaming project changes target

### DIFF
--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -765,5 +765,18 @@
             file-extensions="md"
             file-names="README.md">
       </file-association>
+    </extension>
+    <extension
+         point="org.eclipse.ltk.core.refactoring.renameParticipants">
+      <renameParticipant
+            class="com.espressif.idf.ui.handlers.RenameIdfProjectParticipant"
+            id="com.espressif.idf.ui.renameIdfProjectParticipant"
+            name="renameIdfProject">
+         <enablement>
+            <instanceof
+                  value="org.eclipse.core.resources.IProject">
+            </instanceof>
+         </enablement>
+      </renameParticipant>
    </extension>
 </plugin>

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -36,10 +36,16 @@ import com.espressif.idf.core.util.StringUtil;
 public class LaunchBarListener implements ILaunchBarListener
 {
 	private static boolean jtagIgnored = false;
+	private static boolean targetChangeIgnored = false;
 
 	public static void setIgnoreJtagTargetChange(boolean status)
 	{
 		jtagIgnored = status;
+	}
+
+	public static void setIgnoreTargetChange(boolean status)
+	{
+		targetChangeIgnored = status;
 	}
 
 	@Override
@@ -51,7 +57,7 @@ public class LaunchBarListener implements ILaunchBarListener
 				{
 				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
 						StringUtil.EMPTY);
-					if (!StringUtil.isEmpty(targetName))
+				if (!StringUtil.isEmpty(targetName) && (!targetChangeIgnored))
 					{
 						update(targetName);
 					}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
@@ -47,7 +47,7 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 					LaunchBarListener.setIgnoreTargetChange(false);
 					launchBarManager.setActiveLaunchTarget(activeLaunchTarget);
 				}
-				catch (Exception e)
+				catch (CoreException e)
 				{
 					Logger.log(e);
 				}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
@@ -1,0 +1,58 @@
+package com.espressif.idf.ui.handlers;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.RenameParticipant;
+import org.eclipse.swt.widgets.Display;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.ui.LaunchBarListener;
+
+public class RenameIdfProjectParticipant extends RenameParticipant
+{
+
+	protected boolean initialize(Object element)
+	{
+		return true;
+	}
+
+	public String getName()
+	{
+		return null;
+	}
+
+	public RefactoringStatus checkConditions(IProgressMonitor pm, CheckConditionsContext context)
+			throws OperationCanceledException
+	{
+		return null;
+	}
+
+	public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException
+	{
+		// workaround to save active launch target when renaming the project
+		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+		ILaunchTarget activeLaunchTarget = launchBarManager.getActiveLaunchTarget();
+		LaunchBarListener.setIgnoreTargetChange(true);
+		Display.getDefault().syncExec(() ->
+			Display.getDefault().getActiveShell().addDisposeListener(disposeEvent -> {
+				try
+				{
+					LaunchBarListener.setIgnoreTargetChange(false);
+					launchBarManager.setActiveLaunchTarget(activeLaunchTarget);
+				}
+				catch (Exception e)
+				{
+					Logger.log(e);
+				}
+		}));
+		return null;
+	}
+
+}

--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface,
  slf4j.api
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.launchbar.ui,
+Import-Package: com.espressif.idf.core.util,
+ org.eclipse.launchbar.ui,
  org.eclipse.launchbar.ui.controls.internal,
  org.eclipse.launchbar.ui.internal

--- a/tests/com.espressif.idf.ui.test/configs/default-test-win.properties
+++ b/tests/com.espressif.idf.ui.test/configs/default-test-win.properties
@@ -10,7 +10,7 @@ default.project.copy.wait=7000
 default.env.esp.idf.path={0}/dependencies/idf-tools
 default.env.esp.git.path=git
 default.env.esp.python.version=3.9
-default.env.esp.python.path=python3.9
+default.env.esp.python.path=python3.9.exe
 default.env.esp.idf.download.path={0}
 
 

--- a/tests/com.espressif.idf.ui.test/configs/default-test-win.properties
+++ b/tests/com.espressif.idf.ui.test/configs/default-test-win.properties
@@ -10,7 +10,7 @@ default.project.copy.wait=7000
 default.env.esp.idf.path={0}/dependencies/idf-tools
 default.env.esp.git.path=git
 default.env.esp.python.version=3.9
-default.env.esp.python.path=python3.9.exe
+default.env.esp.python.path=python3.9
 default.env.esp.idf.download.path={0}
 
 

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
@@ -6,6 +6,7 @@ import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
 
@@ -15,14 +16,14 @@ public class EnvSetupOperations
 	private static final String GIT_PATH_PROPERTY = "default.env.esp.git.path";
 	private static final String PYTHON_PATH_PROPERTY = "default.env.esp.python.path";
 	private static final String PYTHON_VERSION_PROPERTY = "default.env.esp.python.version";
-	
+
 	private static boolean SETUP = false;
 
 	public static void setupEspressifEnv(SWTWorkbenchBot bot) throws Exception
 	{
 		if (SETUP)
 			return;
-		
+
 		for (SWTBotView view : bot.views(withPartName("Welcome")))
 		{
 			view.close();
@@ -60,18 +61,19 @@ public class EnvSetupOperations
 		bot.menu("Espressif").menu("ESP-IDF Tools Manager").click().menu("Install Tools").click();
 		bot.activeShell().activate();
 		bot.shell("Install Tools").bot().textWithLabel("ESP-IDF Directory:")
-		.setText(DefaultPropertyFetcher.getStringPropertyValue(ESP_IDF_PATH_PROPERTY, ""));
-		
+				.setText(DefaultPropertyFetcher.getStringPropertyValue(ESP_IDF_PATH_PROPERTY, ""));
+
 		bot.shell("Install Tools").bot().textWithLabel("Git Executable Location:")
 				.setText(DefaultPropertyFetcher.getStringPropertyValue(GIT_PATH_PROPERTY, ""));
 		try
 		{
-			bot.shell("Install Tools").bot().comboBox().setSelection(DefaultPropertyFetcher.getStringPropertyValue(PYTHON_VERSION_PROPERTY, ""));
+			bot.shell("Install Tools").bot().comboBox()
+					.setSelection(DefaultPropertyFetcher.getStringPropertyValue(PYTHON_VERSION_PROPERTY, ""));
 		}
 		catch (WidgetNotFoundException e)
 		{
 			bot.shell("Install Tools").bot().textWithLabel("Python Executable Location:")
-					.setText(DefaultPropertyFetcher.getStringPropertyValue(PYTHON_PATH_PROPERTY, ""));
+					.setText(IDFUtil.getPythonExecutable());
 		}
 		bot.shell("Install Tools").bot().button("Install Tools").click();
 		SWTBotView consoleView = bot.viewById("org.eclipse.ui.console.ConsoleView");


### PR DESCRIPTION
## Description

Added a workaround to not lose the active launch target while renaming the project.

Fixes # ([IEP-1130](https://jira.espressif.com:8443/browse/IEP-1130))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test 1:
- Build project with some target -> rename the project -> target should remain the same
Test 2: 
- rename not built project with some active target -> target should not be changed 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Rename project

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Implemented a feature to maintain the active launch target when renaming a project.

- **Bug Fixes**
  - Added a mechanism to ignore target changes during specific operations to prevent unintended behavior.

- **Refactor**
  - Introduced a new class to handle project renaming operations more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->