### PR TITLE
IEP-1147 Indexer fails when changing active launch configuration

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -145,6 +145,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private IBuildConfiguration buildConfiguration;
 	private IProgressMonitor monitor;
 	public boolean isProgressSet;
+	private QualifiedName TIMESTAMP_COMPILE_COMMANDS_PROPERTY = new QualifiedName(null,
+			"timestamp:compile_commands.json"); //$NON-NLS-1$
 
 	public IDFBuildConfiguration(IBuildConfiguration config, String name) throws CoreException
 	{
@@ -900,7 +902,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	protected int getUpdateOptions()
 	{
 		return IIndexManager.UPDATE_CHECK_TIMESTAMPS | IIndexManager.UPDATE_UNRESOLVED_INCLUDES
-				| IIndexManager.UPDATE_EXTERNAL_FILES_FOR_PROJECT;
+				| IIndexManager.UPDATE_EXTERNAL_FILES_FOR_PROJECT | IIndexManager.FORCE_INDEX_INCLUSION;
 	}
 
 	@Override
@@ -1073,6 +1075,13 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			// no build was run yet, nothing detected
 			try
 			{
+
+				// It is crucial to set this property to 0. Otherwise, the infoPerResource will persist as null for this
+				// configuration. This occurs when the property has been modified in another configuration within the
+				// same project.
+				getCompileCommandsJsonFile(new NullProgressMonitor()).getParent()
+						.setSessionProperty(TIMESTAMP_COMPILE_COMMANDS_PROPERTY, Long.valueOf(0));
+
 				processCompileCommandsFile(null, new NullProgressMonitor());
 			}
 			catch (CoreException e)


### PR DESCRIPTION
## Description
two problems were fixed in this PR:

1. When we have a few configurations for the same project (Debug and Run), changing the active launch configuration could cause the indexer to fail for this project and in this case, the build button was not fixing this issue.
2. Sometimes after IDE restart the project can have some random indexer issues that do not usually happen. The build button does not fix the issue until the full project is clean. To fix it, I had to add IIndexManager.FORCE_INDEX_INCLUSION to update options

Fixes # ([IEP-1147](https://jira.espressif.com:8443/browse/IEP-1147))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Test 1:
- Create Launch/Debug configurations for a project. Switching between them causes the indexer to run on Windows. After indexer completion, there should be no unexpected issues.
Test 2:
- Create a few projects, build them, and restart Eclipse. After this, clicking on the build button should fix unexpected indexer issues.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build
- Indexer

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved build configuration handling by introducing a timestamp mechanism for compile commands.

- **Refactor**
	- Enhanced indexing options to ensure more comprehensive code analysis.

- **Bug Fixes**
	- Adjusted scanner information retrieval to correctly manage session properties related to compile commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->