### PR TITLE
IEP-1276 Provide a configuration option in the launch configuration and open the serial monitor

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
@@ -17,4 +17,5 @@ public final class IDFLaunchConstants
 	public static final String ATTR_LAUNCH_CONFIGURATION_NAME = "com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationName"; //$NON-NLS-1$
 	public static final String ATTR_SERIAL_PORT = "com.espressif.idf.launch.serial.core.serialPort"; //$NON-NLS-1$
 	public static final String IDF_TARGET_TYPE = "com.espressif.idf.launch.serial.core.serialFlashTarget"; //$NON-NLS-1$
+	public static final String OPEN_SERIAL_MONITOR = "OPEN_SERIAL_MONITOR"; //$NON-NLS-1$
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFLaunchConstants.java
@@ -18,4 +18,5 @@ public final class IDFLaunchConstants
 	public static final String ATTR_SERIAL_PORT = "com.espressif.idf.launch.serial.core.serialPort"; //$NON-NLS-1$
 	public static final String IDF_TARGET_TYPE = "com.espressif.idf.launch.serial.core.serialFlashTarget"; //$NON-NLS-1$
 	public static final String OPEN_SERIAL_MONITOR = "OPEN_SERIAL_MONITOR"; //$NON-NLS-1$
+	public static final String SERIAL_MONITOR_ENCODING = "SERIAL_MONITOR_ENCODING"; //$NON-NLS-1$
 }

--- a/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
@@ -24,4 +24,6 @@ Export-Package: com.espressif.idf.launch.serial,
 Bundle-Activator: com.espressif.idf.launch.serial.internal.Activator
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.cdt.launch.serial.core
-Import-Package: org.eclipse.cdt.dsf.gdb
+Import-Package: org.eclipse.cdt.dsf.gdb,
+ org.eclipse.tm.terminal.view.core,
+ org.eclipse.tm.terminal.view.ui.launcher

--- a/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  com.espressif.idf.ui,
  com.espressif.idf.terminal.connector.serial,
  org.eclipse.launchbar.ui,
- org.eclipse.embedcdt.core
+ org.eclipse.embedcdt.core,
+ org.eclipse.tm.terminal.view.core
 Export-Package: com.espressif.idf.launch.serial,
  com.espressif.idf.launch.serial.core,
  com.espressif.idf.launch.serial.internal,

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -197,7 +197,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			Thread.currentThread().interrupt();
 			Logger.log(e);
 		}
-		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false))
+		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true))
 			openSerialMonitor(configuration);
 
 	}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -69,7 +69,6 @@ import com.espressif.idf.terminal.connector.serial.launcher.SerialLauncherDelega
 @SuppressWarnings("restriction")
 public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfigDelegate
 {
-	private static final String OPENOCD_PREFIX = "com.espressif.idf.debug.gdbjtag.openocd"; //$NON-NLS-1$
 	private String serialPort;
 
 	@Override
@@ -185,7 +184,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		Logger.log(String.format("flash command: %s", String.join(" ", commands))); //$NON-NLS-1$ //$NON-NLS-2$
 		String[] envArray = strings.toArray(new String[strings.size()]);
 		Process p = DebugPlugin.exec(commands.toArray(new String[0]), workingDir, envArray);
-		var process = DebugPlugin.newProcess(launch, p, String.join(" ", commands)); //$NON-NLS-1$
+		DebugPlugin.newProcess(launch, p, String.join(" ", commands)); //$NON-NLS-1$
 
 		try
 		{
@@ -196,16 +195,17 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			Thread.currentThread().interrupt();
 			Logger.log(e);
 		}
-		openSerialMonitor(configuration);
+		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false))
+			openSerialMonitor(configuration);
 
 	}
 
 	private void openSerialMonitor(ILaunchConfiguration configuration) throws CoreException
 	{
 		Map<String, Object> map = new HashMap<>();
-		map.put("delegateId", "com.espressif.idf.terminal.connector.serial.launcher.serial");
+		map.put("delegateId", "com.espressif.idf.terminal.connector.serial.launcher.serial"); //$NON-NLS-1$//$NON-NLS-2$
 		map.put(SerialSettings.PORT_NAME_ATTR, serialPort);
-		map.put("idf.monitor.project", configuration.getMappedResources()[0].getName());
+		map.put("idf.monitor.project", configuration.getMappedResources()[0].getName()); //$NON-NLS-1$
 		new SerialLauncherDelegate().execute(map, null);
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -48,6 +48,7 @@ import org.eclipse.launchbar.core.target.launch.ITargetedLaunch;
 import org.eclipse.launchbar.ui.internal.Activator;
 import org.eclipse.launchbar.ui.target.ILaunchTargetUIManager;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
 import org.eclipse.ui.WorkbenchEncoding;
 
 import com.espressif.idf.core.IDFCorePlugin;
@@ -196,7 +197,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			Thread.currentThread().interrupt();
 			Logger.log(e);
 		}
