### PR TITLE
IEP-1230, IEP-1231: ESP-IDF Version Switching and build impact

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -24,6 +24,7 @@ public class Messages extends NLS
 	public static String CMakeErrorParser_NotAWorkspaceResource;
 	public static String IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile;
 	public static String IDFBuildConfiguration_ParseCommand;
+	public static String IDFBuildConfiguration_PreCheck_DifferentIdfPath;
 	public static String IncreasePartitionSizeTitle;
 	public static String IncreasePartitionSizeMessage;
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -23,3 +23,4 @@ ToolsInitializationDifferentPathMessageBoxMessage=A different ESP-IDF path was f
 ToolsInitializationDifferentPathMessageBoxOptionYes=Use New Path
 ToolsInitializationDifferentPathMessageBoxOptionNo=Use Old Path
 RefreshingProjects_JobName=Refreshing Projects...
+IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path. The currently active ESP-IDF path in the IDE is {1}. Please clean the project using ESP-IDF:Project Clean menu option to use the active ESP-IDF configuration. 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ProjectDescriptionReader.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ProjectDescriptionReader.java
@@ -1,6 +1,8 @@
 package com.espressif.idf.core.util;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -37,7 +39,7 @@ public class ProjectDescriptionReader
 
 	private String getAppElfFileName()
 	{
-		String appElfFileName = ""; //$NON-NLS-1$
+		String appElfFileName = StringUtil.EMPTY;
 		try
 		{
 			String buildDir = IDFUtil.getBuildDir(project);
@@ -51,5 +53,27 @@ public class ProjectDescriptionReader
 		}
 
 		return appElfFileName;
+	}
+	
+	public String getIdfPath()
+	{
+		String idfPath = StringUtil.EMPTY;
+		try
+		{
+			String buildDir = IDFUtil.getBuildDir(project);
+			String filePath = buildDir + File.separator + IDFConstants.PROECT_DESCRIPTION_JSON;
+			if (Files.notExists(Paths.get(filePath)))
+			{
+				return idfPath;
+			}
+			GenericJsonReader jsonReader = new GenericJsonReader(filePath);
+			idfPath = jsonReader.getValue("idf_path"); //$NON-NLS-1$
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+
+		return idfPath;
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJob.java
@@ -362,7 +362,6 @@ public abstract class ToolsJob extends Job
 			while ((line = reader.readLine()) != null)
 			{
 				output.append(line).append(System.lineSeparator());
-				console.println(line);
 			}
 			
 			while (process.isAlive() && waitCount > 0)


### PR DESCRIPTION
## Description

ESP-IDF Version Switching and build impact. The build was not working and not showing any proper message to user if the active version was switched and project was built using someother version of idf. Now added a proper message to the console to let user know they need to clean before trying to build the project with currently active version
Also fixed redundant output of the targets when activating a different idf version from esp-idf manager

Fixes # ([IEP-1230](https://jira.espressif.com:8443/browse/IEP-1230), [IEP-1231](https://jira.espressif.com:8443/browse/IEP-1231))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please follow steps in original ticket to verify

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
