### PR TITLE
fix: code clean for cdt indexing and avoid link folders

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -47,12 +47,10 @@ import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.cdt.core.envvar.EnvironmentVariable;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
-import org.eclipse.cdt.core.index.IIndexManager;
 import org.eclipse.cdt.core.model.CoreModel;
 import org.eclipse.cdt.core.model.ElementChangedEvent;
 import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.core.model.IBinaryContainer;
-import org.eclipse.cdt.core.model.ICElement;
 import org.eclipse.cdt.core.model.ICElementDelta;
 import org.eclipse.cdt.core.model.ICModelMarker;
 import org.eclipse.cdt.core.model.ICProject;
@@ -171,7 +169,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 	public IPath getBuildContainerPath() throws CoreException
 	{
-
 		if (hasCustomBuild())
 		{
 			org.eclipse.core.runtime.Path path = new org.eclipse.core.runtime.Path(customBuildDir);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -15,9 +15,7 @@
 package com.espressif.idf.core.build;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.net.URI;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -31,11 +29,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.eclipse.cdt.build.gcc.core.ClangToolChain;
@@ -43,7 +39,6 @@ import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.cmake.core.internal.CMakeUtils;
 import org.eclipse.cdt.core.CCorePlugin;
-import org.eclipse.cdt.core.CommandLauncherManager;
 import org.eclipse.cdt.core.ConsoleOutputStream;
 import org.eclipse.cdt.core.ErrorParserManager;
 import org.eclipse.cdt.core.IConsoleParser;
@@ -61,32 +56,22 @@ import org.eclipse.cdt.core.model.ICElement;
 import org.eclipse.cdt.core.model.ICElementDelta;
 import org.eclipse.cdt.core.model.ICModelMarker;
 import org.eclipse.cdt.core.model.ICProject;
-import org.eclipse.cdt.core.parser.ExtendedScannerInfo;
-import org.eclipse.cdt.core.parser.IScannerInfo;
 import org.eclipse.cdt.core.resources.IConsole;
 import org.eclipse.cdt.internal.core.model.BinaryRunner;
 import org.eclipse.cdt.internal.core.model.CModelManager;
-import org.eclipse.cdt.jsoncdb.core.CompileCommandsJsonParser;
-import org.eclipse.cdt.jsoncdb.core.ISourceFileInfoConsumer;
-import org.eclipse.cdt.jsoncdb.core.ParseRequest;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -106,7 +91,6 @@ import com.espressif.idf.core.util.HintsUtil;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.ParitionSizeHandler;
 import com.espressif.idf.core.util.StringUtil;
-import com.google.gson.Gson;
 
 @SuppressWarnings(value = { "restriction" })
 public class IDFBuildConfiguration extends CBuildConfiguration
@@ -116,15 +100,12 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private static final String NINJA = "Ninja"; //$NON-NLS-1$
 	protected static final String COMPILE_COMMANDS_JSON = "compile_commands.json"; //$NON-NLS-1$
 	protected static final String COMPONENTS = "components"; //$NON-NLS-1$
-	private static final String ESP_IDF_COMPONENTS = "esp_idf_components"; //$NON-NLS-1$
 	public static final String CMAKE_GENERATOR = "cmake.generator"; //$NON-NLS-1$
 	public static final String CMAKE_ARGUMENTS = "cmake.arguments"; //$NON-NLS-1$
 	public static final String CMAKE_ENV = "cmake.environment"; //$NON-NLS-1$
 	public static final String BUILD_COMMAND = "cmake.command.build"; //$NON-NLS-1$
 	public static final String CLEAN_COMMAND = "cmake.command.clean"; //$NON-NLS-1$
-	private JobGroup jobGroup = new JobGroup("Parsing Job...", 1, 1); //$NON-NLS-1$
 	private ILaunchTarget launchtarget;
-	private Map<IResource, IScannerInfo> infoPerResource;
 	/**
 	 * whether one of the CMakeLists.txt files in the project has been modified and saved by the user since the last
 	 * build.<br>
@@ -138,8 +119,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private String customBuildDir;
 	private IProgressMonitor monitor;
 	public boolean isProgressSet;
-	private QualifiedName TIMESTAMP_COMPILE_COMMANDS_PROPERTY = new QualifiedName(null,
-			"timestamp:compile_commands.json"); //$NON-NLS-1$
 	private ILaunchConfiguration configuration;
 
 	public IDFBuildConfiguration(IBuildConfiguration config, String name) throws CoreException
@@ -356,9 +335,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			}
 			runCmakeBuildCommand(console, monitor, project, start, generator, infoStream, buildDir);
 
-			// This is specifically added to trigger the indexing since in Windows OS it
-			// doesn't seem to happen!
-			update(project);
 			return new IProject[] { project };
 		}
 		catch (Exception e)
@@ -440,12 +416,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 					: new IConsoleParser[] { epm, new StatusParser() };
 			watchProcess(consoleParsers, monitor);
 
-			final String isSkip = System.getProperty("skip.idf.components"); //$NON-NLS-1$
-			if (!Boolean.parseBoolean(isSkip) && !monitor.isCanceled())
-			{ // no property defined
-				linkBuildComponents();
-			}
-
 			infoStream.write(String.format(Messages.CMakeBuildConfiguration_BuildingComplete, epm.getErrorCount(),
 					epm.getWarningCount(), buildDir.toString()));
 
@@ -456,10 +426,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 				ParitionSizeHandler paritionSizeHandler = new ParitionSizeHandler(project, infoStream, console);
 				paritionSizeHandler.startCheckingSize();
-				// parse compile_commands.json file
-				// built-ins detection output goes to the build console, if the user requested
-				// output
-				processCompileCommandsFile(console, monitor);
 			}
 
 			infoStream.write(MessageFormat.format("Total time taken to build the project: {0} ms", timeElapsed)); //$NON-NLS-1$
@@ -621,91 +587,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		return node.getBoolean(IDFCorePreferenceConstants.CMAKE_CCACHE_STATUS, true);
 	}
 
-	public void update(IProject project)
-	{
-		ICProject cproject = CCorePlugin.getDefault().getCoreModel().create(project);
-		if (cproject != null)
-		{
-			ArrayList<ICElement> tuSelection = new ArrayList<>();
-			tuSelection.add(cproject);
-
-			ICElement[] cProjectElements = tuSelection.toArray(new ICElement[tuSelection.size()]);
-			try
-			{
-				CCorePlugin.getIndexManager().update(cProjectElements, getUpdateOptions());
-			}
-			catch (Exception e)
-			{
-				Logger.log(e);
-			}
-		}
-	}
-
-	private static String getIdfToolsPath()
-	{
-		return new org.eclipse.core.runtime.Path(IDFUtil.getIDFPath()).toOSString();
-	}
-
-	/**
-	 * Link build components(build_component_paths) from project_description.json to the project.
-	 *
-	 * @param project
-	 * @throws Exception
-	 */
-	protected void linkBuildComponents() throws CoreException
-	{
-		final IPath jsonIPath = getBuildContainerPath()
-				.append(new org.eclipse.core.runtime.Path(COMPILE_COMMANDS_JSON));
-		File jsonDiskFile = jsonIPath.toFile();
-
-		IFolder folder = getIDFComponentsFolder();
-		CommandEntry[] sourceFileInfos = null;
-		try (Reader in = new FileReader(jsonDiskFile))
-		{
-			Gson gson = new Gson();
-			sourceFileInfos = gson.fromJson(in, CommandEntry[].class);
-			for (CommandEntry sourceFileInfo : sourceFileInfos)
-			{
-				String sourceFile = sourceFileInfo.getFile();
-				Logger.log("command::" + sourceFileInfo.getCommand(), true); //$NON-NLS-1$
-				Logger.log("file::" + sourceFile, true); //$NON-NLS-1$
-
-				org.eclipse.core.runtime.Path path = new org.eclipse.core.runtime.Path(sourceFile);
-				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
-				if (file == null)
-				{
-					createLinkForSourceFileOnly(path.toOSString(), folder);
-				}
-			}
-		}
-		catch (IOException e)
-		{
-			Logger.log(e);
-		}
-	}
-
-	/**
-	 * .../build/ide/esp_idf_components
-	 *
-	 * @return
-	 * @throws CoreException
-	 */
-	private IFolder getIDFComponentsFolder() throws CoreException
-	{
-		IProject project = getProject();
-
-		IFolder folder = project.getFolder(getComponentsPath());
-		File file = folder.getLocation().toFile();
-		if (!file.exists())
-		{
-			folder.getLocation().toFile().mkdirs();
-			IProgressMonitor monitor = new NullProgressMonitor();
-			folder.getProject().refreshLocal(IResource.DEPTH_INFINITE, monitor);
-		}
-
-		return folder;
-	}
-
 	@Override
 	public IToolChain getToolChain() throws CoreException
 	{
@@ -719,60 +600,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		return matchedToolChains.stream().findAny().orElse(toolChainManager.getToolChain(typeId, id));
 	}
 
-	private static IPath getComponentsPath()
-	{
-		return new org.eclipse.core.runtime.Path(IDFConstants.BUILD_FOLDER).append("ide").append(ESP_IDF_COMPONENTS); //$NON-NLS-1$
-	}
-
-	private void setLinkLocation(IResource toLink, IPath rawLinkLocation) throws CoreException
-	{
-		if (toLink.getType() == IResource.FILE)
-		{
-			((IFile) toLink).createLink(rawLinkLocation, IResource.REPLACE, new NullProgressMonitor());
-		}
-		if (toLink.getType() == IResource.FOLDER)
-		{
-			((IFolder) toLink).createLink(rawLinkLocation, IResource.REPLACE, new NullProgressMonitor());
-		}
-	}
-
-	private void createLinkForSourceFileOnly(String sourceFile, IFolder folder) throws CoreException
-	{
-		String sourceFileToSplit = sourceFile;
-		if (sourceFile.contains(getIdfToolsPath()))
-		{
-			sourceFileToSplit = sourceFile.substring(getIdfToolsPath().length(), sourceFile.length());
-		}
-		String[] segments = new org.eclipse.core.runtime.Path(sourceFileToSplit).segments();
-
-		for (int i = 0; i < (segments.length - 1); i++)
-		{
-			if (segments[i].equals(COMPONENTS) || segments[i].trim().isEmpty())
-			{
-				continue;
-			}
-			folder = folder.getFolder(segments[i]);
-			if (!folder.exists())
-			{
-				folder.create(true, true, new NullProgressMonitor());
-			}
-		}
-
-		String fileName = new File(sourceFile).getName();
-		IFile iFile = folder.getFile(fileName);
-		if (!iFile.exists())
-		{
-			IFile folderLink = folder.getFile(fileName);
-			setLinkLocation(folderLink, new org.eclipse.core.runtime.Path(sourceFile));
-
-		}
-	}
-
-	protected int getUpdateOptions()
-	{
-		return IIndexManager.UPDATE_CHECK_TIMESTAMPS | IIndexManager.UPDATE_UNRESOLVED_INCLUDES
-				| IIndexManager.UPDATE_EXTERNAL_FILES_FOR_PROJECT | IIndexManager.FORCE_INDEX_INCLUSION;
-	}
 
 	@Override
 	public void clean(IConsole console, IProgressMonitor monitor) throws CoreException
@@ -840,58 +667,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		}
 	}
 
