### PR TITLE
fix: Change preference name from CMake cache to Ccache

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
@@ -1,6 +1,6 @@
 EspresssifPreferencesPage_BuildGroupTxt=Build Settings
-EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build
-EspresssifPreferencesPage_EnableCCache=Enable CMake cache
+EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build, if the CCache tool is installed
+EspresssifPreferencesPage_EnableCCache=Enable Ccache
 EspresssifPreferencesPage_IDFSpecificPrefs=ESP-IDF Specific Preferences.
 EspresssifPreferencesPage_SearchHintsCheckBtn=Search hints for build errors (may affect build performance)
 EspresssifPreferencesPage_SearchHintsTooltip=If enabled, a Build Hints view will automatically open after a build


### PR DESCRIPTION
## Description

Changed preference name from CMake cache to Ccache and improved the tooltip message

Fixes # ([IEP-1205](https://jira.espressif.com:8443/browse/IEP-1205))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Open Espressif preferences
- Verify that preferences name changed from **Enable CMake** cache to **Enable Ccache**

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Preferences

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated tooltip and label for enabling CCache in the IDF CMake build to clarify the requirement of installing the CCache tool and enhance consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->