### PR TITLE
GH issue: Abort build process in presence of errors (IEP-1180) 

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -451,7 +451,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 			Instant finish = Instant.now();
 			long timeElapsed = Duration.between(start, finish).toMillis();
-			if (!monitor.isCanceled())
+			if (!monitor.isCanceled() && epm.getErrorCount() == 0)
 			{
 				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 				ParitionSizeHandler paritionSizeHandler = new ParitionSizeHandler(project, infoStream, console);


### PR DESCRIPTION
## Description

related to the gh issue: https://github.com/espressif/idf-eclipse-plugin/issues/912

Fixes # ([IEP-1180](https://jira.espressif.com:8443/browse/IEP-1180))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Make some errors in project -> verify that idf_size.py isn't called after hitting error during the build

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of build actions by ensuring no errors are present before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->