-	/**
-	 * @param console the console to print the compiler output during built-ins detection to or <code>null</code> if no
-	 *                separate console is to be allocated. Ignored if workspace preferences indicate that no console
-	 *                output is wanted.
-	 * @param monitor the job's progress monitor
-	 */
-	private void processCompileCommandsFile(IConsole console, IProgressMonitor monitor) throws CoreException
-	{
-		IFile file = getCompileCommandsJsonFile(monitor);
-		CompileCommandsJsonParser parser = new CompileCommandsJsonParser(
-				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation, getProject()),
-						CommandLauncherManager.getInstance().getCommandLauncher(this), console));
-		Job parseJob = new Job(Messages.IDFBuildConfiguration_ParseCommand)
-		{
-			protected IStatus run(IProgressMonitor monitor)
-			{
-				try
-				{
-					parser.parse(monitor);
-				}
-				catch (CoreException e)
-				{
-					Logger.log(e);
-				}
-				return Status.OK_STATUS;
-			}
-		};
-		parseJob.setJobGroup(jobGroup);
-		parseJob.schedule();
-	}
-
-	private IFile getCompileCommandsJsonFile(IProgressMonitor monitor) throws CoreException
-	{
-		IFile file = getBuildContainer().getFile(new org.eclipse.core.runtime.Path(COMPILE_COMMANDS_JSON));
-		if (hasCustomBuild())
-		{
-			org.eclipse.core.runtime.Path compileCmdJsonFile = new org.eclipse.core.runtime.Path(COMPILE_COMMANDS_JSON);
-			final IPath jsonIPath = getBuildContainerPath().append(compileCmdJsonFile);
-
-			IFolder folder = getIDFComponentsFolder();
-			String fileName = jsonIPath.toFile().getName();
-			file = folder.getFile(fileName);
-			if (!file.exists())
-			{
-				IFile folderLink = folder.getFile(fileName);
-				setLinkLocation(folderLink, jsonIPath);
-
-			}
-			getProject().refreshLocal(IResource.DEPTH_INFINITE, monitor);
-		}
-		return file;
-	}
 
 	/**
 	 * Recursively removes any files and directories found below the specified Path.
@@ -929,41 +704,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		if (Files.isDirectory(buildDir))
 			cleanDirectory(buildDir);
 		// TODO: not a directory should we do something?
-	}
-
-	/**
-	 * Overridden since the ScannerInfoCache mechanism does not satisfy our needs.
-	 */
-	// interface IScannerInfoProvider
-	@Override
-	public IScannerInfo getScannerInformation(IResource resource)
-	{
-
-		if (infoPerResource == null)
-		{
-			// no build was run yet, nothing detected
-			try
-			{
-
-				// It is crucial to set this property to 0. Otherwise, the infoPerResource will persist as null for this
-				// configuration. This occurs when the property has been modified in another configuration within the
-				// same project.
-				getCompileCommandsJsonFile(new NullProgressMonitor()).getParent()
-						.setSessionProperty(TIMESTAMP_COMPILE_COMMANDS_PROPERTY, Long.valueOf(0));
-
-				processCompileCommandsFile(null, new NullProgressMonitor());
-			}
-			catch (CoreException e)
-			{
-				Logger.log(e);
-			}
-		}
-		return infoPerResource == null ? null : infoPerResource.get(resource);
-	}
-
-	private void setScannerInformation(Map<IResource, IScannerInfo> infoPerResource)
-	{
-		this.infoPerResource = infoPerResource;
 	}
 
 	/**
@@ -1062,97 +802,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	private static void deleteCMakeErrorMarkers(IProject project) throws CoreException
 	{
 		project.deleteMarkers(CMakeErrorParser.CMAKE_PROBLEM_MARKER_ID, false, IResource.DEPTH_INFINITE);
-	}
-
-	private static class CMakeIndexerInfoConsumer implements ISourceFileInfoConsumer
-	{
-		/**
-		 * gathered IScannerInfo objects or <code>null</code> if no new IScannerInfo was received
-		 */
-		private Map<IResource, IScannerInfo> infoPerResource = new HashMap<>();
-		private boolean haveUpdates;
-		private final Consumer<Map<IResource, IScannerInfo>> resultSetter;
-		private IProject project;
-
-		/**
-		 * @param resultSetter receives the all scanner information when processing is finished
-		 * @param iProject
-		 */
-		public CMakeIndexerInfoConsumer(Consumer<Map<IResource, IScannerInfo>> resultSetter, IProject project)
-		{
-			this.resultSetter = Objects.requireNonNull(resultSetter);
-			this.project = project;
-		}
-
-		@Override
-		public void acceptSourceFileInfo(String sourceFileName, List<String> systemIncludePaths,
-				Map<String, String> definedSymbols, List<String> includePaths, List<String> macroFiles,
-				List<String> includeFiles)
-		{
-			IFile file = getFileForCMakePath(sourceFileName, project);
-			if (file != null)
-			{
-				systemIncludePaths.addAll(includePaths);
-
-				ExtendedScannerInfo info = new ExtendedScannerInfo(definedSymbols,
-						systemIncludePaths.stream().toArray(String[]::new), macroFiles.stream().toArray(String[]::new),
-						includeFiles.stream().toArray(String[]::new), includePaths.stream().toArray(String[]::new));
-				infoPerResource.put(file, info);
-				haveUpdates = true;
-			}
-		}
-
-		/**
-		 * Gets an IFile object that corresponds to the source file name given in CMake notation.
-		 *
-		 * @param sourceFileName the name of the source file, in CMake notation. Note that on windows, CMake writes
-		 *                       filenames with forward slashes (/) such as {@code H://path//to//source.c}.
-		 * @param project2
-		 * @return a IFile object or <code>null</code>
-		 */
-		private IFile getFileForCMakePath(String sourceFileName, IProject project)
-		{
-			org.eclipse.core.runtime.Path path = new org.eclipse.core.runtime.Path(sourceFileName);
-			IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
-			if (file != null)
-			{
-				return file;
-			}
-
-			String sourceFile = path.toOSString();
-			String pathtolookfor = new org.eclipse.core.runtime.Path(getIdfToolsPath()).append(COMPONENTS).toOSString(); // $NON-NLS-1$
-			int startIndex = sourceFile.indexOf(pathtolookfor);
-			if (startIndex == -1) // esp-idf/examples/
-			{
-				pathtolookfor = getIdfToolsPath();
-				startIndex = sourceFile.indexOf(pathtolookfor);
-			}
-			if (startIndex == -1) // source file still not found means it was part of another esp-idf
-			{
-				return null;
-			}
-			String relativePath = sourceFile.substring(startIndex + pathtolookfor.length() + 1);
-
-			IPath projectPath = getComponentsPath().append(relativePath);
-			IResource resourcePath = project.findMember(projectPath);
-			if (resourcePath instanceof IFile)
-			{
-				return (IFile) resourcePath;
-			}
-			return null;
-		}
-
-		@Override
-		public void shutdown()
-		{
-			if (haveUpdates)
-			{
-				// we received updates
-				resultSetter.accept(infoPerResource);
-				infoPerResource = null;
-				haveUpdates = false;
-			}
-		}
 	}
 
 	public void setLaunchTarget(ILaunchTarget target)


### PR DESCRIPTION
## Description

Remove all code related to creating links folders for esp_idf_components and CDT Indexing

Fixes # ([IEP-1196](https://jira.espressif.com:8443/browse/IEP-1196))

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Create a new project
- Build a project
- Verify that build/ide/esp_idf_components folder is not created with links to esp-idf components

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Indexing
- Build

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Significant restructuring of build configuration management, focusing on streamlining the process by removing outdated functionalities related to CMake, indexing, parsing, and linking of build components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->