### PR TITLE
IEP-1275: Install tools action triggered even after installing tools through offline installer

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
@@ -14,13 +14,11 @@ import java.util.Map;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.console.MessageConsoleStream;
 
 import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
-import com.espressif.idf.core.IDFCorePreferenceConstants;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.ProcessBuilderFactory;
 import com.espressif.idf.core.logging.Logger;


### PR DESCRIPTION
## Description

Updated to improve the offline installer behavior with IDE, now using the installed tools in the offline installer instead of creating a new set. Improved handling of IDF_TOOLS_PATH to ensure that

Fixes # ([IEP-1275](https://jira.espressif.com:8443/browse/IEP-1275))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please verify this with offline installer's esp_idf.json file to make sure that the tools are not installed but are rather used from the offline installer's directory.
Everything else including the ESP-IDF Manager should stay as is if new bugs are found please report them here and create a new ticket for them.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamlined tool activation process, enhancing efficiency in managing tool configurations.
  
- **Refactor**
  - Removed unnecessary classes and listeners for tool activation, improving code maintainability.
  
- **Chores**
  - Cleaned up import statements to reduce dependencies, facilitating a more straightforward codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->