### PR TITLE
WIP: IEP-1088: Improve the message about tools installation after configuring esp-idf path in Download and Configure IDF

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFDownloadWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFDownloadWizard.java
@@ -48,13 +48,14 @@ public class IDFDownloadWizard extends Wizard
 		boolean configureExistingEnabled = downloadPage.isConfigureExistingEnabled();
 		if (configureExistingEnabled)
 		{
-			String existingIDFLocation = downloadPage.getExistingIDFLocation();
-			Logger.log("Setting IDF_PATH to :" + existingIDFLocation); //$NON-NLS-1$
-
+			String newIDFLocation = downloadPage.getExistingIDFLocation();
+			Logger.log("Setting IDF_PATH to :" + newIDFLocation); //$NON-NLS-1$
+			IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
+			String oldIdfPath = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_PATH);
 			// Configure IDF_PATH
-			new IDFEnvironmentVariables().addEnvVariable("IDF_PATH", existingIDFLocation); //$NON-NLS-1$
+			idfEnvironmentVariables.addEnvVariable(IDFEnvironmentVariables.IDF_PATH, newIDFLocation);
 
-			showMessage(MessageFormat.format(Messages.IDFDownloadWizard_ConfigMessage, existingIDFLocation));
+			showMessage(MessageFormat.format(Messages.IDFDownloadWizard_ConfigMessage, newIDFLocation), oldIdfPath);
 
 		}
 		else
@@ -127,9 +128,9 @@ public class IDFDownloadWizard extends Wizard
 
 				// extracts file name from URL
 				String folderName = new File(url).getName().replace(".zip", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
+				String existingIdfPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.IDF_PATH);
 				configurePath(destinationLocation, folderName);
-				showMessage(MessageFormat.format(Messages.IDFDownloadWizard_DownloadCompleteMsg, folderName));
+				showMessage(MessageFormat.format(Messages.IDFDownloadWizard_DownloadCompleteMsg, folderName), existingIdfPath);
 			}
 		}
 		catch (IOException e)
@@ -150,8 +151,9 @@ public class IDFDownloadWizard extends Wizard
 		try
 		{
 			gitBuilder.repositoryClone();
+			String existingIdfPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.IDF_PATH);
 			configurePath(destinationLocation, "esp-idf"); //$NON-NLS-1$
-			showMessage(MessageFormat.format(Messages.IDFDownloadWizard_CloningCompletedMsg, version));
+			showMessage(MessageFormat.format(Messages.IDFDownloadWizard_CloningCompletedMsg, version), existingIdfPath);
 
 		}
 		catch (Exception e)
@@ -167,7 +169,7 @@ public class IDFDownloadWizard extends Wizard
 		Logger.log("Setting IDF_PATH to:" + idf_path); //$NON-NLS-1$
 
 		// Configure IDF_PATH
-		new IDFEnvironmentVariables().addEnvVariable("IDF_PATH", //$NON-NLS-1$
+		new IDFEnvironmentVariables().addEnvVariable(IDFEnvironmentVariables.IDF_PATH,
 				new File(destinationDir, folderName).getAbsolutePath());
 	}
 
@@ -176,7 +178,7 @@ public class IDFDownloadWizard extends Wizard
 		new ZipUtility().decompress(new File(downloadFile), new File(destinationLocation));
 	}
 
-	private void showMessage(final String message)
+	private void showMessage(final String message, String oldIdfPath)
 	{
 		Display.getDefault().asyncExec(new Runnable()
 		{
@@ -196,6 +198,10 @@ public class IDFDownloadWizard extends Wizard
 					{
 						Logger.log(e);
 					}
+				}
+				else 
+				{
+					new IDFEnvironmentVariables().addEnvVariable(IDFEnvironmentVariables.IDF_PATH, oldIdfPath);
 				}
 			}
 		});

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/messages.properties
@@ -21,10 +21,10 @@ IDFDownloadPage_DownloadIDF=Download ESP-IDF
 IDFDownloadPage_IDFBuildNotSupported=ESP-IDF build system does not support spaces in paths. Please choose a different directory.
 IDFDownloadPage_Note=Note: The newly configured ESP-IDF will set to IDF_PATH in the CDT Build environment (Preferences > C/C++ > Build > Environment)
 IDFDownloadPage_VersionLinkMsg=For more information about ESP-IDF versions, see <a href="https://docs.espressif.com/projects/esp-idf/en/latest/versions.html">https://docs.espressif.com/projects/esp-idf/en/latest/versions.html</a>
-IDFDownloadWizard_CloningCompletedMsg=ESP-IDF {0} cloning completed\! This might require a new set of tools to be installed. Do you want to install them?
+IDFDownloadWizard_CloningCompletedMsg=ESP-IDF {0} cloning completed\! This requires a new set of tools to be installed. Do you want to install them?
 IDFDownloadWizard_CloningJobMsg=Cloning ESP-IDF {0}...
-IDFDownloadWizard_ConfigMessage=IDF_PATH configured with {0}. This might require a new set of tools to be installed. Do you want to install them?
-IDFDownloadWizard_DownloadCompleteMsg={0} download completed\! This might require a new set of tools to be installed. Do you want to install them?
+IDFDownloadWizard_ConfigMessage=New ESP-IDF path set {0}. This requires a new set of tools to be installed. Do you want to install them?
+IDFDownloadWizard_DownloadCompleteMsg={0} download completed\! This requires a new set of tools to be installed. Do you want to install them?
 IDFDownloadWizard_DownloadingJobMsg=Downloading ESP-IDF {0}...
 IDFDownloadWizard_DownloadingMessage=Downloading {0}...
 IDFDownloadWizard_ErrorTitle=Error


### PR DESCRIPTION
## Description

Improved messages to be more contextual and also handled the negative cases on dialogue

Fixes # ([IEP-1088](https://jira.espressif.com:8443/browse/IEP-1088))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Use Download and Configure ESP-IDF to download or configure existing tools. Message should box after download completes or an existing path is given should be more meaningful and pressing no should not break any changes and yes should bring up the install tools dialog

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the ESP-IDF installation wizard with improved path configuration and user messaging.
  - Updated user-facing messages to reflect the requirement of additional tool installations post-setup actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->