-		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false))
+		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true))
 			openSerialMonitor(configuration);
 
 	}
@@ -207,8 +208,9 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		map.put("delegateId", "com.espressif.idf.terminal.connector.serial.launcher.serial"); //$NON-NLS-1$//$NON-NLS-2$
 		map.put(SerialSettings.PORT_NAME_ATTR, serialPort);
 		map.put("idf.monitor.project", configuration.getMappedResources()[0].getName()); //$NON-NLS-1$
-		map.put("encoding", configuration.getAttribute(IDFLaunchConstants.SERIAL_MONITOR_ENCODING, //$NON-NLS-1$
-				WorkbenchEncoding.getWorkbenchDefaultEncoding()));
+		map.put(ITerminalsConnectorConstants.PROP_ENCODING, configuration.getAttribute(
+				IDFLaunchConstants.SERIAL_MONITOR_ENCODING, WorkbenchEncoding.getWorkbenchDefaultEncoding()));
+		map.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.FALSE);
 		new SerialLauncherDelegate().execute(map, null);
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -48,6 +48,7 @@ import org.eclipse.launchbar.core.target.launch.ITargetedLaunch;
 import org.eclipse.launchbar.ui.internal.Activator;
 import org.eclipse.launchbar.ui.target.ILaunchTargetUIManager;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.WorkbenchEncoding;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
@@ -206,6 +207,8 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		map.put("delegateId", "com.espressif.idf.terminal.connector.serial.launcher.serial"); //$NON-NLS-1$//$NON-NLS-2$
 		map.put(SerialSettings.PORT_NAME_ATTR, serialPort);
 		map.put("idf.monitor.project", configuration.getMappedResources()[0].getName()); //$NON-NLS-1$
+		map.put("encoding", configuration.getAttribute(IDFLaunchConstants.SERIAL_MONITOR_ENCODING, //$NON-NLS-1$
+				WorkbenchEncoding.getWorkbenchDefaultEncoding()));
 		new SerialLauncherDelegate().execute(map, null);
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -197,7 +197,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			Thread.currentThread().interrupt();
 			Logger.log(e);
 		}
-		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true))
+		if (configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false))
 			openSerialMonitor(configuration);
 
 	}

--- a/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  com.espressif.idf.core,
  org.eclipse.cdt.core,
  org.eclipse.jface,
- org.eclipse.core.variables
+ org.eclipse.core.variables,
+ org.eclipse.ui.ide
 Bundle-Activator: com.espressif.idf.launch.serial.ui.internal.Activator
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.cdt.launch.serial.ui

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -952,7 +952,7 @@ public class CMakeMainTab2 extends GenericMainTab
 		Label encodingLbl = new Label(group, SWT.NONE);
 		encodingLbl.setText(Messages.CMakeMainTab2_SerialMonitorEncodingLbl);
 		fEncodingCombo = new Combo(group, SWT.READ_ONLY);
-		fEncodingCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		fEncodingCombo.setLayoutData(new GridData(GridData.BEGINNING));
 		List<String> allEncodings = IDEEncoding.getIDEEncodings();
 		String[] encodingArray = allEncodings.toArray(new String[0]);
 		fEncodingCombo.setItems(encodingArray);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -54,6 +54,7 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
@@ -543,6 +544,14 @@ public class CMakeMainTab2 extends GenericMainTab
 		switchComposites.get(flashInterface).forEach(composite -> composite.setVisible(true));
 
 		mainComposite.requestLayout();
