### PR TITLE
IEP-1223 Update clangd drivers path based on the target change

### DIFF
--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdOptionsDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdOptionsDefaults.java
@@ -30,11 +30,11 @@ public class IDFClangdOptionsDefaults extends BuiltinClangdOptionsDefaults
 		Logger.log("clangd: " + clandPath); //$NON-NLS-1$
 		return Optional.ofNullable(clandPath).orElse(ILSPConstants.CLANGD_EXECUTABLE);
 	}
-	
+
 	@Override
 	public String queryDriver()
 	{
-		//By passing --query-driver argument to clangd helps to resolve the cross-compiler toolchain headers.
+		// By passing --query-driver argument to clangd helps to resolve the cross-compiler toolchain headers.
 		String toolchainPath = IDFUtil.getToolchainExePathForActiveTarget();
 		Logger.log("toolchain path: " + toolchainPath); //$NON-NLS-1$
 		return Optional.ofNullable(toolchainPath).orElse(super.queryDriver());

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -46,7 +46,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tools.templates.freemarker,
  org.eclipse.cdt.lsp;bundle-version="1.0.0",
  org.eclipse.cdt.lsp.clangd;bundle-version="1.0.0",
- com.espressif.idf.lsp
+ com.espressif.idf.lsp,
+ org.eclipse.lsp4e
 Automatic-Module-Name: com.espressif.idf.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -5,9 +5,14 @@
 package com.espressif.idf.ui;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.MessageFormat;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
+import org.eclipse.cdt.lsp.LspUtils;
+import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
+import org.eclipse.cdt.lsp.editor.Configuration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -16,6 +21,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
@@ -25,6 +31,7 @@ import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.ui.ILaunchBarUIManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.build.IDFLaunchConstants;
@@ -59,10 +66,37 @@ public class LaunchBarListener implements ILaunchBarListener
 				if (!StringUtil.isEmpty(targetName) && (!targetChangeIgnored))
 				{
 					update(targetName);
+					updateLspQueryDrivers();
+					restartLspServers();
 				}
 			}
 		});
 
+	}
+
+	@SuppressWarnings("restriction")
+	private void restartLspServers()
+	{
+		LspUtils.getLanguageServers().forEach(w -> {
+			try
+			{
+				w.restart();
+			}
+			catch (IOException e)
+			{
+				Logger.log(e);
+			}
+		});
+	}
+
+	@SuppressWarnings("restriction")
+	private void updateLspQueryDrivers()
+	{
+		Configuration configuration = PlatformUI.getWorkbench().getService(ClangdConfiguration.class);
+		ClangdMetadata metadata = (ClangdMetadata) configuration.metadata();
+		String qualifier = configuration.qualifier();
+		InstanceScope.INSTANCE.getNode(qualifier).put(metadata.queryDriver().identifer(),
+				metadata.queryDriver().defaultValue());
 	}
 
 	private void update(String newTarget)


### PR DESCRIPTION
## Description

Update clangd drivers path based on the target change and restart clangd server

Fixes # ([IEP-1223](https://jira.espressif.com:8443/browse/IEP-1223))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Test A:
select esp32 target -> check the LSP editor preferences -> query drivers points to according toolchain 
change the target in the launch bar -> check the LSP editor preferences -> query drivers points to according toolchain 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to restart LSP servers and update query drivers, enhancing language server interactions and configurations.

- **Dependencies**
  - Updated dependencies to include `org.eclipse.lsp4e`, improving integration with Eclipse LSP4E framework.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->