### PR TITLE
fix: fixing duplicates configs when creating new project

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchConfigFinder.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchConfigFinder.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2024-2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.launchbar.core.ILaunchDescriptor;
+
+public class LaunchConfigFinder
+{
+	private ILaunchManager launchManager;
+
+	public LaunchConfigFinder()
+	{
+		launchManager = DebugPlugin.getDefault().getLaunchManager();
+	}
+
+	public LaunchConfigFinder(ILaunchManager launchManager)
+	{
+		this.launchManager = launchManager;
+	}
+
+	public ILaunchConfiguration findAppropriateLaunchConfig(ILaunchDescriptor descriptor, String configIndentifier)
+			throws CoreException
+	{
+		IProject project = descriptor.getAdapter(IProject.class);
+		for (ILaunchConfiguration config : launchManager.getLaunchConfigurations())
+		{
+			launchManager.getLaunchConfigurations();
+			IResource[] mappedResource = config.getMappedResources();
+			if (mappedResource != null && mappedResource.length > 0 && mappedResource[0].getProject().equals(project)
+					&& config.getType().getIdentifier().contentEquals(configIndentifier))
+			{
+				return config;
+			}
+		}
+		return null;
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchConfigFinder.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchConfigFinder.java
@@ -14,7 +14,7 @@ import org.eclipse.launchbar.core.ILaunchDescriptor;
 
 public class LaunchConfigFinder
 {
-	private ILaunchManager launchManager;
+	private final ILaunchManager launchManager;
 
 	public LaunchConfigFinder()
 	{
@@ -32,7 +32,6 @@ public class LaunchConfigFinder
 		IProject project = descriptor.getAdapter(IProject.class);
 		for (ILaunchConfiguration config : launchManager.getLaunchConfigurations())
 		{
-			launchManager.getLaunchConfigurations();
 			IResource[] mappedResource = config.getMappedResources();
 			if (mappedResource != null && mappedResource.length > 0 && mappedResource[0].getProject().equals(project)
 					&& config.getType().getIdentifier().contentEquals(configIndentifier))

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchUtil.java
@@ -7,21 +7,15 @@ package com.espressif.idf.core.util;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 
-public class LaunchConfigFinder
+public class LaunchUtil
 {
 	private final ILaunchManager launchManager;
 
-	public LaunchConfigFinder()
-	{
-		launchManager = DebugPlugin.getDefault().getLaunchManager();
-	}
-
-	public LaunchConfigFinder(ILaunchManager launchManager)
+	public LaunchUtil(ILaunchManager launchManager)
 	{
 		this.launchManager = launchManager;
 	}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -8,12 +8,13 @@ import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
+
+import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.util.LaunchConfigFinder;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
 {
@@ -31,7 +32,10 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		String targetConfig = descriptor.getName();
 		Map<String, ILaunchConfiguration> projectConfigs = configs.computeIfAbsent(project, key -> new HashMap<>());
 		ILaunchConfiguration configuration = projectConfigs.get(targetConfig);
-		configuration = configuration == null ? findExistingLaunchConfiguration(project, descriptor) : configuration;
+		configuration = configuration == null
+				? new LaunchConfigFinder().findAppropriateLaunchConfig(descriptor,
+						IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE)
+				: configuration;
 		configuration = configuration == null ? createLaunchConfiguration(descriptor, target) : configuration;
 		projectConfigs.put(configuration.getName(), configuration);
 		return configuration;
@@ -98,21 +102,4 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 	{
 		// Nothing to do
 	}
-
-	private ILaunchConfiguration findExistingLaunchConfiguration(IProject project, ILaunchDescriptor descriptor)
-			throws CoreException
-	{
-		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-		for (ILaunchConfiguration config : launchManager.getLaunchConfigurations())
-		{
-			IResource[] mappedResource = config.getMappedResources();
-			if (mappedResource != null && mappedResource.length > 0 && mappedResource[0].getProject().equals(project)
-					&& config.getName().equals(descriptor.getName()))
-			{
-				return config;
-			}
-		}
-		return null;
-	}
-
 }

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -8,13 +8,14 @@ import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.util.LaunchConfigFinder;
+import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
 {
@@ -32,10 +33,8 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		String targetConfig = descriptor.getName();
 		Map<String, ILaunchConfiguration> projectConfigs = configs.computeIfAbsent(project, key -> new HashMap<>());
 		ILaunchConfiguration configuration = projectConfigs.get(targetConfig);
-		configuration = configuration == null
-				? new LaunchConfigFinder().findAppropriateLaunchConfig(descriptor,
-						IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE)
-				: configuration;
+		configuration = configuration == null ? new LaunchUtil(DebugPlugin.getDefault().getLaunchManager())
+				.findAppropriateLaunchConfig(descriptor, IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE) : configuration;
 		configuration = configuration == null ? createLaunchConfiguration(descriptor, target) : configuration;
 		projectConfigs.put(configuration.getName(), configuration);
 		return configuration;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -8,7 +8,6 @@ import java.io.File;
 
 import org.eclipse.cdt.debug.internal.core.InternalDebugCoreMessages;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -16,9 +15,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
-import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.PageChangingEvent;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -42,6 +39,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.LaunchConfigFinder;
 import com.espressif.idf.ui.UIPlugin;
 import com.espressif.idf.ui.handlers.EclipseHandler;
 import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
@@ -122,7 +120,8 @@ public class NewIDFProjectWizard extends TemplateWizard
 			try
 			{
 				ILaunchDescriptor desc = launchBarManager.getActiveLaunchDescriptor();
-				if (findAppropriateDebugConfig(desc) == null)
+				if (new LaunchConfigFinder().findAppropriateLaunchConfig(desc,
+						IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE) == null)
 				{
 					createDefaultDebugConfig();
 					launchBarManager.setActiveLaunchDescriptor(desc);
@@ -134,23 +133,6 @@ public class NewIDFProjectWizard extends TemplateWizard
 			}
 		});
 		return performFinish;
-	}
-
-	private ILaunchConfiguration findAppropriateDebugConfig(ILaunchDescriptor descriptor) throws CoreException
-	{
-		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-		IProject project = descriptor.getAdapter(IProject.class);
-		for (ILaunchConfiguration config : launchManager.getLaunchConfigurations())
-		{
-			IResource[] mappedResource = config.getMappedResources();
-			if (mappedResource != null && mappedResource.length > 0 && mappedResource[0].getProject().equals(project)
-					&& config.getType().getIdentifier().contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
-			{
-				return config;
-			}
-		}
-		return null;
-
 	}
 
 	private void createDefaultDebugConfig()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.LaunchConfigFinder;
+import com.espressif.idf.core.util.LaunchUtil;
 import com.espressif.idf.ui.UIPlugin;
 import com.espressif.idf.ui.handlers.EclipseHandler;
 import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
@@ -120,7 +120,7 @@ public class NewIDFProjectWizard extends TemplateWizard
 			try
 			{
 				ILaunchDescriptor desc = launchBarManager.getActiveLaunchDescriptor();
-				if (new LaunchConfigFinder().findAppropriateLaunchConfig(desc,
+				if (new LaunchUtil(DebugPlugin.getDefault().getLaunchManager()).findAppropriateLaunchConfig(desc,
 						IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE) == null)
 				{
 					createDefaultDebugConfig();

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright 2024-2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.launchbar.core.ILaunchDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.util.LaunchConfigFinder;
+
+public class LaunchConfigFinderTest
+{
+	@Mock
+	private ILaunchManager launchManager;
+	@Mock
+	private ILaunchConfiguration launchConfiguration;
+	@Mock
+	private IProject project;
+	@Mock
+	private ILaunchDescriptor launchDescriptor;
+
+	@Mock
+	private ILaunchConfigurationType launchConfigType;
+
+	private LaunchConfigFinder launchConfigFinder;
+
+	@Before
+	public void setUp()
+	{
+		this.launchManager = Mockito.mock(ILaunchManager.class);
+		this.launchConfiguration = Mockito.mock(ILaunchConfiguration.class);
+		this.launchConfigType = Mockito.mock(ILaunchConfigurationType.class);
+		this.launchDescriptor = Mockito.mock(ILaunchDescriptor.class);
+		this.project = Mockito.mock(IProject.class);
+		launchConfigFinder = new LaunchConfigFinder(launchManager);
+	}
+
+	@Test
+	public void testFindAppropriateDebugConfig() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(new IProject[] { project });
+		when(launchConfiguration.getType()).thenReturn(launchConfigType);
+		when(launchConfiguration.getType().getIdentifier()).thenReturn(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+		when(launchDescriptor.getAdapter(IProject.class)).thenReturn(project);
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(launchConfiguration, result);
+	}
+
+	@Test
+	public void testFindExistingLaunchConfiguration() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(new IProject[] { project });
+		when(launchConfiguration.getType()).thenReturn(launchConfigType);
+		when(launchConfiguration.getType().getIdentifier()).thenReturn(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
+		when(launchDescriptor.getAdapter(IProject.class)).thenReturn(project);
+		when(launchConfiguration.getName()).thenReturn("name");
+		when(launchDescriptor.getName()).thenReturn("name");
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(launchConfiguration, result);
+	}
+
+	@Test
+	public void testFindAppropriateDebugConfig_NoMappedResources() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(null);
+		when(launchDescriptor.getAdapter(IProject.class)).thenReturn(project);
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(null, result);
+	}
+
+	@Test
+	public void testFindAppropriateDebugConfig_MappedResourcesAreEmpty() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(new IProject[] {});
+		when(launchDescriptor.getAdapter(IProject.class)).thenReturn(project);
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(null, result);
+	}
+
+	@Test
+	public void testFindAppropriateDebugConfig_NoMatchingType() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(new IProject[] { project });
+		when(launchConfiguration.getType()).thenReturn(launchConfigType);
+		when(launchConfigType.getIdentifier()).thenReturn("notDebugType");
+		when(launchDescriptor.getAdapter(IProject.class)).thenReturn(project);
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(null, result);
+	}
+
+	@Test
+	public void testFindExistingLaunchConfiguration_NoMatchingName() throws CoreException
+	{
+		when(project.getProject()).thenReturn(project);
+		when(launchManager.getLaunchConfigurations()).thenReturn(new ILaunchConfiguration[] { launchConfiguration });
+		when(launchConfiguration.getMappedResources()).thenReturn(new IProject[] { project });
+		when(launchConfiguration.getName()).thenReturn("anotherName");
+		when(launchDescriptor.getName()).thenReturn("name");
+		when(launchConfiguration.getType()).thenReturn(launchConfigType);
+		when(launchConfiguration.getType().getIdentifier()).thenReturn(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
+
+		ILaunchConfiguration result = launchConfigFinder.findAppropriateLaunchConfig(launchDescriptor,
+				IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
+
+		assertEquals(null, result);
+	}
+}

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
@@ -19,7 +19,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.util.LaunchConfigFinder;
+import com.espressif.idf.core.util.LaunchUtil;
 
 public class LaunchConfigFinderTest
 {
@@ -35,7 +35,7 @@ public class LaunchConfigFinderTest
 	@Mock
 	private ILaunchConfigurationType launchConfigType;
 
-	private LaunchConfigFinder launchConfigFinder;
+	private LaunchUtil launchConfigFinder;
 
 	@Before
 	public void setUp()
@@ -45,7 +45,7 @@ public class LaunchConfigFinderTest
 		this.launchConfigType = Mockito.mock(ILaunchConfigurationType.class);
 		this.launchDescriptor = Mockito.mock(ILaunchDescriptor.class);
 		this.project = Mockito.mock(IProject.class);
-		launchConfigFinder = new LaunchConfigFinder(launchManager);
+		launchConfigFinder = new LaunchUtil(launchManager);
 	}
 
 	@Test


### PR DESCRIPTION
## Description

Steps to reproduce for me:
 
1. create a new default project "test"
2. delete a project without deleting all related configuration
3. create a default "test" project again
4. click edit on the configuration 
5. The name of configuration is not "test" as supposed to be and a lot of duplicates are created

The problem happens because the default launch config is removed during project deletion and then we can't find it in a map always creating duplicates of the original one. Fixed by looking for existing config via launch manager first before creating a new configuration.
Fixes # ([IEP-1187](https://jira.espressif.com:8443/browse/IEP-1187))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

1. create a new default project "test"
2. delete a project without deleting all related configuration
3. create a default "test" project again
4. click edit on the configuration 
5. make sure no duplicates were created.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch configuration
- Debug configuration

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced project creation wizard to better handle and search for debug configurations.
- **Refactor**
	- Improved the efficiency and readability of the launch configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->