### PR TITLE
feat: Bundled JRE 17 with Espressif-IDE

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -40,6 +40,37 @@
 				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.full-17</executionEnvironment>
+					<environments>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
 		</plugins>
-	</build>
+	</build>	
+		
 </project>

--- a/releng/com.espressif.idf.configuration/pom.xml
+++ b/releng/com.espressif.idf.configuration/pom.xml
@@ -38,6 +38,7 @@
 					</target>
 					<resolver>p2</resolver>
 					<pomDependencies>consider</pomDependencies>
+					<executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.full-17</executionEnvironment>
 					<environments>
 						<environment>
 							<os>linux</os>

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -42,10 +42,10 @@
    <intro introId="com.espressif.idf.ui.intro"/>
 
    <vm>
-      <linux include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
-      <macos include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</macos>
       <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</solaris>
-      <windows include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</windows>
    </vm>
 
    <plugins>
@@ -55,6 +55,7 @@
       <feature id="com.espressif.idf.feature" installMode="root"/>
       <feature id="org.eclipse.cdt" installMode="root"/>
       <feature id="org.eclipse.cdt.gdb" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full" installMode="root"/>
       <feature id="org.eclipse.cdt.gnu.build" installMode="root"/>
       <feature id="org.eclipse.cdt.gnu.debug" installMode="root"/>
       <feature id="org.eclipse.cdt.gnu.dsf" installMode="root"/>

--- a/releng/com.espressif.idf.product/pom.xml
+++ b/releng/com.espressif.idf.product/pom.xml
@@ -114,6 +114,7 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.full-17</executionEnvironment>
 					<environments>
 						<environment>
 							<os>win32</os>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -139,6 +139,10 @@
 			<repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository"/>
 			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.14.0.202301260747"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="17.0.11.v20240426-1830"/>
+		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
 			<dependencies>
 				<dependency>


### PR DESCRIPTION
## Description

Bundled JRE 17 with Espressif-IDE


## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Download Espressif-IDE from this PR on different platforms and verify that espressif-ide.ini contains lines such as 
"-vm
plugins/org.eclipse.justj.openjdk.hotspot.jre.full.win32.x86_64_17.0.11.v20240426-1830/jre/bin"
- Espressif-IDE should run without installing Java
- 
**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced compatibility by updating Java SE version from 11 to 17 for Linux, macOS, and Windows platforms.
	- Added support for OpenJDK Hotspot JRE.
  
- **Refactor**
	- Updated target platform configurations across various modules to improve performance and compatibility with different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->