### PR TITLE
fix: Update macOS application display name

### DIFF
--- a/releng/com.espressif.idf.product/pom.xml
+++ b/releng/com.espressif.idf.product/pom.xml
@@ -69,6 +69,47 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>name.abuchen</groupId>
+				<artifactId>fix-info-plist-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>fix-info-plist</id>
+						<phase>package</phase>
+						<configuration>
+							<productId>com.espressif.idf.product</productId>
+						</configuration>
+						<goals>
+							<goal>fix-info-plist</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<appName>Espressif-IDE.app</appName>
+					<properties>
+						<property>
+							<name>CFBundleName</name>
+							<value>Espressif-IDE</value>
+						</property>
+						<property>
+							<name>CFBundleDisplayName</name>
+							<value>Espressif-IDE</value>
+						</property>
+						<property>
+							<name>CFBundleGetInfoString</name>
+							<value>Espressif-IDE for Mac OS X. Copyright Espressif Systems.All rights reserved.</value>
+						</property>
+						<property>
+							<name>Eclipse</name>
+							<value />
+						</property>
+						<property>
+							<name>CFBundleLocalizations</name>
+							<value><![CDATA[<array><string>en</string><string>de</string><string>es</string><string>nl</string><string>pt</string><string>pt-BR</string><string>fr</string><string>it</string><string>cs</string><string>ru</string><string>sk</string><string>pl</string><string>zh</string><string>zh_TW</string><string>da</string></array>]]></value>
+						</property>
+					</properties>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>


### PR DESCRIPTION
## Description

Update macOS application display name from Espressif-ide to  Espressif-IDE

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- download espressif-ide from PR
- verify application display name

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- dmg file

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
