### PR TITLE
IEP-1254: Fixing message to reflect ESP-IDF: Project Full Clean not just Project Clean for switched ESP-IDF Version

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -23,4 +23,4 @@ ToolsInitializationDifferentPathMessageBoxMessage=A different ESP-IDF path was f
 ToolsInitializationDifferentPathMessageBoxOptionYes=Use New Path
 ToolsInitializationDifferentPathMessageBoxOptionNo=Use Old Path
 RefreshingProjects_JobName=Refreshing Projects...
-IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path.\nThe currently active ESP-IDF path in the IDE is {1}.\nPlease clean the project using "ESP-IDF:Project Clean" menu option to use the active ESP-IDF configuration. 
+IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path.\nThe currently active ESP-IDF path in the IDE is {1}.\nPlease clean the project using "ESP-IDF:Project Full Clean" menu option to use the active ESP-IDF configuration. 


### PR DESCRIPTION
## Description

Fixing message to reflect ESP-IDF: Project Full Clean not just Project Clean for switched ESP-IDF Version

Fixes # ([IEP-1254](https://jira.espressif.com:8443/browse/IEP-1254))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Install two versions for esp-idf and build the project and then try to switch the esp-idf to another version and build project the updated message should reflect the user about using ESP-IDF:Project Full Clean command not Project Clean

## Checklist
- [x] PR Self Reviewed
- [x] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the message related to ESP-IDF path configuration to instruct users to perform a "Project Full Clean" instead of "Project Clean" for using the active ESP-IDF configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->