### PR TITLE
Fix: added batik plugins for TM4E plugin to dependencies 

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -65,25 +65,11 @@
 			<repository location="https://download.eclipse.org/egit/updates"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.apache.batik.xml" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.dom" version="1.16.0.v20230210-1249"/>
 			<unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
 			<unit id="org.apache.batik.util" version="1.16.0.v20221027-0840"/>
 			<unit id="org.apache.batik.i18n" version="1.16.0.v20221027-0840"/>
 			<unit id="org.apache.batik.constants" version="1.16.0.v20221027-0840"/>
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
-			<unit id="org.apache.batik.anim" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.awt.util" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.bridge" version="1.16.0.v20230210-1249"/>
-			<unit id="org.apache.batik.codec" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.dom.svg" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.ext" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.gvt" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.parser" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.script" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.shared.resources" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.svggen" version="1.16.0.v20221027-0840"/>
-			<unit id="org.apache.batik.transcoder" version="1.16.0.v20221027-0840"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -90,6 +90,9 @@
    <bundle id="org.snakeyaml.engine">
       <category name="com.espressif.idf.dependencies"/>
    </bundle>
+   <bundle id="org.apache.batik.i18n">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>
          ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -93,6 +93,15 @@
    <bundle id="org.apache.batik.i18n">
       <category name="com.espressif.idf.dependencies"/>
    </bundle>
+   <bundle id="org.apache.batik.css">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.constants">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
+   <bundle id="org.apache.batik.util">
+      <category name="com.espressif.idf.dependencies"/>
+   </bundle>
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>
          ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications


### PR DESCRIPTION
## Description

We don't need these batik plugins if we are using latest Espressif-IDE or using latest eclipse-cdt and update site because latest batik dependencies pick up automatically for that case, but if we update older version of Espressif-IDE with latest update site these batik dependencies could be missing. As solution, in this pr I added required batik dependecies for TM4E to depencies in category.xml

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

update the older version of Espressif-IDE and install dependencies from the list in the update site -> verify that syntax highlight works along with other functionalities

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Removed various outdated components to streamline the application and enhance performance.
- **New Features**
  - Integrated new internationalization support to improve user experience across different languages.
- **Bug Fixes**
  - Added missing bundles to ensure proper functionality and prevent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->