### PR TITLE
IEP-1157: SWTBot SBOM Tool test cases.

### DIFF
--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Require-Bundle: org.eclipse.ui,
  com.espressif.idf.core.test;bundle-version="0.0.1",
  org.eclipse.jface,
  slf4j.api,
- com.espressif.idf.ui;bundle-version="1.0.1",
- org.apache.commons.lang3;bundle-version="3.14.0"
+ com.espressif.idf.ui;bundle-version="1.0.1"
 Bundle-ActivationPolicy: lazy
 Import-Package: com.espressif.idf.core.util,
  org.eclipse.launchbar.ui,

--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.ui,
  com.espressif.idf.core.test;bundle-version="0.0.1",
  org.eclipse.jface,
  slf4j.api,
- com.espressif.idf.ui;bundle-version="1.0.1"
+ com.espressif.idf.ui;bundle-version="1.0.1",
+ org.apache.commons.lang3;bundle-version="3.14.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: com.espressif.idf.core.util,
  org.eclipse.launchbar.ui,

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -28,6 +28,7 @@ import com.espressif.idf.ui.test.operations.ProjectTestOperations;
  * @author Andrii Filippov
  *
  */
+@SuppressWarnings("restriction")
 @RunWith(SWTBotJunit4ClassRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class NewEspressifIDFProjectSBOMTest
@@ -48,7 +49,7 @@ public class NewEspressifIDFProjectSBOMTest
 	public void givenNewProjectCreatedRunSBOMtoolUsingContextMenu() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest1");
+		Fixture.givenProjectNameIs("NewSbomProjectFirstTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.runSBOMtoolBeforeProjectBuild();
 	}
@@ -57,7 +58,7 @@ public class NewEspressifIDFProjectSBOMTest
 	public void givenNewProjectCreatedBuilProjectThenRunSBOMtoolUsingContextMenu() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest2");
+		Fixture.givenProjectNameIs("NewSbomProjectSecondTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.runSBOMtoolUsingContextMenu();
@@ -67,7 +68,7 @@ public class NewEspressifIDFProjectSBOMTest
 	public void runSBOMtoolRedirectOutputToFile() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest3");
+		Fixture.givenProjectNameIs("NewSbomProjectThirdTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.runSBOMtoolUsingContextMenuRedirectOutputToFile();
@@ -77,7 +78,7 @@ public class NewEspressifIDFProjectSBOMTest
 	public void givenNewProjectCreatedBuilProjectThenRunSBOMtoolUsingContextMenuCheckingPath() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest4");
+		Fixture.givenProjectNameIs("NewSbomProjectFourthTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.runSBOMtoolCheckingPathValidation();
@@ -117,12 +118,12 @@ public class NewEspressifIDFProjectSBOMTest
 		{
 			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
 			ProjectTestOperations.waitForProjectBuild(bot);
-			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
 		}
 
 		private static void cleanTestEnv()
 		{
-			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
 			ProjectTestOperations.closeAllProjects(bot);
 			ProjectTestOperations.deleteAllProjects(bot);
 		}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -48,48 +48,98 @@ public class NewEspressifIDFProjectSBOMTest
 	}
 
 	@Test
-	public void givenNewProjectCreatedNotBuiltWhenOpenSBOMtoolThenSBOMtoolNotWorking() throws Exception
+	public void givenNewProjectCreatedNotBuiltWhenOpenSbomThenSbomIsDisabled() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewSbomProjectFirstTest");
+		Fixture.givenProjectNameIs("NewProjectSbomFirstTest");
 		Fixture.whenNewProjectIsSelected();
-		Fixture.whenOpenSBOMtool();
-		Fixture.thenRunOkbuttonDisabled(Fixture.bot);
+		Fixture.whenOpenSbomTool();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+		Fixture.whenRedirectOutputToTheFileClicked();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+		Fixture.whenRedirectOutputToTheFileClicked();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
 	}
 
 	@Test
-	public void givenNewProjectCreatedBuiltWhenRunSBOMtoolThenCheckResultInConsole() throws Exception
+	public void givenNewProjectCreatedBuiltWhenRunSbomThenSbomIsGeneratedInConsole() throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewSbomProjectSecondTest");
+		Fixture.givenProjectNameIs("NewProjectSbomSecondTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
-		Fixture.whenRunSBOMtool();
+		Fixture.whenOpenSbomTool();
+		Fixture.whenRunSbomTool();
 		Fixture.thenCheckResultInConsole();
 	}
 
 	@Test
-	public void givenNewProjectCreatedBuiltWhenRunSBOMtoolRedirectOutputToFileThenVerifyConsoleAndCheckResultInFile()
+	public void givenNewProjectCreatedBuiltWhenRunSBOMtoolRedirectOutputToFileThenCheckConsoleAndSbomFile()
 			throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewSbomProjectThirdTest");
+		Fixture.givenProjectNameIs("NewProjectSbomThirdTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
-		Fixture.whenRunSBOMtoolUsingContextMenuRedirectOutputToFile();
-		Fixture.thenVerifyConsole();
-		Fixture.thenCheckResultInFile();
+		Fixture.whenOpenSbomTool();
+		Fixture.whenRedirectOutputToTheFileClicked();
+		Fixture.whenRunSbomTool();
+		Fixture.thenCheckInConsole();
+		Fixture.whenRefreshProject();
+		Fixture.thenOpenSbomFile();
+		Fixture.thenCheckSbomFile();
 	}
 
 	@Test
-	public void givenNewProjectCreatedBuiltWhenOpenSBOMtoolThenCheckPathValidation() throws Exception
+	public void givenNewProjectCreatedBuiltWhenOpenSbomAndCleanProjectDescriptionPathThenCheckPathValidation()
+			throws Exception
 	{
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewSbomProjectFourthTest");
+		Fixture.givenProjectNameIs("NewProjectSbomFourthTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
-		Fixture.whenOpenSBOMtool();
-		Fixture.thenCheckPathValidation(Fixture.bot);
+		Fixture.whenOpenSbomTool();
+		Fixture.whenCleanProjectDescriptionPath();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltWhenOpenSbomAndAddSpaceToProjectDescriptionPathThenCheckPathValidation()
+			throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSbomFifthTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenOpenSbomTool();
+		Fixture.whenAddSpaceToProjectDescriptionPath();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltWhenOpenSbomAndAddBackSlashToProjectDescriptionPathThenCheckPathValidation()
+			throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSbomSixthTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenOpenSbomTool();
+		Fixture.whenAddBackSlashToProjectDescriptionPath();
+		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltWhenOpenSbomAndAddSpaceToOutputFilePathThenCheckPathValidation()
+			throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSbomSeventhTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenOpenSbomTool();
+		Fixture.whenRedirectOutputToTheFileClicked();
+		Fixture.thenAddSpaceToOutputFilePathAndCheckValidation(Fixture.bot);
 	}
 
 	private static class Fixture
@@ -136,25 +186,24 @@ public class NewEspressifIDFProjectSBOMTest
 			ProjectTestOperations.deleteAllProjects(bot);
 		}
 
-		private static void whenOpenSBOMtool() throws IOException
+		private static void whenOpenSbomTool() throws IOException
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 		}
 
-		private static void thenRunOkbuttonDisabled(SWTWorkbenchBot bot) throws IOException
+		private static void thenRunOKbuttonDisabled(SWTWorkbenchBot bot) throws IOException
 		{
 			SWTBotButton okButton = bot.button("OK");
 			assertTrue(!okButton.isEnabled());
-			bot.checkBox("Redirect output to the file").click();
-			assertTrue(!okButton.isEnabled());
-			bot.checkBox("Redirect output to the file").click();
-			assertTrue(!okButton.isEnabled());
-			bot.button("Cancel").click();
 		}
 
-		private static void whenRunSBOMtool() throws IOException
+		private static void whenRedirectOutputToTheFileClicked() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
+			bot.checkBox("Redirect output to the file").click();
+		}
+
+		private static void whenRunSbomTool() throws IOException
+		{
 			bot.button("OK").click();
 			ProjectTestOperations
 					.joinJobByName(com.espressif.idf.ui.update.Messages.SbomCommandDialog_EspIdfSbomJobName);
@@ -165,52 +214,51 @@ public class NewEspressifIDFProjectSBOMTest
 			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "SPDXVersion");
 		}
 
