### PR TITLE
IEP-1246 Set --compile-commands-dir=<path> for the current project which the user is trying to build

### DIFF
--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -28,7 +28,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,
  org.eclipse.embedcdt.core;visibility:=reexport,
  com.sun.jna,
- com.sun.jna.platform
+ com.sun.jna.platform,
+ org.eclipse.cdt.lsp.clangd,
+ org.eclipse.cdt.lsp,
+ org.eclipse.lsp4e
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -90,6 +90,7 @@ import com.espressif.idf.core.util.ClangdConfigFileHandler;
 import com.espressif.idf.core.util.DfuCommandsUtil;
 import com.espressif.idf.core.util.HintsUtil;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.ParitionSizeHandler;
 import com.espressif.idf.core.util.ProjectDescriptionReader;
 import com.espressif.idf.core.util.StringUtil;
@@ -469,7 +470,9 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 				if (getToolChain() instanceof GCCToolChain toolchain)
 					writeConsoleNotes(infoStream, workingDir.toOSString(), toolchain.getPath().toString());
-
+				LspService lspService = new LspService();
+				lspService.updateAdditionalOptions(String.format("--compile-commands-dir=%s", buildDir)); //$NON-NLS-1$
+				lspService.restartLspServers();
 			}
 
 			infoStream.write(MessageFormat.format("Total time taken to build the project: {0} ms", timeElapsed)); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2024 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.eclipse.cdt.lsp.LspUtils;
+import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
+import org.eclipse.cdt.lsp.editor.Configuration;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.lsp4e.LanguageServerWrapper;
+import org.eclipse.ui.PlatformUI;
+
+import com.espressif.idf.core.logging.Logger;
+
+@SuppressWarnings("restriction")
+public class LspService
+{
+	private final Configuration configuration;
+	private final Stream<LanguageServerWrapper> languageServerWrappers;
+
+	public LspService()
+	{
+		this(PlatformUI.getWorkbench().getService(ClangdConfiguration.class), LspUtils.getLanguageServers());
+	}
+
+	public LspService(Configuration configuration, Stream<LanguageServerWrapper> languageServerWrappers)
+	{
+		this.configuration = configuration;
+		this.languageServerWrappers = languageServerWrappers;
+	}
+
+	public void restartLspServers()
+	{
+		languageServerWrappers.forEach(w -> {
+			try
+			{
+				w.restart();
+			}
+			catch (IOException e)
+			{
+				Logger.log(e);
+			}
+		});
+	}
+
+	public void updateAdditionalOptions(String additionalOptions)
+	{
+		if (configuration.metadata() instanceof ClangdMetadata metadata)
+		{
+			String qualifier = configuration.qualifier();
+			InstanceScope.INSTANCE.getNode(qualifier).put(metadata.additionalOptions().identifer(), additionalOptions);
+		}
+	}
+
+	public void updateLspQueryDrivers()
+	{
+		if (configuration.metadata() instanceof ClangdMetadata metadata)
+		{
+			String qualifier = configuration.qualifier();
+			InstanceScope.INSTANCE.getNode(qualifier).put(metadata.queryDriver().identifer(),
+					metadata.queryDriver().defaultValue());
+		}
+	}
+
+}

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -45,9 +45,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.freemarker.freemarker,
  org.eclipse.tools.templates.freemarker,
  org.eclipse.cdt.lsp;bundle-version="1.0.0",
- org.eclipse.cdt.lsp.clangd;bundle-version="1.0.0",
- com.espressif.idf.lsp,
- org.eclipse.lsp4e
+ org.eclipse.cdt.lsp.clangd;bundle-version="1.0.0"
 Automatic-Module-Name: com.espressif.idf.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -5,14 +5,9 @@
 package com.espressif.idf.ui;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.MessageFormat;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
-import org.eclipse.cdt.lsp.LspUtils;
-import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
-import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
-import org.eclipse.cdt.lsp.editor.Configuration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -21,7 +16,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
@@ -31,12 +25,12 @@ import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.ui.ILaunchBarUIManager;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.SDKConfigJsonReader;
 import com.espressif.idf.core.util.StringUtil;
 
@@ -66,37 +60,13 @@ public class LaunchBarListener implements ILaunchBarListener
 				if (!StringUtil.isEmpty(targetName) && (!targetChangeIgnored))
 				{
 					update(targetName);
-					updateLspQueryDrivers();
-					restartLspServers();
+					LspService lspService = new LspService();
+					lspService.updateLspQueryDrivers();
+					lspService.restartLspServers();
 				}
 			}
 		});
 
-	}
-
-	@SuppressWarnings("restriction")
-	private void restartLspServers()
-	{
-		LspUtils.getLanguageServers().forEach(w -> {
-			try
-			{
-				w.restart();
-			}
-			catch (IOException e)
-			{
-				Logger.log(e);
-			}
-		});
-	}
-
-	@SuppressWarnings("restriction")
-	private void updateLspQueryDrivers()
-	{
-		Configuration configuration = PlatformUI.getWorkbench().getService(ClangdConfiguration.class);
-		ClangdMetadata metadata = (ClangdMetadata) configuration.metadata();
-		String qualifier = configuration.qualifier();
-		InstanceScope.INSTANCE.getNode(qualifier).put(metadata.queryDriver().identifer(),
-				metadata.queryDriver().defaultValue());
 	}
 
 	private void update(String newTarget)


### PR DESCRIPTION
## Description

Set --compile-commands-dir=<path> for the current project which the user is trying to build

Fixes # ([IEP-1246](https://jira.espressif.com:8443/browse/IEP-1246))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Test A:
build project -> check additional lsp options -> --compile-commands-dir points to the right path
Test B:
change the target -> check query drivers -> points to correct toolchain

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- LSP editor

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced management of Language Server Protocol (LSP) servers, including restarting servers and updating configuration options.

- **Refactor**
  - Streamlined dependencies and imports related to LSP services for improved performance and maintainability.
  - Replaced deprecated LSP utility methods with new `LspService` methods for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->