### PR TITLE
feat: added esp-p4 support

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -301,6 +301,14 @@ config-only component and an interface library is created instead."
            id="riscv32-esp-elf"
            name="esp32h2">
      </ToolChain>
+          <ToolChain
+                arch="riscv32"
+                compilerPattern="riscv32-esp-elf[\\/]+bin[\\/]+riscv32-esp-elf-gcc(?:\.exe)?$"
+                debuggerPattern="riscv32-esp-elf-gdb(\.exe)?$"
+                fileName="toolchain-esp32p4.cmake"
+                id="riscv32-esp-elf"
+                name="esp32p4">
+          </ToolChain>
   </extension>
   <extension point="org.eclipse.core.variables.dynamicVariables">
      <variable


### PR DESCRIPTION
## Description

Added esp-p4 target.

Fixes # ([IEP-1315](https://jira.espressif.com:8443/browse/IEP-1315))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the RISC-V architecture with the addition of the `esp32p4` toolchain configuration, enhancing compatibility with a wider range of hardware targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->