### PR TITLE
fix: updating espressif openocd path during startup

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -41,6 +41,7 @@ import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.resources.ResourceChangeListener;
 import com.espressif.idf.core.toolchain.ESPToolChainManager;
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.dialogs.BuildView;
 import com.espressif.idf.ui.dialogs.MessageLinkDialog;
@@ -189,6 +190,7 @@ public class InitializeToolsStartup implements IStartup
 			{
 				Logger.log(e);
 			}
+			IDFUtil.updateEspressifPrefPageOpenocdPath();
 
 		}
 		catch (


### PR DESCRIPTION
## Description

fixed an issue when during the first start of Espressif-IDE, the openocd path is undefined.

Fixes # ([IEP-1176](https://jira.espressif.com:8443/browse/IEP-1176))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Download Espressif-IDE from this PR
- copy esp-idf.json from the Espressif-IDE which comes from the offline installer into the new Espressif-IDE
- start Espressif-IDE, verify environment variables, openocd path from the Espressif preferences page

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- openocd path

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved tool initialization process for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->