+
+		// Update the layout and size of the parent composite if it is a ScrolledComposite
+		if (mainComposite.getParent() instanceof ScrolledComposite sc)
+		{
+			mainComposite.setSize(mainComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+			sc.setMinSize(mainComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+			mainComposite.layout(true, true);
+		}
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -974,7 +974,6 @@ public class CMakeMainTab2 extends GenericMainTab
 				mainComposite.layout(true, true);
 				updateLaunchConfigurationDialog();
 			}
-
 		});
 	}
 
@@ -983,7 +982,8 @@ public class CMakeMainTab2 extends GenericMainTab
 		try
 		{
 			checkOpenSerialMonitorButton
-					.setSelection(configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false));
+					.setSelection(configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true));
+			checkOpenSerialMonitorButton.notifyListeners(SWT.Selection, null);
 			int encodingIndex = fEncodingCombo
 					.indexOf(configuration.getAttribute(IDFLaunchConstants.SERIAL_MONITOR_ENCODING, StringUtil.EMPTY));
 			encodingIndex = encodingIndex == -1 ? 0 : encodingIndex;

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -102,7 +102,7 @@ public class CMakeMainTab2 extends GenericMainTab
 	private Combo comboTargets;
 	private ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 	private ILaunchTargetManager targetManager = Activator.getService(ILaunchTargetManager.class);
-	private Button checkButton;
+	private Button checkOpenSerialMonitorButton;
 
 	public enum FlashInterface
 	{
@@ -623,7 +623,7 @@ public class CMakeMainTab2 extends GenericMainTab
 			wc.setAttribute(IDFLaunchConstants.ATTR_JTAG_FLASH_ARGUMENTS, jtagArgumentsField.getText());
 			wc.setAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS, uartAgrumentsField.getText());
 			wc.setAttribute(IDFLaunchConstants.ATTR_DFU_FLASH_ARGUMENTS, dfuArgumentsField.getText());
-			wc.setAttribute("openSerialPort", checkButton.getSelection());
+			wc.setAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, checkOpenSerialMonitorButton.getSelection());
 			wc.doSave();
 		}
 		catch (CoreException e)
@@ -642,6 +642,7 @@ public class CMakeMainTab2 extends GenericMainTab
 	public void initializeFrom(ILaunchConfiguration configuration)
 	{
 		super.initializeFrom(configuration);
+		updateStartSerialMonitorCheckbox(configuration);
 		updateProjetFromConfig(configuration);
 		updateFlashOverStatus(configuration);
 		updateArgumentsWithDefaultFlashCommand(configuration);
@@ -924,8 +925,22 @@ public class CMakeMainTab2 extends GenericMainTab
 
 	private void createOpenSerialMonitorCheckBox(Composite mainComposite)
 	{
-		checkButton = new Button(mainComposite, SWT.CHECK);
-		checkButton.setText("Open serial monitor after flashing");
+		checkOpenSerialMonitorButton = new Button(mainComposite, SWT.CHECK);
+		checkOpenSerialMonitorButton.setText(Messages.CMakeMainTab2_SerialMonitorBtn);
+
+	}
+
+	private void updateStartSerialMonitorCheckbox(ILaunchConfiguration configuration)
+	{
+		try
+		{
+			checkOpenSerialMonitorButton
+					.setSelection(configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true));
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
 
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -102,6 +102,7 @@ public class CMakeMainTab2 extends GenericMainTab
 	private Combo comboTargets;
 	private ILaunchBarManager launchBarManager = Activator.getService(ILaunchBarManager.class);
 	private ILaunchTargetManager targetManager = Activator.getService(ILaunchTargetManager.class);
+	private Button checkButton;
 
 	public enum FlashInterface
 	{
@@ -130,6 +131,7 @@ public class CMakeMainTab2 extends GenericMainTab
 		isJtagFlashAvailable = ESPFlashUtil.checkIfJtagIsAvailable();
 		setControl(mainComposite);
 		createJtagFlashButton(mainComposite);
+		createOpenSerialMonitorCheckBox(mainComposite);
 		createDfuTargetComposite(mainComposite);
 		createProjectGroup(mainComposite, 0);
 		createUartComposite(mainComposite);
@@ -621,6 +623,7 @@ public class CMakeMainTab2 extends GenericMainTab
 			wc.setAttribute(IDFLaunchConstants.ATTR_JTAG_FLASH_ARGUMENTS, jtagArgumentsField.getText());
 			wc.setAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS, uartAgrumentsField.getText());
 			wc.setAttribute(IDFLaunchConstants.ATTR_DFU_FLASH_ARGUMENTS, dfuArgumentsField.getText());
+			wc.setAttribute("openSerialPort", checkButton.getSelection());
 			wc.doSave();
 		}
 		catch (CoreException e)
@@ -918,4 +921,12 @@ public class CMakeMainTab2 extends GenericMainTab
 				new NewSerialFlashTargetWizard());
 		applyTargetJob.schedule(JOB_DELAY_MS);
 	}
