### PR TITLE
IEP-1255: Adding option to remove all versions

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/ToolSetConfigurationManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/ToolSetConfigurationManager.java
@@ -50,6 +50,21 @@ public class ToolSetConfigurationManager
 	{
 		reload = true;
 		getIdfToolSets(false);
+		// cleanup the env and toolchains
+		IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
+		idfEnvironmentVariables.removeAllEnvVariables();
+		try
+		{
+			ESPToolChainManager espToolChainManager = new ESPToolChainManager();
+			espToolChainManager.removeCmakeToolChains();
+			espToolChainManager.removeStdToolChains();	
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
+		
+		// update the json now to remove the idf from it.
 		List<IDFToolSet> idfToolSetsToExport = new ArrayList<IDFToolSet>();
 		for (IDFToolSet idfTool : idfToolSets)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFNewToolsWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/install/IDFNewToolsWizard.java
@@ -333,7 +333,7 @@ public class IDFNewToolsWizard extends Wizard
 			Display.getDefault().asyncExec(() -> {
 				if (espidfMainTablePage != null)
 				{
-					espidfMainTablePage.refreshTable();
+					espidfMainTablePage.refreshEditorUI();
 				}
 			});
 			

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/Messages.java
@@ -116,11 +116,12 @@ public class Messages extends NLS
 	public static String EspIdfManagerStateCol;
 	public static String EspIdfManagerActivateCol;
 	public static String EspIdfManagerAddToolsBtn;
+	public static String EspIdfManagerRemoveAllBtn;
 	public static String EspIdfManagerDeleteBtn;
-	public static String EspIdfManagerMessageBoxActiveToolchainDelete;
-	public static String EspIdfManagerMessageBoxActiveToolchainDeleteTitle;
 	public static String EspIdfManagerMessageBoxDeleteConfirmMessage;
 	public static String EspIdfManagerMessageBoxDeleteConfirmMessageTitle;
+	public static String EspIdfManagerMessageBoxDeleteAllConfirmMessage;
+	public static String EspIdfManagerMessageBoxDeleteAllConfirmMessageTitle;
 	
 	public static String IDFDownloadHandler_ESPIDFConfiguration;
 	public static String IDFDownloadHandler_DownloadPage_Title;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJobListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJobListener.java
@@ -49,7 +49,7 @@ public class ToolsActivationJobListener extends JobChangeAdapter
 		Display.getDefault().asyncExec(() -> {
 			if (espidfMainTablePage != null)
 			{
-				espidfMainTablePage.refreshTable();
+				espidfMainTablePage.refreshEditorUI();
 			}
 		});
 		OpenDialogListenerSupport.getSupport().firePropertyChange(PopupDialog.ENABLE_LAUNCHBAR_EVENTS.name(), null,

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/messages.properties
@@ -118,11 +118,12 @@ EspIdfManagerLocationCol=Location
 EspIdfManagerStateCol=State
 EspIdfManagerActivateCol=Active
 EspIdfManagerAddToolsBtn=Add ESP-IDF
+EspIdfManagerRemoveAllBtn=Remove All
 EspIdfManagerDeleteBtn=Delete
-EspIdfManagerMessageBoxActiveToolchainDelete=You are trying to delete active toolchain. Please switch active toolchain to delete.
-EspIdfManagerMessageBoxActiveToolchainDeleteTitle=Cannot delete active toolchain
-EspIdfManagerMessageBoxDeleteConfirmMessage=Do you want to delete the toolchain with ESP-IDF version: {0}
-EspIdfManagerMessageBoxDeleteConfirmMessageTitle=Confirm Delete 
+EspIdfManagerMessageBoxDeleteConfirmMessage=Do you want to remove the toolchain with ESP-IDF version: {0}
+EspIdfManagerMessageBoxDeleteConfirmMessageTitle=Confirm Remove
+EspIdfManagerMessageBoxDeleteAllConfirmMessage=Do you want to remove all ESP-IDF versions from IDE
+EspIdfManagerMessageBoxDeleteAllConfirmMessageTitle=Remove All ESP-IDF Versions 
 EspIdfManagerReloadBtnToolTip=Reload from disk
 EspIdfManagerDeleteBtnToolTip=Delete ESP-IDF version from IDE
 


### PR DESCRIPTION
## Description

Added an option to remove all the ESP-IDF version in the manager view also now you can delete the active version.

Fixes # ([IEP-1255](https://jira.espressif.com:8443/browse/IEP-1255))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?
Install multiple versions and try using Remove All button which should remove every version from the IDE. Also test removing the active version. Verify that the remove all button stays disabled when there are no versions in the IDE.

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Remove All" button to facilitate the removal of all ESP-IDF versions from the IDE.
  - Introduced new message prompts for confirming the deletion of all ESP-IDF versions.

- **Enhancements**
  - Enhanced the user interface by renaming `refreshTable()` to `refreshEditorUI()` for better clarity and functionality.
  - Updated UI components to handle actions related to removing all toolsets.

- **Bug Fixes**
  - Improved environment cleanup logic when deleting an IDF entry to ensure complete removal of related toolchains and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->