-		private static void thenVerifyConsole() throws IOException
+		private static void thenCheckInConsole() throws IOException
 		{
 			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console",
 					"The output was redirected to the file:");
 		}
 
-		private static void whenRunSBOMtoolUsingContextMenuRedirectOutputToFile() throws IOException
+		private static void whenRefreshProject() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
-			bot.checkBox("Redirect output to the file").click();
-			bot.button("OK").click();
-			ProjectTestOperations
-					.joinJobByName(com.espressif.idf.ui.update.Messages.SbomCommandDialog_EspIdfSbomJobName);
-		}
-
-		private static void thenCheckResultInFile() throws IOException
-		{
-			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console",
-					"The output was redirected to the file:");
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+		}
+
+		private static void thenOpenSbomFile() throws IOException
+		{
 			bot.tree().getTreeItem(projectName).getNode("sbom.txt").select();
 			bot.tree().getTreeItem(projectName).getNode("sbom.txt").doubleClick();
+		}
+
+		private static void thenCheckSbomFile() throws IOException
+		{
 			assertTrue(ProjectTestOperations.checkTextEditorContentForPhrase("SPDXVersion", bot));
 		}
 
-		private static void thenCheckPathValidation(SWTWorkbenchBot bot) throws IOException
+		private static void thenAddSpaceToOutputFilePathAndCheckValidation(SWTWorkbenchBot bot) throws IOException
 		{
 			SWTBotButton okButton = bot.button("OK");
-			bot.checkBox("Redirect output to the file").click();
 			if (!SystemUtils.IS_OS_LINUX)
 			{
-				ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path",
-						" ");
+				bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Output File Path:").setText(" ");
 				assertTrue(!okButton.isEnabled());
 			}