+
+	private void createOpenSerialMonitorCheckBox(Composite mainComposite)
+	{
+		checkButton = new Button(mainComposite, SWT.CHECK);
+		checkButton.setText("Open serial monitor after flashing");
+
+	}
+
 }

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -138,8 +138,8 @@ public class CMakeMainTab2 extends GenericMainTab
 		setControl(mainComposite);
 		createJtagFlashButton(mainComposite);
 		createOpenSerialMonitorGroup(mainComposite);
-		createDfuTargetComposite(mainComposite);
 		createProjectGroup(mainComposite, 0);
+		createDfuTargetComposite(mainComposite);
 		createUartComposite(mainComposite);
 		createJtagflashComposite(mainComposite);
 		createDfuArgumentField(mainComposite);
@@ -934,10 +934,10 @@ public class CMakeMainTab2 extends GenericMainTab
 	private void createOpenSerialMonitorGroup(Composite mainComposite)
 	{
 		Group group = SWTFactory.createGroup(mainComposite, Messages.CMakeMainTab2_SerialMonitorGroup, 2, 1,
-				GridData.FILL_BOTH);
+				GridData.FILL_HORIZONTAL);
 		checkOpenSerialMonitorButton = new Button(group, SWT.CHECK);
 		checkOpenSerialMonitorButton.setText(Messages.CMakeMainTab2_SerialMonitorBtn);
-		GridData gd = new GridData(SWT.BEGINNING, SWT.NORMAL, true, false);
+		GridData gd = new GridData(SWT.FILL, SWT.FILL, false, false);
 		gd.horizontalSpan = 2;
 		checkOpenSerialMonitorButton.setLayoutData(gd);
 		checkOpenSerialMonitorButton.addSelectionListener(new SelectionAdapter()

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -949,25 +949,33 @@ public class CMakeMainTab2 extends GenericMainTab
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, false, false);
 		gd.horizontalSpan = 2;
 		checkOpenSerialMonitorButton.setLayoutData(gd);
-		checkOpenSerialMonitorButton.addSelectionListener(new SelectionAdapter()
-		{
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e)
-			{
-				updateLaunchConfigurationDialog();
-			}
-		});
 		Label encodingLbl = new Label(group, SWT.NONE);
 		encodingLbl.setText(Messages.CMakeMainTab2_SerialMonitorEncodingLbl);
-		fEncodingCombo = new Combo(group, SWT.NONE);
+		fEncodingCombo = new Combo(group, SWT.READ_ONLY);
 		fEncodingCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		List<String> allEncodings = IDEEncoding.getIDEEncodings();
 		String[] encodingArray = allEncodings.toArray(new String[0]);
 		fEncodingCombo.setItems(encodingArray);
 		if (encodingArray.length > 0)
 			fEncodingCombo.select(0);
-		fEncodingCombo.addModifyListener(e -> updateLaunchConfigurationDialog());
 
+		fEncodingCombo.addModifyListener(e -> updateLaunchConfigurationDialog());
+		checkOpenSerialMonitorButton.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				fEncodingCombo.setVisible(checkOpenSerialMonitorButton.getSelection());
+				GridData data = (GridData) fEncodingCombo.getLayoutData();
+				data.exclude = !fEncodingCombo.getVisible();
+				encodingLbl.setVisible(checkOpenSerialMonitorButton.getSelection());
+				data = (GridData) encodingLbl.getLayoutData();
+				data.exclude = !encodingLbl.getVisible();
+				mainComposite.layout(true, true);
+				updateLaunchConfigurationDialog();
+			}
+
+		});
 	}
 
 	private void updateStartSerialMonitorGroup(ILaunchConfiguration configuration)
