### PR TITLE
fix: fixed maven build by updating jdk reference

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -126,8 +126,8 @@
 			<unit id="org.eclipse.swtchart.feature.feature.group" version="0.14.0.202301260747"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
-			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="17.0.11.v20240426-1830"/>
+			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.12"/>
+			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="17.0.12.v20240802-1518"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
 			<dependencies>


### PR DESCRIPTION
fixed build by updating repository location of JDK 17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Java Runtime Environment (JRE) dependency to version 17.0.12, enhancing stability and performance.
- **Bug Fixes**
  - Addressed potential bugs and security vulnerabilities by specifying a fixed version of the JRE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->