-			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", "");
-			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
-					"Project Description Path", "");
-			assertTrue(!okButton.isEnabled());
-			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
-					"Project Description Path", " ");
-			assertTrue(!okButton.isEnabled());
-			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
-					"Project Description Path", "\\");
-			assertTrue(!okButton.isEnabled());
-			bot.button("Cancel").click();
+		}
+
+		private static void whenCleanProjectDescriptionPath() throws IOException
+		{
+			bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Project Description Path:").setText("");
+		}
+
+		private static void whenAddSpaceToProjectDescriptionPath() throws IOException
+		{
+			bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Project Description Path:").setText(" ");
+		}
+
+		private static void whenAddBackSlashToProjectDescriptionPath() throws IOException
+		{
+			bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Project Description Path:").setText("\\");
 		}
 	}
 }

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -132,11 +133,12 @@ public class NewEspressifIDFProjectSBOMTest
 		private static void runSBOMtoolBeforeProjectBuild() throws IOException
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			SWTBotButton okButton = bot.button("OK");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			bot.checkBox("Redirect output to the file").click();
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			bot.checkBox("Redirect output to the file").click();
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			bot.button("Cancel").click();
 		}
 
@@ -168,22 +170,23 @@ public class NewEspressifIDFProjectSBOMTest
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 			bot.checkBox("Redirect output to the file").click();
+			SWTBotButton okButton = bot.button("OK");
 			if (!SystemUtils.IS_OS_LINUX)
 			{
 				ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path",
 						" ");
-				assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+				assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			}
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", "");
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
 					"Project Description Path", "");
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
 					"Project Description Path", " ");
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
 					"Project Description Path", "\\");
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(okButton));
 			bot.button("Cancel").click();
 		}
 	}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -131,7 +131,7 @@ public class NewEspressifIDFProjectSBOMTest
 
 		private static void runSBOMtoolBeforeProjectBuild() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
 			bot.checkBox("Redirect output to the file").click();
 			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
@@ -142,7 +142,7 @@ public class NewEspressifIDFProjectSBOMTest
 
 		private static void runSBOMtoolUsingContextMenu() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 			bot.button("OK").click();
 			ProjectTestOperations
 					.joinJobByName(com.espressif.idf.ui.update.Messages.SbomCommandDialog_EspIdfSbomJobName);
