### PR TITLE
IEP-1090: Close the welcome page if opened when new project is created 

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -33,6 +33,10 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.part.ViewPart;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.espressif.idf.core.IDFConstants;
@@ -812,5 +816,24 @@ public class IDFUtil
 		String idfToolsPath = Platform.getPreferencesService().getString(IDFCorePlugin.PLUGIN_ID,
 				IDFCorePreferenceConstants.IDF_TOOLS_PATH, IDFCorePreferenceConstants.IDF_TOOLS_PATH_DEFAULT, null);
 		return idfToolsPath;
+	}
+	
+	public static void closeWelcomePage(IWorkbenchWindow activeww)
+	{
+		Display.getDefault().syncExec(()-> {
+			if (activeww != null)
+			{
+				IWorkbenchPage page = activeww.getActivePage();
+				if (page != null)
+				{
+					ViewPart viewPart = (ViewPart) page.findView("org.eclipse.ui.internal.introview"); //$NON-NLS-1$
+					if (viewPart != null)
+					{
+						page.hideView(viewPart);
+					}
+
+				}
+			}
+		});
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/NewProjectHandler.java
@@ -7,6 +7,7 @@ import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.wizard.NewIDFProjectWizard;
 
 /**
@@ -18,6 +19,7 @@ public class NewProjectHandler extends AbstractHandler
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException
 	{
+		IDFUtil.closeWelcomePage(EclipseHandler.getActiveWorkbenchWindow());
 		if (!NewProjectHandlerUtil.installToolsCheck())
 		{
 			return null;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ManageEspIdfVersionsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ManageEspIdfVersionsHandler.java
@@ -10,14 +10,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.part.ViewPart;
 
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.tools.IToolsInstallationWizardConstants;
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.handlers.EclipseHandler;
 import com.espressif.idf.ui.tools.manager.ESPIDFManagerEditor;
 
@@ -39,19 +38,8 @@ public class ManageEspIdfVersionsHandler extends AbstractHandler
 			public void run()
 			{
 				IWorkbenchWindow activeww = EclipseHandler.getActiveWorkbenchWindow();
-				if (activeww != null)
-				{
-					IWorkbenchPage page = activeww.getActivePage();
-					if (page != null)
-					{
-						ViewPart viewPart = (ViewPart) page.findView("org.eclipse.ui.internal.introview");
-						if (viewPart != null)
-						{
-							page.hideView(viewPart);
-						}
-
-					}
-				}
+				IDFUtil.closeWelcomePage(activeww);
+				
 				try
 				{
 					File inputFile = new File(toolSetConfigFilePath());
@@ -62,7 +50,6 @@ public class ManageEspIdfVersionsHandler extends AbstractHandler
 
 					IFile iFile = ResourcesPlugin.getWorkspace().getRoot()
 							.getFile(new Path(inputFile.getAbsolutePath()));
-
 					IDE.openEditor(activeww.getActivePage(), new FileEditorInput(iFile), ESPIDFManagerEditor.EDITOR_ID);
 				}
 				catch (Exception e)


### PR DESCRIPTION
## Description

Close the welcome page if opened when new project is created

Fixes # ([IEP-1090](https://jira.espressif.com:8443/browse/IEP-1090))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Keep the welcome page opened after installing tools and try creating new project. Welcome page should be closed

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to programmatically close the welcome page in the Eclipse IDE, enhancing user control over the interface.
  - Integrated welcome page closure within the New Project creation flow, preventing it from remaining open during project setup.

- **Refactor**
  - Streamlined the workflow in `ManageEspIdfVersionsHandler` by simplifying the logic for managing the welcome page visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->