### PR TITLE
fix: fixed typo in after build message

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -298,7 +298,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		{
 			Logger.log(e);
 		}
-		
+
 		this.monitor = monitor;
 		isProgressSet = false;
 
@@ -353,7 +353,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		ProjectDescriptionReader projectDescriptionReader = new ProjectDescriptionReader(getProject());
 		String projectDescriptionIdfPath = projectDescriptionReader.getIdfPath();
 		Path pathPdIdfPath = Paths.get(projectDescriptionIdfPath);
-		
+
 		if (StringUtil.isEmpty(projectDescriptionIdfPath))
 		{
 			return true;
@@ -361,25 +361,26 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
 		String envIdfPath = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.IDF_PATH);
 		Path pathEnvIdf = Paths.get(envIdfPath);
-		
+
 		boolean samePaths = false;
 		if (Platform.getOS().equals(Platform.OS_WIN32))
 		{
 			samePaths = pathEnvIdf.toString().equalsIgnoreCase(pathPdIdfPath.toString());
 		}
-		else 
+		else
 		{
 			samePaths = pathEnvIdf.toString().equals(pathPdIdfPath.toString());
 		}
-		
+
 		if (!samePaths)
 		{
-			String outputMessage = MessageFormat.format(Messages.IDFBuildConfiguration_PreCheck_DifferentIdfPath, projectDescriptionIdfPath, envIdfPath);
+			String outputMessage = MessageFormat.format(Messages.IDFBuildConfiguration_PreCheck_DifferentIdfPath,
+					projectDescriptionIdfPath, envIdfPath);
 			console.getInfoStream().write(outputMessage);
-			
+
 			return false;
 		}
-		
+
 		return true;
 	}
 
@@ -489,9 +490,9 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		infoStream.write("\n");//$NON-NLS-1$
 		infoStream.write("\n");//$NON-NLS-1$
 		infoStream.write(
-				"2. To enable source code navigation (i.e., navigation to .c files), you need to set compile-commands-cmd argument to clangd with the build folder." //$NON-NLS-1$
+				"2. To enable source code navigation (i.e., navigation to .c files), you need to set compile-commands-dir argument to clangd with the build folder." //$NON-NLS-1$
 						+ String.format(
-								"%nTo do this, navigate to Preferences > C/C++ > Build > Editor(LSP) > clangd and set --compile-commands-cmd=%s in the additional arguments text area.", //$NON-NLS-1$
+								"%nTo do this, navigate to Preferences > C/C++ > Build > Editor(LSP) > clangd and set --compile-commands-dir=%s in the additional arguments text area.", //$NON-NLS-1$
 								workingDir));
 		infoStream.write("\n");//$NON-NLS-1$
 	}


### PR DESCRIPTION
## Description

It should be compile-commands-dir instead of compile-commands-cmd in after build message

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability and maintainability through minor modifications, including whitespace adjustments, string formatting updates, and code reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->