### PR TITLE
fix: set default query-driver path based on current active target

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -340,7 +340,7 @@ public class IDFUtil
 		return getXtensaToolchainExecutablePathByTarget(projectEspTarget);
 	}
 	
-	public static String getXtensaToolchainExePathForActiveTarget()
+	public static String getToolchainExePathForActiveTarget()
 	{
 		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
 		try

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdOptionsDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdOptionsDefaults.java
@@ -30,5 +30,14 @@ public class IDFClangdOptionsDefaults extends BuiltinClangdOptionsDefaults
 		Logger.log("clangd: " + clandPath); //$NON-NLS-1$
 		return Optional.ofNullable(clandPath).orElse(ILSPConstants.CLANGD_EXECUTABLE);
 	}
+	
+	@Override
+	public String queryDriver()
+	{
+		//By passing --query-driver argument to clangd helps to resolve the cross-compiler toolchain headers.
+		String toolchainPath = IDFUtil.getToolchainExePathForActiveTarget();
+		Logger.log("toolchain path: " + toolchainPath); //$NON-NLS-1$
+		return Optional.ofNullable(toolchainPath).orElse(super.queryDriver());
+	}
 
 }


### PR DESCRIPTION
## Description

Set default query-driver path based on current active target

Fixes # ([IEP-1195](https://jira.espressif.com:8443/browse/IEP-195))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Create a new project with a selected target
- Build a project
- Open the editor and observe that all the headers are resolved
- Verify the preferences, query-driver is set for the active target

However, there are challenges when you switch between targets, user has to manually set query-driver path in the prefernces and that will restart the lsp.

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS):macOS

## Dependent components impacted by this PR:

- New project
- Indexer

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
