### PR TITLE
IEP-1277 Create .clang_format

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/ILSPConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/ILSPConstants.java
@@ -11,4 +11,5 @@ public interface ILSPConstants
 {
 	String CLANGD_EXECUTABLE = "clangd"; //$NON-NLS-1$
 	String CLANGD_CONFIG_FILE = ".clangd"; //$NON-NLS-1$
+	String CLANG_FORMAT_FILE = ".clang-format"; //$NON-NLS-1$
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -85,6 +85,7 @@ import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.internal.CMakeConsoleWrapper;
 import com.espressif.idf.core.internal.CMakeErrorParser;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.ClangFormatFileHandler;
 import com.espressif.idf.core.util.ClangdConfigFileHandler;
 import com.espressif.idf.core.util.DfuCommandsUtil;
 import com.espressif.idf.core.util.HintsUtil;
@@ -339,6 +340,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 			}
 			runCmakeBuildCommand(console, monitor, project, start, generator, infoStream, buildDir);
 			new ClangdConfigFileHandler().update(project);
+			new ClangFormatFileHandler(project).update();
 			return new IProject[] { project };
 		}
 		catch (Exception e)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/.clang-format-project
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/.clang-format-project
@@ -1,0 +1,9 @@
+# We'll use defaults from the LLVM style, but with some modifications so that it's close to the CDT K&R style.
+BasedOnStyle: LLVM
+UseTab: Always
+IndentWidth: 4
+TabWidth: 4
+PackConstructorInitializers: NextLineOnly
+BreakConstructorInitializers: AfterColon
+IndentAccessModifiers: false
+AccessModifierOffset: -4

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
@@ -17,7 +17,8 @@ public class ClangFormatFileHandler {
 
     private final IFile clangFormatFile;
 
-    public ClangFormatFileHandler(IProject project) throws CoreException {
+    public ClangFormatFileHandler(IProject project) throws CoreException
+    {
         this.clangFormatFile = project.getFile(ILSPConstants.CLANG_FORMAT_FILE);
     }
 
@@ -27,7 +28,8 @@ public class ClangFormatFileHandler {
 	 * @throws IOException   if an I/O error occurs during file creation or writing
 	 * @throws CoreException if an error occurs while refreshing the project
 	 */
-    public void update() throws IOException, CoreException {
+    public void update() throws IOException, CoreException
+    {
         if (clangFormatFile.exists())
         {
             return;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
@@ -4,31 +4,21 @@
  *******************************************************************************/
 package com.espressif.idf.core.util;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
 
 import com.espressif.idf.core.ILSPConstants;
 
 public class ClangFormatFileHandler {
 
-    private final IProject project;
-    private final Path clangFormatPath;
+    private final IFile clangFormatFile;
 
     public ClangFormatFileHandler(IProject project) throws CoreException {
-        this.project = project;
-        this.clangFormatPath = project.getLocation().toPath().resolve(ILSPConstants.CLANG_FORMAT_FILE);
+        this.clangFormatFile = project.getFile(ILSPConstants.CLANG_FORMAT_FILE);
     }
 
 	/**
@@ -38,50 +28,13 @@ public class ClangFormatFileHandler {
 	 * @throws CoreException if an error occurs while refreshing the project
 	 */
     public void update() throws IOException, CoreException {
-		boolean isNewFile = createNewClangFormatFile();
-
-        if (isNewFile) {
-			Map<String, Object> data = new LinkedHashMap<>();
-			data.put("BasedOnStyle", "LLVM"); //$NON-NLS-1$ //$NON-NLS-2$
-			data.put("IndentWidth", 4); //$NON-NLS-1$
-
-            writeYamlFile(data);
+        if (clangFormatFile.exists())
+        {
+            return;
         }
-    }
-
-    private DumperOptions createYamlOptions() {
-        DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        options.setPrettyFlow(true);
-        return options;
-    }
-
-    private void writeYamlFile(Map<String, Object> data) throws IOException {
-        try (Writer writer = new FileWriter(clangFormatPath.toFile())) {
-            new Yaml(createYamlOptions()).dump(data, writer);
-        }
-    }
-
-	/**
-	 * Ensures that the .clang-format file exists. If the file does not exist, it is created and the project is
-	 * refreshed.
-	 *
-	 * @return true if the file was created, false if it already existed
-	 * @throws IOException   if an I/O error occurs during file creation
-	 * @throws CoreException if an error occurs while refreshing the project
-	 */
-	private boolean createNewClangFormatFile() throws IOException, CoreException
-	{
-        if (Files.exists(clangFormatPath)) {
-            return false;
-        }
-
-        try {
-            Files.createFile(clangFormatPath);
-            project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
-            return true;
-        } catch (IOException e) {
-            throw new IOException("Failed to create .clang_format file: " + e.getMessage(), e); //$NON-NLS-1$
+        try (final var source = getClass().getResourceAsStream(".clang-format-project");) //$NON-NLS-1$
+        {
+            clangFormatFile.create(source, true, new NullProgressMonitor());
         }
     }
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
@@ -13,14 +13,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import com.espressif.idf.core.ILSPConstants;
 
-public class ClangFormatFileHandler {
+public class ClangFormatFileHandler
+{
+	private final IFile clangFormatFile;
 
-    private final IFile clangFormatFile;
-
-    public ClangFormatFileHandler(IProject project) throws CoreException
-    {
-        this.clangFormatFile = project.getFile(ILSPConstants.CLANG_FORMAT_FILE);
-    }
+	public ClangFormatFileHandler(IProject project) throws CoreException
+	{
+		this.clangFormatFile = project.getFile(ILSPConstants.CLANG_FORMAT_FILE);
+	}
 
 	/**
 	 * Updates the .clang-format file. If the file does not exist, it is created and initialized with default settings.
@@ -28,15 +28,15 @@ public class ClangFormatFileHandler {
 	 * @throws IOException   if an I/O error occurs during file creation or writing
 	 * @throws CoreException if an error occurs while refreshing the project
 	 */
-    public void update() throws IOException, CoreException
-    {
-        if (clangFormatFile.exists())
-        {
-            return;
-        }
-        try (final var source = getClass().getResourceAsStream(".clang-format-project");) //$NON-NLS-1$
-        {
-            clangFormatFile.create(source, true, new NullProgressMonitor());
-        }
-    }
+	public void update() throws IOException, CoreException
+	{
+		if (clangFormatFile.exists())
+		{
+			return;
+		}
+		try (final var source = getClass().getResourceAsStream(".clang-format-project");) //$NON-NLS-1$
+		{
+			clangFormatFile.create(source, true, new NullProgressMonitor());
+		}
+	}
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
@@ -1,0 +1,81 @@
+package com.espressif.idf.core.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import com.espressif.idf.core.ILSPConstants;
+
+public class ClangFormatFileHandler
+{
+
+	public void update(IProject project) throws CoreException, IOException
+	{
+		File file = getClangFormatFile(project);
+
+		// Load existing .clang-format file
+		FileInputStream inputStream = new FileInputStream(file);
+		final DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		options.setPrettyFlow(true);
+		Yaml yaml = new Yaml(options);
+		Map<String, Object> obj = yaml.load(inputStream);
+
+		// Create new YAML structure if file is empty
+		Map<String, Object> data = createOrGetExistingYamlStructure(obj);
+		data.put("BasedOnStyle", data.getOrDefault("BasedOnStyle", "LLVM")); //$NON-NLS-1$
+		data.put("IndentWidth", data.getOrDefault("IndentWidth", 4));
+		// Write updated clang-format back to file
+		try (Writer writer = new FileWriter(file))
+		{
+			yaml.dump(data, writer);
+		}
+		catch (IOException e)
+		{
+			throw new IOException("Error writing .clang-format file: " + e.getMessage(), e); //$NON-NLS-1$
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> createOrGetExistingYamlStructure(Object obj)
+	{
+		if (obj instanceof Map)
+		{
+			return (Map<String, Object>) obj;
+		}
+		return new LinkedHashMap<>();
+	}
+
+	private File getClangFormatFile(IProject project) throws IOException, CoreException
+	{
+		// Resolve the path of the clang-format config file within the project directory
+		Path clangFormatPath = project.getLocation().toPath().resolve(ILSPConstants.CLANG_FORMAT_FILE);
+		if (!Files.exists(clangFormatPath))
+		{
+			try
+			{
+				Files.createFile(clangFormatPath);
+			}
+			catch (IOException e)
+			{
+				throw new IOException("Failed to create .clang_format file: " + e.getMessage(), e); //$NON-NLS-1$
+			}
+			project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		}
+		return clangFormatPath.toFile();
+	}
+
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -66,5 +66,4 @@ public class LspService
 					metadata.queryDriver().defaultValue());
 		}
 	}
-
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.ClangFormatFileHandler;
 import com.espressif.idf.core.util.ClangdConfigFileHandler;
 import com.espressif.idf.core.util.LaunchUtil;
 import com.espressif.idf.ui.UIPlugin;
@@ -145,6 +146,7 @@ public class NewIDFProjectWizard extends TemplateWizard
 	{
 		try
 		{
+			new ClangFormatFileHandler().update(project);
 			new ClangdConfigFileHandler().update(project);
 		}
 		catch (Exception e)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -111,7 +111,7 @@ public class NewIDFProjectWizard extends TemplateWizard
 				String projectName = projectCreationWizardPage.getProjectName();
 				IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 				selProvider.setSelection(new StructuredSelection(project));
-				updateClangdFile(project);
+				updateClangFiles(project);
 			}
 		}
 
@@ -142,12 +142,12 @@ public class NewIDFProjectWizard extends TemplateWizard
 		return performFinish;
 	}
 
-	private void updateClangdFile(IProject project)
+	private void updateClangFiles(IProject project)
 	{
 		try
 		{
-			new ClangFormatFileHandler().update(project);
 			new ClangdConfigFileHandler().update(project);
+			new ClangFormatFileHandler(project).update();
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
## Description

Creating the .clang-format file with the default settings with a new project. Also, if .clang-format file is missing, it's adding automatically after the build

Fixes # ([IEP-1277](https://jira.espressif.com:8443/browse/IEP-1277))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Create a new project -> check .clang-format file
- Delete .clang-format file -> build the project -> check .clang-format file

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:
- Formatting


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new constant for Clang format file management, enhancing configuration options.
	- Added a new handler for `.clang-format` file to streamline formatting setup in projects.
	- Improved project setup wizard to accommodate both Clang configurations and formatting files.

- **Bug Fixes**
	- Minor formatting cleanup in the LSP service implementation to enhance code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->