### PR TITLE
fix: ensure clangd file exists before writing config attributes

### DIFF
--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/ClangdConfigFileHandler.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/ClangdConfigFileHandler.java
@@ -6,14 +6,19 @@ package com.espressif.idf.lsp;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.yaml.snakeyaml.Yaml;
 
 import com.espressif.idf.core.logging.Logger;
@@ -24,7 +29,7 @@ import com.espressif.idf.core.logging.Logger;
 public class ClangdConfigFileHandler
 {
 	@SuppressWarnings("unchecked")
-	public void update(IProject project) throws FileNotFoundException
+	public void update(IProject project) throws CoreException, IOException
 	{
 		File file = getClangdConfigFile(project);
 
@@ -32,34 +37,56 @@ public class ClangdConfigFileHandler
 		FileInputStream inputStream = new FileInputStream(file);
 		Yaml yaml = new Yaml();
 		Object obj = yaml.load(inputStream);
+
+		// Create new YAML structure if file is empty
+		Map<String, Object> data;
 		if (obj instanceof Map)
 		{
-			Map<String, Object> data = (Map<String, Object>) obj;
-
-			// Add new attribute to CompileFlags
-			Map<String, Object> compileFlags = (Map<String, Object>) data.get("CompileFlags"); //$NON-NLS-1$
-			compileFlags.put("Remove", new String[] { "-m*", "-f*" }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
-			// Write updated clangd back to file
-			try (Writer writer = new FileWriter(file))
-			{
-				yaml.dump(data, writer);
-			}
-			catch (IOException e)
-			{
-				Logger.log("Error writing .clangd file: " + e.getMessage()); //$NON-NLS-1$
-			}
+			data = (Map<String, Object>) obj;
 		}
 		else
 		{
-			Logger.log("Invalid .clangd file format."); //$NON-NLS-1$
+			data = new LinkedHashMap<>();
+		}
+
+		// Add or update CompileFlags section
+		Map<String, Object> compileFlags = (Map<String, Object>) data.get("CompileFlags");
+		if (compileFlags == null)
+		{
+			compileFlags = new LinkedHashMap<>();
+			data.put("CompileFlags", compileFlags); //$NON-NLS-1$
+		}
+		compileFlags.put("CompilationDatabase", "build"); //$NON-NLS-1$ //$NON-NLS-2$
+		compileFlags.put("Remove", Arrays.asList("-m*", "-f*")); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// Write updated clangd back to file
+		try (Writer writer = new FileWriter(file))
+		{
+			yaml.dump(data, writer);
+		}
+		catch (IOException e)
+		{
+			Logger.log("Error writing .clangd file: " + e.getMessage()); //$NON-NLS-1$
 		}
 	}
 
-	private File getClangdConfigFile(IProject project)
+	private File getClangdConfigFile(IProject project) throws IOException, CoreException
 	{
-		// Path to the existing clangd file
-		IFile file = project.getFile(ILSPConstants.CLANGD_CONFIG_FILE);
-		return file.getLocation().toFile();
+		// Resolve the path of the clangd config file within the project directory
+		Path clangdPath = project.getLocation().toPath().resolve(ILSPConstants.CLANGD_CONFIG_FILE);
+		if (!Files.exists(clangdPath))
+		{
+			try
+			{
+				Files.createFile(clangdPath);
+			}
+			catch (IOException e)
+			{
+				throw new IOException("Failed to create clangd config file: " + e.getMessage(), e); //$NON-NLS-1$
+			}
+			project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		}
+		return clangdPath.toFile();
 	}
+
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -5,7 +5,6 @@
 package com.espressif.idf.ui.wizard;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 
 import org.eclipse.cdt.debug.internal.core.InternalDebugCoreMessages;
 import org.eclipse.core.resources.IProject;
@@ -147,7 +146,7 @@ public class NewIDFProjectWizard extends TemplateWizard
 	{
 		try {
 			new ClangdConfigFileHandler().update(project);
-		} catch (FileNotFoundException e) {
+		} catch (Exception e) {
 			Logger.log(e);
 		}
 	}


### PR DESCRIPTION
## Description

Ensure clangd file exists. If does not exist, create a new file and write the default config attributes

Fixes # ([IEP-1192](https://jira.espressif.com:8443/browse/IEP-1192))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Create any template project 
-  Ensure we have .clangd file with the following attributes 

```
CompileFlags:
CompilationDatabase: build
Remove: [-m*, -f*]
```

 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- create project
- build
- Indexer errors in the editor

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced YAML handling to support creation of new structures for empty files.
	- Updated logic for handling `CompileFlags` section in configuration files.
- **Refactor**
	- Improved file writing and error handling for a smoother user experience.
	- Refactored method for fetching configuration files, including file creation and project refresh.
- **Bug Fixes**
	- Generalized error handling in project wizard to catch a broader range of exceptions, improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->