### PR TITLE
fix: Fix the update site issue with vIEP2.12.1

### DIFF
--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -90,6 +90,9 @@
    <bundle id="org.freemarker.freemarker">
       <category name="com.espressif.idf"/>
    </bundle>
+   <bundle id="org.snakeyaml.engine">
+      <category name="com.espressif.idf"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>
          ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications


### PR DESCRIPTION
## Description

Fix the update site issue with vIEP 2.12.1 builds to due to dependency plugins

Fixes # ([IEP-1175](https://jira.espressif.com:8443/browse/IEP-1175))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Download Eclipse CDt 2023-12
- Install PR update site
- Installation should go through without any problems

**Test Configuration**:
* ESP-IDF Version: NA
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Update site

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
