### PR TITLE
IEP-1311 Ensure that the our runActionHandler only works on our configurations

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
@@ -48,8 +48,19 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 		{
 			ILaunchBarManager launchBarManager = UIPlugin.getService(ILaunchBarManager.class);
 			new StopLaunchBuildHandler().stop();
+
 			ILaunchConfiguration config = launchBarManager.getActiveLaunchConfiguration();
 			if (config == null)
+			{
+				return Status.OK_STATUS;
+			}
+
+			boolean isEspLaunchConfig = config.getType().getIdentifier()
+					.contentEquals(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
+			boolean isEspDebugConfig = config.getType().getIdentifier()
+					.contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
+
+			if (!isEspLaunchConfig && !isEspDebugConfig)
 			{
 				return Status.OK_STATUS;
 			}
@@ -74,8 +85,7 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 				}
 				return Status.CANCEL_STATUS;
 			}
-			if (launchMode.getIdentifier().equals(ILaunchManager.DEBUG_MODE)
-					&& config.getType().getIdentifier().contentEquals(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE))
+			if (launchMode.getIdentifier().equals(ILaunchManager.DEBUG_MODE) && isEspLaunchConfig)
 			{
 				List<String> suitableDescNames = findSuitableDescNames(projectName,
 						IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
@@ -86,8 +96,7 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 				}
 				returnCode = runActionBasedOnDescCount(launchBarManager, suitableDescNames);
 			}
-			else if (launchMode.getIdentifier().equals(ILaunchManager.RUN_MODE)
-					&& config.getType().getIdentifier().contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
+			else if (launchMode.getIdentifier().equals(ILaunchManager.RUN_MODE) && isEspDebugConfig)
 			{
 				List<String> suitableDescNames = findSuitableDescNames(projectName,
 						IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
@@ -62,7 +62,7 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 
 			if (!isEspLaunchConfig && !isEspDebugConfig)
 			{
-				return Status.OK_STATUS;
+				return super.execute(event);
 			}
 
 			ILaunchMode launchMode = launchBarManager.getActiveLaunchMode();


### PR DESCRIPTION
## Description

The project check was executed even for configurations without projects, so we have to ensure that runActionHandler executes only on our configurations

Fixes # ([IEP-1331](https://jira.espressif.com:8443/browse/IEP-1331))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for handling launch configurations, improving support for specific launch types.
	- Introduced additional checks for identifying ESP-IDF run and debug configurations.

- **Bug Fixes**
	- Streamlined execution conditions to ensure only relevant configurations are processed, reducing errors with unsupported types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->