### PR TITLE
feat: added support for multi_config

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -68,7 +68,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.DebugPlugin;
@@ -180,13 +179,19 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	{
 		String userArgs = getProperty(CMAKE_ARGUMENTS);
 		// Custom build directory
-		int buildDirIndex = userArgs.indexOf("-B"); //$NON-NLS-1$
-		customBuildDir = buildDirIndex == -1 ? StringUtil.EMPTY
-				: userArgs.replaceFirst("-B", StringUtil.EMPTY).stripLeading(); //$NON-NLS-1$
+		String[] cmakeArgumentsArr = userArgs.split(" "); //$NON-NLS-1$
+		customBuildDir = StringUtil.EMPTY;
+		for (int i = 0; i < cmakeArgumentsArr.length; i++)
+		{
+			if (cmakeArgumentsArr[i].equals("-B")) //$NON-NLS-1$
+			{
+				customBuildDir = cmakeArgumentsArr[i + 1];
+				break;
+			}
+		}
 		try
 		{
-			getProject().setPersistentProperty(
-					new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY), customBuildDir);
+			IDFUtil.setBuildDir(getProject(), customBuildDir);
 		}
 		catch (CoreException e)
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -78,7 +78,7 @@ public class IDFUtil
 				+ IDFConstants.IDF_PYTHON_SCRIPT;
 		return new File(idf_py_script);
 	}
-	
+
 	/**
 	 * @return idf.py file path based on the IDF_PATH given in the argument
 	 */
@@ -110,7 +110,7 @@ public class IDFUtil
 				+ IDFConstants.IDF_TOOLS_SCRIPT;
 		return new File(idf_py_script);
 	}
-	
+
 	/**
 	 * @return idf_tools.py file path based on the IDF_PATH given in the argument
 	 */
@@ -360,7 +360,7 @@ public class IDFUtil
 		}
 		return getXtensaToolchainExecutablePathByTarget(projectEspTarget);
 	}
-	
+
 	public static String getToolchainExePathForActiveTarget()
 	{
 		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
@@ -543,6 +543,19 @@ public class IDFUtil
 	}
 
 	/**
+	 * Sets project build directory
+	 * 
+	 * @param project
+	 * @param pathToBuildDir
+	 * @throws CoreException
+	 */
+	public static void setBuildDir(IProject project, String pathToBuildDir) throws CoreException
+	{
+		project.setPersistentProperty(new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY),
+				pathToBuildDir);
+	}
+
+	/**
 	 * Project .map file path
 	 *
 	 * @param project
@@ -672,7 +685,7 @@ public class IDFUtil
 		}
 		return new SDKConfigJsonReader(project).getValue("IDF_TARGET"); //$NON-NLS-1$
 	}
-	
+
 	public static IProject getProjectFromActiveLaunchConfig() throws CoreException
 	{
 		final ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
@@ -682,10 +695,10 @@ public class IDFUtil
 		{
 			return mappedResources[0].getProject();
 		}
-		
+
 		return null;
 	}
-	
+
 	public static String getGitExecutablePathFromSystem()
 	{
 		IPath gitPath = new SystemExecutableFinder().find("git"); //$NON-NLS-1$
@@ -694,7 +707,7 @@ public class IDFUtil
 		{
 			return gitPath.toOSString();
 		}
-		
+
 		if (Platform.OS_WIN32.equals(Platform.getOS()))
 		{
 			GitWinRegistryReader gitWinRegistryReader = new GitWinRegistryReader();
@@ -735,7 +748,7 @@ public class IDFUtil
 		}
 		return StringUtil.EMPTY;
 	}
-	
+
 	public static boolean isReparseTag(File file)
 	{
 		if (!Platform.getOS().equals(Platform.OS_WIN32))

--- a/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/server/ConfigServerManager.java
+++ b/bundles/com.espressif.idf.sdk.config.core/src/com/espressif/idf/sdk/config/core/server/ConfigServerManager.java
@@ -49,7 +49,7 @@ public class ConfigServerManager
 			jsonConfigServer.start();
 			return jsonConfigServer;
 		}
-		
+
 		return jsonConfigServer;
 	}
 	
@@ -72,13 +72,14 @@ public class ConfigServerManager
 	        if (o == null || getClass() != o.getClass()) return false;
 	        ProjectFileMapKey that = (ProjectFileMapKey) o;
 	        
-	        return project.getName().equals(that.project.getName()) && file.getName().equals(that.file.getName());
+			return project.getName().equals(that.project.getName())
+					&& file.getLocation().equals(that.file.getLocation());
 	    }
 		
 		@Override
 		public int hashCode()
 		{
-			return Objects.hash(project.getName(), file.getName());
+			return Objects.hash(project.getName(), file.getLocation());
 		}
 	}
 }


### PR DESCRIPTION
## Description

added ability to run sdkconfig from any build folder

Fixes # ([IEP-1250](https://jira.espressif.com:8443/browse/IEP-1250))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Create the multi_conf project example. 
- Try to build with different custom build folders
- run sdkconfigs from different directories 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of custom build directories in project settings.
	- Enhanced SDK configuration management with new methods for setting and managing build folders.

- **Bug Fixes**
	- Corrected logic for extracting build directories from CMake arguments.

- **Enhancements**
	- Refined error handling and UI creation for SDK configuration files.
	- Updated logic in configuration server management for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->