### PR TITLE
IEP-1135 Incorrect default gdb executable for RISCV targets

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -247,7 +247,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="xtensa"
            compilerPattern="xtensa-esp32-elf[\\/]+bin[\\/]+xtensa-esp32-elf-gcc(?:\.exe)?$"
-           debuggerPattern="xtensa-esp32-elf-gdb(\.exe)?"
+           debuggerPattern="xtensa-esp32-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32.cmake"
            id="xtensa-esp32-elf"
            name="esp32">
@@ -255,7 +255,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="xtensa"
            compilerPattern="xtensa-esp32s2-elf[\\/]+bin[\\/]+xtensa-esp32s2-elf-gcc(?:\.exe)?$"
-           debuggerPattern="xtensa-esp32s2-elf-gdb(\.exe)?"
+           debuggerPattern="xtensa-esp32s2-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32s2.cmake"
            id="xtensa-esp32s2-elf"
            name="esp32s2">
@@ -263,7 +263,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="xtensa"
            compilerPattern="xtensa-esp32s3-elf[\\/]+bin[\\/]+xtensa-esp32s3-elf-gcc(?:\.exe)?$"
-           debuggerPattern="xtensa-esp32s3-elf-gdb(\.exe)?"
+           debuggerPattern="xtensa-esp32s3-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32s3.cmake"
            id="xtensa-esp32s3-elf"
            name="esp32s3">
@@ -271,7 +271,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="riscv32"
            compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
-           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
+           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32c2.cmake"
            id="riscv32-esp-elf"
            name="esp32c2">
@@ -279,7 +279,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="riscv32"
            compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
-           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
+           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32c3.cmake"
            id="riscv32-esp-elf"
            name="esp32c3">
@@ -287,7 +287,7 @@ config-only component and an interface library is created instead."
      <ToolChain
            arch="riscv32"
            compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
-           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
+           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32c6.cmake"
            id="riscv32-esp-elf"
            name="esp32c6">
@@ -295,7 +295,7 @@ config-only component and an interface library is created instead."
           <ToolChain
            arch="riscv32"
            compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
-           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?"
+           debuggerPattern="riscv32-esp-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32h2.cmake"
            id="riscv32-esp-elf"
            name="esp32h2">


### PR DESCRIPTION
## Description

Fixed debugger patterns to get correct gdb executables. The problem was, that without "$" at the end we could get the wrong executable, for example, bin\xtensa-esp32-elf-gdb-3.7.exe, etc.
 
Fixes # ([IEP-1135](https://jira.espressif.com:8443/browse/IEP-1135))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Test 1:
try to debug with different targets
Test 2:
check the actual executable path in the debugger tab for different targets 
**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- Debugger tab

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