@@ -151,7 +151,7 @@ public class NewEspressifIDFProjectSBOMTest
 
 		private static void runSBOMtoolUsingContextMenuRedirectOutputToFile() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 			bot.checkBox("Redirect output to the file").click();
 			bot.button("OK").click();
 			ProjectTestOperations
@@ -166,7 +166,7 @@ public class NewEspressifIDFProjectSBOMTest
 
 		private static void runSBOMtoolCheckingPathValidation() throws IOException
 		{
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "SBOM Tool");
 			bot.checkBox("Redirect output to the file").click();
 			if (!SystemUtils.IS_OS_LINUX)
 			{

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.junit.After;
@@ -167,8 +168,12 @@ public class NewEspressifIDFProjectSBOMTest
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
 			bot.checkBox("Redirect output to the file").click();
-			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", " ");
-			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			if (!SystemUtils.IS_OS_LINUX)
+			{
+				ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path",
+						" ");
+				assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			}
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", "");
 			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
 					"Project Description Path", "");

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -99,7 +99,7 @@ public class NewEspressifIDFProjectSBOMTest
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.whenOpenSbomTool();
-		Fixture.whenCleanProjectDescriptionPath();
+		Fixture.whenEmptyProjectDescriptionPath();
 		Fixture.thenRunOKbuttonDisabled(Fixture.bot);
 	}
 
@@ -133,13 +133,21 @@ public class NewEspressifIDFProjectSBOMTest
 	public void givenNewProjectCreatedBuiltWhenOpenSbomAndAddSpaceToOutputFilePathThenCheckPathValidation()
 			throws Exception
 	{
-		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
-		Fixture.givenProjectNameIs("NewProjectSbomSeventhTest");
-		Fixture.whenNewProjectIsSelected();
-		Fixture.whenProjectIsBuiltUsingContextMenu();
-		Fixture.whenOpenSbomTool();
-		Fixture.whenRedirectOutputToTheFileClicked();
-		Fixture.thenAddSpaceToOutputFilePathAndCheckValidation(Fixture.bot);
+		if (!SystemUtils.IS_OS_LINUX)
+		{
+			Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+			Fixture.givenProjectNameIs("NewProjectSbomSeventhTest");
+			Fixture.whenNewProjectIsSelected();
+			Fixture.whenProjectIsBuiltUsingContextMenu();
+			Fixture.whenOpenSbomTool();
+			Fixture.whenRedirectOutputToTheFileClicked();
+			Fixture.whenAddSpaceToOutputFilePath(Fixture.bot);
+			Fixture.thenRunOKbuttonDisabled(Fixture.bot);
+		}
+		else
+		{
+			assertTrue(true);
+		}
 	}
 
 	private static class Fixture
@@ -236,17 +244,12 @@ public class NewEspressifIDFProjectSBOMTest
 			assertTrue(ProjectTestOperations.checkTextEditorContentForPhrase("SPDXVersion", bot));
 		}
 
-		private static void thenAddSpaceToOutputFilePathAndCheckValidation(SWTWorkbenchBot bot) throws IOException
+		private static void whenAddSpaceToOutputFilePath(SWTWorkbenchBot bot) throws IOException
 		{
-			SWTBotButton okButton = bot.button("OK");
-			if (!SystemUtils.IS_OS_LINUX)
-			{
-				bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Output File Path:").setText(" ");
-				assertTrue(!okButton.isEnabled());
-			}
+			bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Output File Path:").setText(" ");
 		}
 
-		private static void whenCleanProjectDescriptionPath() throws IOException
+		private static void whenEmptyProjectDescriptionPath() throws IOException
 		{
 			bot.shell("Software Bill of Materials Tool").bot().textWithLabel("Project Description Path:").setText("");
 		}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSBOMTest.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui.test.executable.cases.project;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
