### PR TITLE
fix: disable cdt indexer with the lsp plugin activation

### DIFF
--- a/bundles/com.espressif.idf.lsp/plugin.xml
+++ b/bundles/com.espressif.idf.lsp/plugin.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension
+         point="org.eclipse.ui.startup">
+      <startup
+            class="com.espressif.idf.lsp.LspPluginStartup">
+      </startup>
+   </extension>
 
 </plugin>

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/LspPluginStartup.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/LspPluginStartup.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2024 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.lsp;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.dom.IPDOMManager;
+import org.eclipse.ui.IStartup;
+
+/**
+ * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
+ */
+public class LspPluginStartup implements IStartup
+{
+
+	@Override
+	public void earlyStartup()
+	{
+		CCorePlugin.getIndexManager().setDefaultIndexerId(IPDOMManager.ID_NO_INDEXER);
+	}
+
+}


### PR DESCRIPTION
## Description

Disable cdt indexer with the lsp plugin activation

Fixes # ([IEP-1116](https://jira.espressif.com:8443/browse/IEP-1116))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Create a project
- Build a project
- Observe that CDT Indexer process is not triggered after the build completion
- Also verify that CDT Indexer enable option is disabled by default 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Indexer
- Build

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
