### PR TITLE
fix: build folder not cleared after changing jtag target

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -51,17 +51,16 @@ public class LaunchBarListener implements ILaunchBarListener
 	@Override
 	public void activeLaunchTargetChanged(ILaunchTarget target)
 	{
-		Display.getDefault().asyncExec(() ->
-		{
-				if (target != null)
-				{
+		Display.getDefault().asyncExec(() -> {
+			if (target != null)
+			{
 				String targetName = target.getAttribute("com.espressif.idf.launch.serial.core.idfTarget", //$NON-NLS-1$
 						StringUtil.EMPTY);
 				if (!StringUtil.isEmpty(targetName) && (!targetChangeIgnored))
-					{
-						update(targetName);
-					}
+				{
+					update(targetName);
 				}
+			}
 		});
 
 	}
@@ -104,9 +103,8 @@ public class LaunchBarListener implements ILaunchBarListener
 						// get current target
 						String currentTarget = new SDKConfigJsonReader((IProject) project).getValue("IDF_TARGET"); //$NON-NLS-1$
 
-						if ((activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false)
-								|| activeConfig.getType().getIdentifier()
-										.contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
+						if ((activeConfig.getAttribute(IDFLaunchConstants.FLASH_OVER_JTAG, false) || activeConfig
+								.getType().getIdentifier().contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
 								&& !jtagIgnored)
 						{
 							String targetForJtagFlash = activeConfig.getWorkingCopy()
@@ -121,6 +119,7 @@ public class LaunchBarListener implements ILaunchBarListener
 								{
 									ILaunchBarUIManager uiManager = UIPlugin.getService(ILaunchBarUIManager.class);
 									uiManager.openConfigurationEditor(launchBarManager.getActiveLaunchDescriptor());
+									deleteBuildFolder(project, buildLocation);
 									return;
 								}
 							}
@@ -136,32 +135,7 @@ public class LaunchBarListener implements ILaunchBarListener
 											project.getName(), currentTarget, newTarget));
 							if (isDelete)
 							{
-								IWorkspaceRunnable runnable = new IWorkspaceRunnable()
-								{
-
-									@Override
-									public void run(IProgressMonitor monitor) throws CoreException
-									{
-
-										monitor.beginTask("Deleting build folder...", 1); //$NON-NLS-1$
-										Logger.log("Deleting build folder " + buildLocation.getAbsolutePath()); //$NON-NLS-1$
-										deleteDirectory(buildLocation);
-										cleanSdkConfig(project);
-										project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-									}
-
-								};
-
-								// run workspace job
-								try
-								{
-									ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
-								}
-								catch (Exception e1)
-								{
-									Logger.log(IDFCorePlugin.getPlugin(), "Unable to delete the build folder", //$NON-NLS-1$
-											e1);
-								}
+								deleteBuildFolder(project, buildLocation);
 							}
 						}
 					}
@@ -173,6 +147,36 @@ public class LaunchBarListener implements ILaunchBarListener
 		catch (CoreException e1)
 		{
 			Logger.log(e1);
+		}
+	}
+
+	private void deleteBuildFolder(IResource project, File buildLocation)
+	{
+		IWorkspaceRunnable runnable = new IWorkspaceRunnable()
+		{
+
+			@Override
+			public void run(IProgressMonitor monitor) throws CoreException
+			{
+
+				monitor.beginTask("Deleting build folder...", 1); //$NON-NLS-1$
+				Logger.log("Deleting build folder " + buildLocation.getAbsolutePath()); //$NON-NLS-1$
+				deleteDirectory(buildLocation);
+				cleanSdkConfig(project);
+				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+			}
+
+		};
+
+		// run workspace job
+		try
+		{
+			ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
+		}
+		catch (Exception e1)
+		{
+			Logger.log(IDFCorePlugin.getPlugin(), "Unable to delete the build folder", //$NON-NLS-1$
+					e1);
 		}
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/messages.properties
@@ -1,3 +1,3 @@
 LaunchBarListener_TargetChanged_Msg=Current target for the project {0} has changed from {1} to {2} in the launchbar, would you like to delete the "build" folder for the project?
 LaunchBarListener_TargetChanged_Title=IDF Launch Target Changed
-LaunchBarListener_TargetDontMatch_Msg=The selected target {0} doesn''t match the target {1} for the JTAG flashing in {2}. Do you want to change the selected board in the configuration?
+LaunchBarListener_TargetDontMatch_Msg=The selected target {0} doesn''t match the target {1} for the JTAG flashing in {2}. Do you want to change the selected board in the configuration? The sdkconfig and the "build" folder will be cleared


### PR DESCRIPTION
## Description

fixed this use case:
Create project - JTAG target ESP32 -> build project -> change target to ESP32 S2 -> pop-up for changing JTAG target -> NO build folder cleaning pop-up 

so now we are cleaning the build folder if, in the first pop-up, we clicked yes.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