+import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+import com.espressif.idf.ui.test.operations.EnvSetupOperations;
+import com.espressif.idf.ui.test.operations.ProjectTestOperations;
+
+/**
+ * Test class to test the SBOM feature
+ * 
+ * @author Andrii Filippov
+ *
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NewEspressifIDFProjectSBOMTest
+{
+	@BeforeClass
+	public static void beforeTestClass() throws Exception
+	{
+		Fixture.loadEnv();
+	}
+
+	@After
+	public void afterEachTest()
+	{
+		Fixture.cleanTestEnv();
+	}
+
+	@Test
+	public void givenNewProjectCreatedRunSBOMtoolUsingContextMenu() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest1");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.runSBOMtoolBeforeProjectBuild();
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuilProjectThenRunSBOMtoolUsingContextMenu() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest2");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.runSBOMtoolUsingContextMenu();
+	}
+
+	@Test
+	public void runSBOMtoolRedirectOutputToFile() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest3");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.runSBOMtoolUsingContextMenuRedirectOutputToFile();
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuilProjectThenRunSBOMtoolUsingContextMenuCheckingPath() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSBOMtoolTest4");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.runSBOMtoolCheckingPathValidation();
+	}
+
+	private static class Fixture
+	{
+		private static SWTWorkbenchBot bot;
+		private static String category;
+		private static String subCategory;
+		private static String projectName;
+
+		private static void loadEnv() throws Exception
+		{
+			bot = WorkBenchSWTBot.getBot();
+			EnvSetupOperations.setupEspressifEnv(bot);
+			bot.sleep(1000);
+		}
+
+		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)
+		{
+			Fixture.category = category;
+			Fixture.subCategory = subCategory;
+		}
+
+		private static void givenProjectNameIs(String projectName)
+		{
+			Fixture.projectName = projectName;
+		}
+
+		private static void whenNewProjectIsSelected() throws Exception
+		{
+			ProjectTestOperations.setupProject(projectName, category, subCategory, bot);
+		}
+
+		private static void whenProjectIsBuiltUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
+			ProjectTestOperations.waitForProjectBuild(bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
+		}
+
+		private static void cleanTestEnv()
+		{
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinish(bot);
+			ProjectTestOperations.closeAllProjects(bot);
+			ProjectTestOperations.deleteAllProjects(bot);
+		}
+
+		private static void runSBOMtoolBeforeProjectBuild() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			bot.checkBox("Redirect output to the file").click();
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			bot.checkBox("Redirect output to the file").click();
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			bot.button("Cancel").click();
+		}
+
+		private static void runSBOMtoolUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			bot.button("OK").click();
+			ProjectTestOperations
+					.joinJobByName(com.espressif.idf.ui.update.Messages.SbomCommandDialog_EspIdfSbomJobName);
+			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "SPDXVersion");
+		}
+
+		private static void runSBOMtoolUsingContextMenuRedirectOutputToFile() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			bot.checkBox("Redirect output to the file").click();
+			bot.button("OK").click();
+			ProjectTestOperations
+					.joinJobByName(com.espressif.idf.ui.update.Messages.SbomCommandDialog_EspIdfSbomJobName);
+			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console",
+					"The output was redirected to the file:");
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+			bot.tree().getTreeItem(projectName).getNode("sbom.txt").select();
+			bot.tree().getTreeItem(projectName).getNode("sbom.txt").doubleClick();
+			assertTrue(ProjectTestOperations.checkTextEditorContentForPhrase("SPDXVersion", bot));
+		}
+
+		private static void runSBOMtoolCheckingPathValidation() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "ESP-IDF: SBOM Tool");
+			bot.checkBox("Redirect output to the file").click();
+			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", " ");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool", "Output File Path", "");
+			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
+					"Project Description Path", "");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
+					"Project Description Path", " ");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			ProjectTestOperations.setTextFieldInShell(bot, "Software Bill of Materials Tool",
+					"Project Description Path", "\\");
+			assertTrue(ProjectTestOperations.checkButtonIsDisabled(bot, "OK"));
+			bot.button("Cancel").click();
+		}
+	}
+}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
@@ -63,7 +63,7 @@ public class NewEspressifIDFProjectTest
 	{
 		Fixture.cleanTestEnv();
 	}
-	
+
 	@Test
 	public void givenNewIDFProjectIsSelectedThenProjectIsCreatedAndAddedToProjectExplorer() throws Exception
 	{
@@ -71,7 +71,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.givenProjectNameIs("NewProjectTest");
 		Fixture.whenNewProjectIsSelected();
 		Fixture.thenProjectIsAddedToProjectExplorer();
-		
+
 	}
 
 	@Test
@@ -141,6 +141,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.whenInstallNewComponentUsingContextMenu();
+		Fixture.whenRefreshProject();
 		Fixture.checkIfNewComponentIsInstalledUsingContextMenu();
 	}
 
@@ -152,6 +153,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.whenProjectCleanUsingContextMenu();
+		Fixture.whenRefreshProject();
 		Fixture.checkIfProjectCleanedFilesInBuildFolder();
 	}
 
@@ -163,6 +165,7 @@ public class NewEspressifIDFProjectTest
 		Fixture.whenNewProjectIsSelected();
 		Fixture.whenProjectIsBuiltUsingContextMenu();
 		Fixture.whenProjectFullCleanUsingContextMenu();
+		Fixture.whenRefreshProject();
 		Fixture.checkIfProjectFullCleanedFilesInBuildFolder();
 	}
 
@@ -272,8 +275,11 @@ public class NewEspressifIDFProjectTest
 			bot.button("Install").click();
 			ProjectTestOperations.waitForProjectNewComponentInstalled(bot);
 			bot.editorByTitle(projectName).close();
+		}
+
+		private static void whenRefreshProject() throws IOException
+		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
-			bot.sleep(2000);
 		}
 
 		private static void checkPythonCLeanCommandDeleteFolder() throws IOException
@@ -363,8 +369,6 @@ public class NewEspressifIDFProjectTest
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Project Clean");
 			ProjectTestOperations.joinJobByName(Messages.ProjectCleanCommandHandler_RunningProjectCleanJobName);
 			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "Done");
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
-			bot.sleep(2000);
 		}
 
 		private static void whenProjectFullCleanUsingContextMenu() throws IOException
@@ -372,8 +376,6 @@ public class NewEspressifIDFProjectTest
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Project Full Clean");
 			ProjectTestOperations.joinJobByName(Messages.ProjectFullCleanCommandHandler_RunningFullcleanJobName);
 			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "Done");
-			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
-			bot.sleep(2000);
 			TestWidgetWaitUtility.waitForOperationsInProgressToFinishSync(bot);
 		}
 

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectTest.java
@@ -362,7 +362,7 @@ public class NewEspressifIDFProjectTest
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Project Clean");
 			ProjectTestOperations.joinJobByName(Messages.ProjectCleanCommandHandler_RunningProjectCleanJobName);
-			ProjectTestOperations.waitForProjectClean(bot);
+			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "Done");
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
 			bot.sleep(2000);
 		}
@@ -371,7 +371,7 @@ public class NewEspressifIDFProjectTest
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Project Full Clean");
 			ProjectTestOperations.joinJobByName(Messages.ProjectFullCleanCommandHandler_RunningFullcleanJobName);
-			ProjectTestOperations.waitForProjectClean(bot);
+			ProjectTestOperations.findInConsole(bot, "Espressif IDF Tools Console", "Done");
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
 			bot.sleep(2000);
 			TestWidgetWaitUtility.waitForOperationsInProgressToFinishSync(bot);

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -575,6 +575,7 @@ public class ProjectTestOperations
 			projectItem.select();
 			projectItem.contextMenu(contextMenuLabel).click();
 		}
+		bot.sleep(3000);
 	}
 
 	public static void findInConsole(SWTWorkbenchBot bot, String consoleName, String findText) throws IOException

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -586,11 +586,6 @@ public class ProjectTestOperations
 		TestWidgetWaitUtility.waitUntilViewContains(bot, findText, consoleView, 3000);
 	}
 
-	public static void setTextFieldInShell(SWTWorkbenchBot bot, String shellName, String textWithLabel, String setText)
-	{
-		bot.shell(shellName).bot().textWithLabel(textWithLabel + ":").setText(setText);
-	}
-
 	public static void joinJobByName(String jobName)
 	{
 		Job[] jobs = Job.getJobManager().find(null);

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -575,7 +575,7 @@ public class ProjectTestOperations
 			projectItem.select();
 			projectItem.contextMenu(contextMenuLabel).click();
 		}
-		bot.sleep(3000);
+		WaitUtils.waitForJobs();
 	}
 
 	public static void findInConsole(SWTWorkbenchBot bot, String consoleName, String findText) throws IOException

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -302,6 +302,8 @@ public class ProjectTestOperations
 
 		bot.tree().expandNode(category).select(subCategory);
 		bot.button("Finish").click();
+		SWTBotShell shell1 = bot.shell("New IDF Project");
+		shell1.activate();
 		bot.textWithLabel("Project name:").setText(projectName);
 		bot.button("Finish").click();
 		TestWidgetWaitUtility.waitUntilViewContainsTheTreeItemWithName(projectName, bot.viewByTitle("Project Explorer"),

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -573,23 +573,25 @@ public class ProjectTestOperations
 			projectItem.select();
 			projectItem.contextMenu(contextMenuLabel).click();
 		}
-		try
-		{
-			Thread.sleep(2000);
-		}
-		catch (InterruptedException e)
-		{
-			logger.error(e.getMessage(), e);
-		}
-
 	}
 
-	public static void waitForProjectClean(SWTWorkbenchBot bot) throws IOException
+	public static void findInConsole(SWTWorkbenchBot bot, String consoleName, String findText) throws IOException
 	{
-		SWTBotView consoleView = viewConsole("Espressif IDF Tools Console", bot);
+		SWTBotView consoleView = viewConsole(consoleName, bot);
 		consoleView.show();
 		consoleView.setFocus();
-		TestWidgetWaitUtility.waitUntilViewContains(bot, "Done", consoleView, 0);
+		TestWidgetWaitUtility.waitUntilViewContains(bot, findText, consoleView, 3000);
+	}
+
+	public static boolean checkButtonIsDisabled(SWTWorkbenchBot bot, String buttonLabel) throws IOException
+	{
+		bot.button(buttonLabel);
+		return !bot.button(buttonLabel).isEnabled(); // return false if active
+	}
+
+	public static void setTextFieldInShell(SWTWorkbenchBot bot, String shellName, String textWithLabel, String setText)
+	{
+		bot.shell(shellName).bot().textWithLabel(textWithLabel + ":").setText(setText);
 	}
 
 	public static void joinJobByName(String jobName)

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -586,11 +586,6 @@ public class ProjectTestOperations
 		TestWidgetWaitUtility.waitUntilViewContains(bot, findText, consoleView, 3000);
 	}
 
-	public static boolean checkButtonIsDisabled(SWTBotButton button)
-	{
-		return !button.isEnabled();
-	}
-
 	public static void setTextFieldInShell(SWTWorkbenchBot bot, String shellName, String textWithLabel, String setText)
 	{
 		bot.shell(shellName).bot().textWithLabel(textWithLabel + ":").setText(setText);

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -586,10 +586,9 @@ public class ProjectTestOperations
 		TestWidgetWaitUtility.waitUntilViewContains(bot, findText, consoleView, 3000);
 	}
 
-	public static boolean checkButtonIsDisabled(SWTWorkbenchBot bot, String buttonLabel) throws IOException
+	public static boolean checkButtonIsDisabled(SWTBotButton button)
 	{
-		bot.button(buttonLabel);
-		return !bot.button(buttonLabel).isEnabled(); // return false if active
+		return !button.isEnabled();
 	}
 
 	public static void setTextFieldInShell(SWTWorkbenchBot bot, String shellName, String textWithLabel, String setText)


### PR DESCRIPTION
## Description

Test cases: 

- Run SBOM Tool **without** _project_description.json_ file created.   
- Run SBOM Tool **with** _project_description.json_ file created.   
- SBOMT Tool dialog window: **basic PATH validation** 
- update method _waitForProjectClean()_ -> to -> _findInConsole()_ to make it universal for every consoles.

Fixes # ([IEP-1157](https://jira.espressif.com:8443/browse/IEP-1157))


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [X] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a test class to validate the SBOM (Software Bill of Materials) feature for Espressif IDF projects.
  - Added new test methods for various scenarios related to creating, building, and interacting with projects using the SBOM tool.

- **Improvements**
  - Enhanced synchronization and handling of project cleaning and refreshing operations in test cases.

- **Bug Fixes**
  - Replaced sleep functions with more reliable waiting methods to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->