### PR TITLE
IEP-1198 Unclear message when another ESP-IDF path is found

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -29,9 +29,11 @@ public class Messages extends NLS
 
 	public static String ToolsInitializationDifferentPathMessageBoxMessage;
 	public static String ToolsInitializationDifferentPathMessageBoxTitle;
-	
+	public static String ToolsInitializationDifferentPathMessageBoxOptionYes;
+	public static String ToolsInitializationDifferentPathMessageBoxOptionNo;
+
 	public static String RefreshingProjects_JobName;
-	
+
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -19,5 +19,7 @@ IDFBuildConfiguration_ParseCommand=Parse Compile Commands File
 IncreasePartitionSizeTitle=Low Application Partition Size
 IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
 ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file
-ToolsInitializationDifferentPathMessageBoxMessage=A different IDF path was found in the startup configuration file do you want to install the tools in this path or keep the older path\nNew Path: {0}\nOld Path: {1}
+ToolsInitializationDifferentPathMessageBoxMessage=A different ESP-IDF path was found in the esp_idf.json.json configuration file. Do you want to install the tools in the new path or the old path? Please click on the appropriate button.\nNew Path: {0}\nOld Path: {1}
+ToolsInitializationDifferentPathMessageBoxOptionYes=Use New Path
+ToolsInitializationDifferentPathMessageBoxOptionNo=Use Old Path
 RefreshingProjects_JobName=Refreshing Projects...

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -115,6 +116,8 @@ public class InitializeToolsStartup implements IStartup
 			Display.getDefault().syncExec(() -> {
 				Shell shell = new Shell(Display.getDefault());
 				MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.YES | SWT.NO);
+				messageBox.setButtonLabels(Map.of(SWT.YES, Messages.ToolsInitializationDifferentPathMessageBoxOptionYes,
+						SWT.NO, Messages.ToolsInitializationDifferentPathMessageBoxOptionNo));
 				messageBox.setText(Messages.ToolsInitializationDifferentPathMessageBoxTitle);
 				messageBox.setMessage(MessageFormat.format(Messages.ToolsInitializationDifferentPathMessageBoxMessage,
 						newIdfPath, idfEnvMgr.getEnvValue(IDFEnvironmentVariables.IDF_PATH)));
@@ -122,7 +125,8 @@ public class InitializeToolsStartup implements IStartup
 				if (response == SWT.NO)
 				{
 					IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
-					updateEspIdfJsonFile(idf_json_file, idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_PATH));
+					updateEspIdfJsonFile(idf_json_file,
+							idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_PATH));
 					Preferences prefs = getPreferences();
 					prefs.putBoolean(IS_INSTALLER_CONFIG_SET, true);
 					try
@@ -204,8 +208,7 @@ public class InitializeToolsStartup implements IStartup
 	@SuppressWarnings("unchecked")
 	private void openAvailableHintsDialog(PropertyChangeEvent evt)
 	{
-		Display.getDefault().asyncExec(() ->
-		{
+		Display.getDefault().asyncExec(() -> {
 			List<ReHintPair> erroHintPairs = (List<ReHintPair>) evt.getNewValue();
 			// if list is empty we don't want to change focus from the console output
 			if (erroHintPairs.isEmpty())
@@ -215,16 +218,14 @@ public class InitializeToolsStartup implements IStartup
 			}
 			try
 			{
-				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
-						.showView(BUILDHINTS_ID);
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(BUILDHINTS_ID);
 			}
 			catch (PartInitException e)
 			{
 				Logger.log(e);
 			}
 			updateValuesInBuildView(erroHintPairs);
-		}
-		);
+		});
 
 	}
 
@@ -240,13 +241,12 @@ public class InitializeToolsStartup implements IStartup
 
 	private void openLowPartitionSizeDialog(PropertyChangeEvent evt)
 	{
-		Display.getDefault().asyncExec(() ->
-				MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
+		Display.getDefault()
+				.asyncExec(() -> MessageLinkDialog.openWarning(Display.getDefault().getActiveShell(),
 						Messages.IncreasePartitionSizeTitle, MessageFormat.format(Messages.IncreasePartitionSizeMessage,
-								evt.getNewValue(), evt.getOldValue(), DOC_URL))
-			);
+								evt.getNewValue(), evt.getOldValue(), DOC_URL)));
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private void updateEspIdfJsonFile(File idf_json_file, String newIdfPathToUpdate)
 	{


### PR DESCRIPTION
## Description

 
Make warning message when different IDF version is detected in esp-idf.json more intuitive
Fixes # ([IEP-1198](https://jira.espressif.com:8443/browse/IEP-1198))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved messaging for ESP-IDF path configuration, offering clearer instructions and options to users.
- **Refactor**
	- Enhanced code readability and maintainability in tool initialization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->