### PR TITLE
fix: Restructure dependencies and fix for launchbar not visible issues

### DIFF
--- a/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
@@ -14,7 +14,21 @@ Require-Bundle: org.eclipse.ui,
  org.apache.batik.i18n;bundle-version="1.16.0",
  org.apache.batik.css;bundle-version="1.16.0",
  org.apache.batik.util;bundle-version="1.16.0",
- org.apache.batik.constants;bundle-version="1.16.0"
+ org.apache.batik.constants;bundle-version="1.16.0",
+ org.apache.batik.anim;bundle-version="1.16.0",
+ org.apache.batik.awt.util;bundle-version="1.16.0",
+ org.apache.batik.bridge;bundle-version="1.16.0",
+ org.apache.batik.dom;bundle-version="1.16.0",
+ org.apache.batik.codec;bundle-version="1.16.0",
+ org.apache.batik.dom.svg;bundle-version="1.16.0",
+ org.apache.batik.ext;bundle-version="1.16.0",
+ org.apache.batik.gvt;bundle-version="1.16.0",
+ org.apache.batik.script;bundle-version="1.16.0",
+ org.apache.batik.parser;bundle-version="1.16.0",
+ org.apache.batik.svggen;bundle-version="1.16.0",
+ org.apache.batik.shared.resources;bundle-version="1.16.0",
+ org.apache.batik.xml;bundle-version="1.16.0",
+ org.apache.batik.transcoder;bundle-version="1.16.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.espressif.idf.lsp
 Bundle-ActivationPolicy: lazy

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Espressif-IDE" uid="com.espressif.idf.product" id="com.espressif.idf.branding.idf" application="org.eclipse.ui.ide.workbench" version="2.13.0" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Espressif-IDE" uid="com.espressif.idf.product" id="com.espressif.idf.branding.idf" application="org.eclipse.ui.ide.workbench" version="2.13.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/com.espressif.idf.branding/icons/alt_about.png"/>
@@ -76,6 +76,7 @@
       <feature id="org.eclipse.swtchart.feature" installMode="root"/>
       <feature id="org.eclipse.nebula.widgets.xviewer.feature" installMode="root"/>
       <feature id="org.eclipse.cdt.lsp.feature" installMode="root"/>
+      <feature id="org.eclipse.tm4e.feature" installMode="root"/>
    </features>
 
    <configurations>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -54,11 +54,6 @@
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/lsp4e/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
 			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/"/>
 		</location>
@@ -74,25 +69,25 @@
 			<repository location="https://download.eclipse.org/swtchart/releases/0.13.0/repository"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.apache.batik.xml" version="0.0.0"/>
-			<unit id="org.apache.batik.dom" version="0.0.0"/>
-			<unit id="org.apache.batik.css" version="0.0.0"/>
-			<unit id="org.apache.batik.util" version="0.0.0"/>
-			<unit id="org.apache.batik.i18n" version="0.0.0"/>
-			<unit id="org.apache.batik.constants" version="0.0.0"/>
+			<unit id="org.apache.batik.xml" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.dom" version="1.16.0.v20230210-1249"/>
+			<unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.util" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.i18n" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.constants" version="1.16.0.v20221027-0840"/>
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.remote.console.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.remote.serial.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/ptp/remote/releases/3.0/remote-3.0.1/"/>
+			<unit id="org.apache.batik.anim" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.awt.util" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.bridge" version="1.16.0.v20230210-1249"/>
+			<unit id="org.apache.batik.codec" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.dom.svg" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.ext" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.gvt" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.parser" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.script" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.shared.resources" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.svggen" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.transcoder" version="1.16.0.v20221027-0840"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
@@ -105,11 +100,6 @@
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="http://download.eclipse.org/nebula/releases/latest"/>
@@ -126,6 +116,28 @@
 			<unit id="org.eclipse.embedcdt.debug.gdbjtag.openocd.feature.group" version="6.4.0.202307251916"/>
 			<unit id="org.eclipse.embedcdt.feature.group" version="6.4.0.202307251916"/>
 			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.4.0.202307251916"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.25.0/"/>
+			<unit id="com.google.gson" version="2.10.1"/>
+			<unit id="org.eclipse.lsp4e" version="0.18.6.202403050753"/>
+			<unit id="org.eclipse.lsp4e.debug" version="0.15.7.202402141138"/>
+			<unit id="org.eclipse.lsp4j" version="0.22.0.v20240213-2011"/>
+			<unit id="org.eclipse.lsp4j.debug" version="0.22.0.v20240213-2011"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.22.0.v20240213-2011"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.22.0.v20240213-2011"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tm4e/releases/0.9.0/"/>
+			<unit id="com.google.gson" version="2.10.1"/>
+			<unit id="org.apache.batik.constants" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
+			<unit id="org.apache.batik.util" version="1.16.0.v20221027-0840"/>
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.9.0.202401090933"/>
+			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.9.0.202401090933"/>
+			<unit id="org.jcodings" version="1.0.58"/>
+			<unit id="org.joni" version="2.2.1"/>
+			<unit id="org.snakeyaml.engine" version="2.7.0"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
 			<dependencies>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -28,7 +28,7 @@
       <category name="com.espressif.idf"/>
    </feature>
    <bundle id="org.apache.batik.xml">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.eclipse.embedcdt.templates.core">
       <category name="com.espressif.idf"/>
@@ -49,22 +49,22 @@
       <category name="com.espressif.idf"/>
    </bundle>
    <bundle id="org.jcodings">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.joni">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.yaml.snakeyaml">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="com.google.gson">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="com.google.guava">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="com.google.guava.failureaccess">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.eclipse.lsp4j">
       <category name="com.espressif.idf"/>
@@ -79,35 +79,78 @@
       <category name="com.espressif.idf"/>
    </bundle>
    <bundle id="org.jsoup">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.eclipse.tm4e.registry">
       <category name="com.espressif.idf"/>
    </bundle>
    <bundle id="org.apache.httpcomponents.httpclient">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.freemarker.freemarker">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.snakeyaml.engine">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.apache.batik.css">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.apache.batik.util">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.apache.batik.constants">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <bundle id="org.apache.batik.i18n">
-      <category name="com.espressif.idf"/>
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.anim">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.awt.util">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.bridge">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.codec">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.dom">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.dom.svg">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.ext">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.gvt">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.parser">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.script">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.svggen">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.transcoder">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.ext.awt">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.shared.resources">
+      <category name="com.espressif.idf.dependencies"/>
    </bundle>
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>
          ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications
       </description>
    </category-def>
+   <category-def name="com.espressif.idf.dependencies" label="ESP-IDF Eclipse Plugin - Dependencies"/>
 </site>


### PR DESCRIPTION
## Description

Restructure dependencies and fix for launchbar not visible issues

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Able to install PR update site on eclipse and espressif-ide v2.12.1 
- Able to install PR update site on espressif-ide v2.12.1 and launchbar is visible


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site
- Epressif-ide installation

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced support for external libraries and dependencies, ensuring better performance and compatibility.
- **Refactor**
	- Updated product configuration to support a mix of features for improved flexibility.
	- Revised dependency management for a more streamlined and efficient development environment.
- **Chores**
	- Updated category names for bundles to better reflect their purpose and content.
	- Improved categorization by replacing "com.espressif.idf" with "com.espressif.idf.dependencies" for multiple bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->