### PR TITLE
fix: Increase Espressif-IDE heap xms and xmx values to improve performance

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -14,11 +14,11 @@
    </configIni>
 
    <launcherArgs>
-      <vmArgsLin>-Xms256m -Xmx2048m  -Dosgi.requiredJavaVersion=17 -Dosgi.instance.area.default=@user.home/workspace
+      <vmArgsLin>-Xms2048m -Xmx4096m  -Dosgi.requiredJavaVersion=17 -Dosgi.instance.area.default=@user.home/workspace
       </vmArgsLin>
-      <vmArgsMac>-Xms256m -Xmx2048m  -Xdock:icon=../Resources/espressif.icns -XstartOnFirstThread -Dosgi.requiredJavaVersion=17 -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.instance.area.default=@user.home/workspace
+      <vmArgsMac>-Xms2048m -Xmx4096m  -Xdock:icon=../Resources/espressif.icns -XstartOnFirstThread -Dosgi.requiredJavaVersion=17 -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.instance.area.default=@user.home/workspace
       </vmArgsMac>
-      <vmArgsWin>-Xms256m -Xmx2048m   -Dosgi.requiredJavaVersion=17 -Dosgi.instance.area.default=@user.home/workspace
+      <vmArgsWin>-Xms2048m -Xmx4096m   -Dosgi.requiredJavaVersion=17 -Dosgi.instance.area.default=@user.home/workspace
       </vmArgsWin>
    </launcherArgs>
 


### PR DESCRIPTION
## Description

Increase the initial heap size for Espressif-IDE from 256m to 2048m and the maximum heap size from 2048m to 4096m to improve IDE launch performance. This change also enhances the indexer and parser performance when dealing with a larger number of files.

Fixes # ([IEP-1320](https://jira.espressif.com:8443/browse/IEP-1320))
https://github.com/espressif/idf-eclipse-plugin/issues/963

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

 - Download Espressif-IDE from the PR
 - Verify launch
 - Verify project build and indexer performance

**Test Configuration**:
* ESP-IDF Version: NA
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Espressif-IDE Launch
- Indexer

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated version for the `com.espressif.idf.branding` bundle to 3.1.0, indicating potential enhancements.
	- Updated version for the `com.espressif.idf.feature` to 3.1.0, suggesting new functionalities or improvements.
	- Incremented the `espressif-ide-release-version` to 3.1.0, reflecting enhancements or bug fixes in the Espressif IDE.
	- Increased memory allocation parameters for the Espressif-IDE across all platforms, improving performance and resource handling. 

- **Bug Fixes**
	- Potential bug fixes included with the version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->