### PR TITLE
IEP-1194: No such file exceptions in error log during IDE startup

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
@@ -151,7 +151,7 @@ public class ESPToolChainManager
 				.map(espToolChainElement -> findToolChain(getAllPaths(), espToolChainElement.debuggerPattern))
 				.findFirst().orElse(null);
 	}
-	
+
 	public File findCompiler(String target)
 	{
 		return toolchainElements.values().stream()
@@ -179,7 +179,8 @@ public class ESPToolChainManager
 
 	private Path[] getDirectories(String path)
 	{
-		return Arrays.stream(path.split(File.pathSeparator)).map(String::trim).map(Paths::get).toArray(Path[]::new);
+		return Arrays.stream(path.split(File.pathSeparator)).map(String::trim).map(Paths::get).filter(Files::exists)
+				.toArray(Path[]::new);
 	}
 
 	private File findMatchingFile(Path dir, String filePattern)


### PR DESCRIPTION
## Description

During the first IDE startup, we are trying to initialize toolchains from the PATH. If Path contains paths that don't exist anymore we will get an exception

Fixes # ([IEP-1194](https://jira.espressif.com:8443/browse/IEP-1194)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Create new workspace
- add non-existent path to PATH
- clear error log
- restart IDE
- verify that no "No such file" exceptions in error log after restart

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the toolchain manager to only include existing directories, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->