@@ -975,7 +983,7 @@ public class CMakeMainTab2 extends GenericMainTab
 		try
 		{
 			checkOpenSerialMonitorButton
-					.setSelection(configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, true));
+					.setSelection(configuration.getAttribute(IDFLaunchConstants.OPEN_SERIAL_MONITOR, false));
 			int encodingIndex = fEncodingCombo
 					.indexOf(configuration.getAttribute(IDFLaunchConstants.SERIAL_MONITOR_ENCODING, StringUtil.EMPTY));
 			encodingIndex = encodingIndex == -1 ? 0 : encodingIndex;

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -49,6 +49,8 @@ public class Messages extends NLS
 	public static String IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle;
 	public static String IDFLaunchTargetNotFoundMsg3;
 	public static String CMakeMainTab2_SerialMonitorBtn;
+	public static String CMakeMainTab2_SerialMonitorGroup;
+	public static String CMakeMainTab2_SerialMonitorEncodingLbl;
 
 	public static String TargetPortUpdatingMessage;
 	public static String TargetPortInformationMessage;

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -17,7 +17,8 @@ package com.espressif.idf.launch.serial.ui.internal;
 
 import org.eclipse.osgi.util.NLS;
 
-public class Messages extends NLS {
+public class Messages extends NLS
+{
 	private static final String BUNDLE_NAME = "com.espressif.idf.launch.serial.ui.internal.messages"; //$NON-NLS-1$
 	public static String NewSerialFlashTargetWizard_Title;
 	public static String NewSerialFlashTargetWizardPage_Description;
@@ -47,17 +48,20 @@ public class Messages extends NLS {
 	public static String IDFLaunchTargetNotFoundMsg2;
 	public static String IDFLaunchTargetNotFoundIDFLaunchTargetNotFoundTitle;
 	public static String IDFLaunchTargetNotFoundMsg3;
+	public static String CMakeMainTab2_SerialMonitorBtn;
 
 	public static String TargetPortUpdatingMessage;
 	public static String TargetPortInformationMessage;
 	public static String TargetPortFoundMessage;
 	public static String TargetPortNotFoundMessage;
 
-	static {
+	static
+	{
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
 	}
 
-	private Messages() {
+	private Messages()
+	{
 	}
 }

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -33,6 +33,8 @@ CMakeMainTab2_OpeonOcdSetupGroupTitle=OpenOCD Setup:
 CMakeMainTab2_JtagFlashingNotSupportedMsg=(JTAG flash functionality isn't available, please update OpenOCD. The minimum required version is v0.10.0-esp32-20210401)
 CMakeMainTab2_SettingTargetJob=Setting a target in launch bar...
 CMakeMainTab2_SerialMonitorBtn=Open Serial Monitor After Flashing
+CMakeMainTab2_SerialMonitorGroup=Serial Monitor Settings
+CMakeMainTab2_SerialMonitorEncodingLbl=Encoding:
 
 IDFLaunchTargetNotFoundMsg1=IDF Launch Target with 
 IDFLaunchTargetNotFoundMsg2=\ is not found. 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -32,6 +32,7 @@ configBoardTooTip=Select a board based on ESP target
 CMakeMainTab2_OpeonOcdSetupGroupTitle=OpenOCD Setup:
 CMakeMainTab2_JtagFlashingNotSupportedMsg=(JTAG flash functionality isn't available, please update OpenOCD. The minimum required version is v0.10.0-esp32-20210401)
 CMakeMainTab2_SettingTargetJob=Setting a target in launch bar...
+CMakeMainTab2_SerialMonitorBtn=Open Serial Monitor After Flashing
 
 IDFLaunchTargetNotFoundMsg1=IDF Launch Target with 
 IDFLaunchTargetNotFoundMsg2=\ is not found. 


### PR DESCRIPTION
## Description

In the launch configuration now there is an option to start the serial monitor right after the serial flash

Fixes # ([IEP-1276](https://jira.espressif.com:8443/browse/IEP-1276))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Create a new project -> edit launch configuration -> "Open Serial Monitor" option is set by default
- flash project 
- serial monitor should be opened by default

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a button for opening the serial monitor during launch configurations.
  - Added encoding selection feature for the serial monitor.
  
- **Enhancements**
  - Updated launch configurations to support serial monitor settings.
  
- **Bug Fixes**
  - Improved formatting consistency in UI messages.

These changes aim to enhance user experience by providing more control over serial monitoring and encoding options during the launch process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->