### PR TITLE
IEP-1174: List Installed tools using wrong python

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -29,10 +28,8 @@ import com.espressif.idf.core.IDFCorePreferenceConstants;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.SystemExecutableFinder;
-import com.espressif.idf.core.Version;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.PyWinRegistryReader;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.IDFConsole;
 import com.espressif.idf.ui.InputStreamConsoleThread;
@@ -123,25 +120,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 
 	protected String getPythonExecutablePath()
 	{
-		// Get Python
-		if (Platform.OS_WIN32.equals(Platform.getOS()))
-		{
-			PyWinRegistryReader pyWinRegistryReader = new PyWinRegistryReader();
-			pythonVersions = pyWinRegistryReader.getPythonVersions();
-			if (pythonVersions.isEmpty())
-			{
-				Logger.log("No Python installations found in the system."); //$NON-NLS-1$
-			}
-
-			pythonExecutablenPath = pythonVersions.entrySet().stream().filter(
-					e -> new Version(e.getKey().replaceAll("-.+", StringUtil.EMPTY)).compareTo(new Version("3.6")) >= 0) //$NON-NLS-1$ //$NON-NLS-2$
-					.map(Entry::getValue).findAny().orElseGet(IDFUtil::getPythonExecutable);
-
-		}
-		else
-		{
-			pythonExecutablenPath = IDFUtil.getPythonExecutable();
-		}
+		pythonExecutablenPath = IDFUtil.getPythonExecutable();
 		return pythonExecutablenPath;
 	}
 


### PR DESCRIPTION
## Description

fix for getting python only from path not from windows registry

Fixes # ([IEP-1174](https://jira.espressif.com:8443/browse/IEP-1174))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Install tools and then click installed tools

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for obtaining the Python executable path in the tools update process, enhancing performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->