### PR TITLE
fix: Terminal ESP-IDF Path conflict issues

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
@@ -382,7 +382,7 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 				String idfExtraPaths = IDFUtil.getIDFExtraPaths();
 				if(!StringUtil.isEmpty(idfExtraPaths))
 				{
-					envValue = envValue + ":" + idfExtraPaths; //$NON-NLS-1$
+					envValue = idfExtraPaths + ":" + envValue; //$NON-NLS-1$
 				}
 			}
 			envpList.add(envKey + "=" + envValue); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
@@ -302,6 +302,16 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_DEFAULT_SHELL_UNIX_ARGS);
 		}
 
+		// Avoding profiles to isolate PATH enviroment
+		arguments = ""; //$NON-NLS-1$
+		if (image.contains("bash")) { //$NON-NLS-1$
+			arguments = "--noprofile --norc"; //$NON-NLS-1$
+		} else if (image.contains("zsh")) { //$NON-NLS-1$
+			arguments = "--no-rcs --no-globalrcs"; //$NON-NLS-1$
+		} else if (image.contains("powershell")) { //$NON-NLS-1$
+			arguments = "-NoProfile"; //$NON-NLS-1$
+		}
+
 		// Determine if a PTY will be used
 		boolean isUsingPTY = (properties.get(ITerminalsConnectorConstants.PROP_PROCESS_OBJ) == null
 				&& PTY.isSupported(PTY.Mode.TERMINAL))
@@ -375,13 +385,13 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 		//Set CDT build environment variables
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
 		Set<String> keySet = envMap.keySet();
+
 		for (String envKey : keySet) {
 			String envValue = envMap.get(envKey);
 			if (envKey.equals("PATH")) //$NON-NLS-1$
 			{
 				String idfExtraPaths = IDFUtil.getIDFExtraPaths();
-				if(!StringUtil.isEmpty(idfExtraPaths))
-				{
+				if (!StringUtil.isEmpty(idfExtraPaths)) {
 					envValue = idfExtraPaths + ":" + envValue; //$NON-NLS-1$
 				}
 			}
@@ -394,11 +404,10 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 		Assert.isTrue(image != null || process != null);
 
 		String terminalWrkDir = getWorkingDir();
-		if (StringUtil.isEmpty(terminalWrkDir))
-		{
+		if (StringUtil.isEmpty(terminalWrkDir)) {
 			terminalWrkDir = workingDir;
 		}
-		
+
 		// Construct the terminal settings store
 		ISettingsStore store = new SettingsStore();
 
@@ -420,7 +429,6 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 			processSettings
 					.setMergeWithNativeEnvironment(value instanceof Boolean ? ((Boolean) value).booleanValue() : false);
 		}
-
 		// And save the settings to the store
 		processSettings.save(store);
 
@@ -435,7 +443,7 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 
 		return connector;
 	}
-	
+
 	protected String getWorkingDir() {
 		Bundle bundle = Platform.getBundle("org.eclipse.core.resources"); //$NON-NLS-1$
 		if (bundle != null && bundle.getState() != Bundle.UNINSTALLED && bundle.getState() != Bundle.STOPPING) {


### PR DESCRIPTION
## Description

**The problem:**
Everything works fine when l'm building applications through launch bar icons, but it fails when using the idf.py command from the terminal.
 
**The reason:**
I've installed ESP-IDF using the IDF installer, which configures the IDF_PATH environment variable in the system path. However, when launching the ESP-IDF terminal, you're also setting IDF_PATH and tool paths. Since these are added to the end of the system path, they take precedence  and causing the conflict.

**Solution:**
Instead of appending it to the end of the system path, adding the CDT build environment PATH to the front ensures it takes precedence

Fixes # ([IEP-1249](https://jira.espressif.com:8443/browse/IEP-1249))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Install ESP-IDF 5.1 using command line tools
- Setup IDE
- Install ESP-IDF 5.2 using the IDE
- Go the ESP-IDF terminal and run idf.py build or idf.py reconfigure command and observe that idf.py is considered from the 5.1 path not from the 5.2 

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- ESP-IDF Terminal

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved environment variable handling to ensure `idfExtraPaths` are correctly prioritized in the terminal connector setup.
	- Enhanced terminal initialization by preventing user profile loading for specific shell types, optimizing the terminal's `PATH` resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->