### PR TITLE
IEP-1204 Change the default name for the debug configuration

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -39,7 +39,7 @@
 	<extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
 		<launchConfigurationTypeImage
 			configTypeID="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
-			icon="icons/obj16/ESP-IDF GDB OpenOCD Debugging.png"
+			icon="platform:/plugin/org.eclipse.jdt.debug.ui/icons/full/etool16/debug_exc.png"
 			id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTypeImage" />
 	</extension>
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -39,7 +39,7 @@
 	<extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
 		<launchConfigurationTypeImage
 			configTypeID="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
-			icon="platform:/plugin/org.eclipse.jdt.debug.ui/icons/full/etool16/debug_exc.png"
+			icon="platform:/plugin/org.eclipse.debug.ui/icons/full/eview16/debug_persp.png"
 			id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTypeImage" />
 	</extension>
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -141,11 +141,14 @@ public class NewIDFProjectWizard extends TemplateWizard
 		return performFinish;
 	}
 
-	private void updateClangdFile(IProject project) 
+	private void updateClangdFile(IProject project)
 	{
-		try {
+		try
+		{
 			new ClangdConfigFileHandler().update(project);
-		} catch (Exception e) {
+		}
+		catch (Exception e)
+		{
 			Logger.log(e);
 		}
 	}
@@ -165,12 +168,13 @@ public class NewIDFProjectWizard extends TemplateWizard
 
 		PageChangingEvent pageChangingEvent = new PageChangingEvent(wizard, wizard.getStartingPage(), editPage);
 		editPage.handlePageChanging(pageChangingEvent);
-
 		wizard.performFinish();
 
 		try
 		{
-			wizard.getWorkingCopy().doSave();
+			String originalName = wizard.getWorkingCopy().getName();
+			String debugConfigName = originalName.substring(0, originalName.lastIndexOf("Configuration")) + " Debug"; //$NON-NLS-1$ //$NON-NLS-2$
+			wizard.getWorkingCopy().copy(debugConfigName).doSave();
 		}
 		catch (CoreException e)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -173,7 +173,9 @@ public class NewIDFProjectWizard extends TemplateWizard
 		try
 		{
 			String originalName = wizard.getWorkingCopy().getName();
-			String debugConfigName = originalName.substring(0, originalName.lastIndexOf("Configuration")) + " Debug"; //$NON-NLS-1$ //$NON-NLS-2$
+			int configPartIndex = originalName.lastIndexOf("Configuration"); //$NON-NLS-1$
+			String debugConfigName = configPartIndex != -1 ? originalName.substring(0, configPartIndex) + "Debug" //$NON-NLS-1$
+					: originalName;
 			wizard.getWorkingCopy().copy(debugConfigName).doSave();
 		}
 		catch (CoreException e)


### PR DESCRIPTION
## Description

Changed the default debug config name and icon.

Fixes # ([IEP-1204](https://jira.espressif.com:8443/browse/IEP-1204))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Create a project -> check the debug configuration

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Updated icon reference for launch configuration in the Eclipse plugin to improve visual consistency.
  
- **Improvements**
  - Enhanced exception handling in project setup wizard for smoother user experience.
  - Added new logic for creating modified debug configurations, facilitating better project debugging setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->