### PR TITLE
IEP-1136: release/v5.2 installation failed fix

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -246,7 +246,7 @@ config-only component and an interface library is created instead."
   <extension point="com.espressif.idf.core.toolchain">
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32-elf[\\/]+bin[\\/]+xtensa-esp32-elf-gcc(?:\.exe)?$"
+           compilerPattern="(?:xtensa-esp-elf|xtensa-esp32-elf)[\\/]+bin[\\/]+xtensa-esp32-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32.cmake"
            id="xtensa-esp32-elf"
@@ -254,7 +254,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32s2-elf[\\/]+bin[\\/]+xtensa-esp32s2-elf-gcc(?:\.exe)?$"
+           compilerPattern="(?:xtensa-esp-elf|xtensa-esp32s2-elf)[\\/]+bin[\\/]+xtensa-esp32s2-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32s2-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32s2.cmake"
            id="xtensa-esp32s2-elf"
@@ -262,7 +262,7 @@ config-only component and an interface library is created instead."
      </ToolChain>
      <ToolChain
            arch="xtensa"
-           compilerPattern="xtensa-esp32s3-elf[\\/]+bin[\\/]+xtensa-esp32s3-elf-gcc(?:\.exe)?$"
+           compilerPattern="(?:xtensa-esp-elf|xtensa-esp32s3-elf)[\\/]+bin[\\/]+xtensa-esp32s3-elf-gcc(?:\.exe)?$"
            debuggerPattern="xtensa-esp32s3-elf-gdb(\.exe)?$"
            fileName="toolchain-esp32s3.cmake"
            id="xtensa-esp32s3-elf"

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFVersionsReader.java
@@ -98,7 +98,7 @@ public class IDFVersionsReader
 		for (String version : versions)
 		{
 			Logger.log("Version: " + version); //$NON-NLS-1$
-			if (version.startsWith("master")) //$NON-NLS-1$
+			if (version.startsWith("master") || version.startsWith("release/")) //$NON-NLS-1$ //$NON-NLS-2$
 			{
 				String gitHubVersionUrl = MASTER_URL;
 				String espressifVersionUrl = MASTER_URL;
@@ -108,13 +108,6 @@ public class IDFVersionsReader
 			{
 				String gitHubVersionUrl = GITHUB_VERSION_URL.replace(versionRegEx, version);
 				String espressifVersionUrl = ESPRESSIF_VERSION_URL.replace(versionRegEx, version);
-				versionsMap.put(version, new IDFVersion(version, gitHubVersionUrl, espressifVersionUrl));
-			}
-			else if (version.startsWith("release/")) //$NON-NLS-1$
-			{
-				String newVersion = version.replace("release/", ""); //$NON-NLS-1$ //$NON-NLS-2$
-				String gitHubVersionUrl = GITHUB_VERSION_URL.replace(versionRegEx, newVersion);
-				String espressifVersionUrl = ESPRESSIF_VERSION_URL.replace(versionRegEx, newVersion);
 				versionsMap.put(version, new IDFVersion(version, gitHubVersionUrl, espressifVersionUrl));
 			}
 		}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/GitRepositoryBuilder.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/GitRepositoryBuilder.java
@@ -71,6 +71,7 @@ public class GitRepositoryBuilder
 				  .setDirectory(this.repositoryDirectory)
 				  .setBranchesToClone(branchesToClone)
 				  .setBranch(getBranchPath(this.activeBranch))
+				  .setTimeout(300)
 				  .call();
 		
 		// @formatter:on


### PR DESCRIPTION
## Description

Updated code to clone directly instead of downloading archive for release branches. 
Added timeout for repo clone as release branches were getting timed out.
Improved the code to properly name the cloned repos based on versions.

Fixes # ([IEP-1136](https://jira.espressif.com:8443/browse/IEP-1136))

## Type of change

Please delete options that are not relevant.
- Bug fix

## How has this been tested?

Follow the steps in Jira ticket to reproduce and test.

**Test Configuration**:
* OS (Windows,Linux and macOS): any

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a timeout for the repository cloning process to enhance stability.

- **Bug Fixes**
	- Improved version handling in the software update process for a smoother user experience.

- **Refactor**
	- Streamlined version prefix checks to consolidate version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->