### PR TITLE
IEP-1252: Add MenuConfig menu option under ESP-IDF menu list

### DIFF
--- a/bundles/com.espressif.idf.sdk.config.ui/plugin.xml
+++ b/bundles/com.espressif.idf.sdk.config.ui/plugin.xml
@@ -39,6 +39,12 @@
 					</reference>
 				</visibleWhen>
 			</command>
+   <command
+         commandId="com.espressif.idf.sdk.config.ui.command.menuConfig"
+         icon="icons/sdkconfig.png"
+         label="Menu Config"
+         style="push">
+   </command>
 		</menuContribution>
 	</extension>
 	<extension
@@ -48,6 +54,11 @@
 			id="com.espressif.idf.sdk.config.ui.command.setdefault"
 			name="%command.name">
 		</command>
+  <command
+        defaultHandler="com.espressif.idf.sdk.config.ui.OpenSdkConfigEditor"
+        id="com.espressif.idf.sdk.config.ui.command.menuConfig"
+        name="Open MenuConfig">
+  </command>
 	</extension>
 	<extension
 		point="org.eclipse.core.expressions.definitions">

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/Messages.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/Messages.java
@@ -27,6 +27,8 @@ public class Messages extends NLS
 	public static String SDKConfigurationEditor_SDKConfiguration;
 	public static String SDKConfigurationEditor_StartingJSONConfigServer;
 	public static String SDKConfigurationEditor_UnableFindKConfigFile;
+	public static String SDKConfigFileNotFound_ErrorMessage;
+	public static String SDKConfigurationFileNotFound_Title;
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/OpenSdkConfigEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/OpenSdkConfigEditor.java
@@ -1,0 +1,63 @@
+package com.espressif.idf.sdk.config.ui;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.ide.IDE;
+
+public class OpenSdkConfigEditor extends AbstractHandler
+{
+
+	private static final String SDKCONFIG_FILE_NAME = "sdkconfig";
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException
+	{
+		IWorkbenchPage page = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage();
+		IProject project = getCurrentProject();
+		try
+		{
+			IFile sdkConfigFile = project.getFile(SDKCONFIG_FILE_NAME);
+			if (sdkConfigFile.exists())
+			{
+				IDE.openEditor(page, sdkConfigFile);
+			}
+			else
+			{
+				MessageDialog.openError(HandlerUtil.getActiveShell(event), Messages.SDKConfigurationFileNotFound_Title,
+						Messages.SDKConfigFileNotFound_ErrorMessage);
+			}
+		}
+		catch (CoreException e)
+		{
+			throw new ExecutionException("Error opening sdkconfig file", e);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the currently selected project in the workspace.
+	 */
+	private IProject getCurrentProject()
+	{
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		IProject[] projects = root.getProjects();
+		for (IProject project : projects)
+		{
+			if (project.isOpen() && project.getFile(SDKCONFIG_FILE_NAME).exists())
+			{
+				return project;
+			}
+		}
+		return null;
+	}
+}

--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/messages.properties
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/messages.properties
@@ -16,3 +16,5 @@ SDKConfigurationEditor_SaveChanges=Do you want to save the changes in the Design
 SDKConfigurationEditor_SDKConfiguration=SDK Configuration
 SDKConfigurationEditor_StartingJSONConfigServer=Starting JSON Configuration Server
 SDKConfigurationEditor_UnableFindKConfigFile=Unable to find kconfig_menus.json in the build config folder.\n
+SDKConfigFileNotFound_ErrorMessage=No sdkconfig file found in the project.
+SDKConfigurationFileNotFound_Title=sdkconfig missing


### PR DESCRIPTION
## Description

Added menuconfig option in ESP-IDF menu list for projects

Fixes # ([IEP-1252](https://jira.espressif.com:8443/browse/IEP-1252))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Create project and write click to see the Menu Config option in the ESP-IDF context menu and try to launch SDKConfig Editor using that

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Menu Config" command in the SDK configuration UI for easier access to the MenuConfig editor.
  - Added error handling for scenarios where the SDK configuration file is not found, providing users with clear error messages.

- **Bug Fixes**
  - Enhanced user experience by ensuring feedback is provided when the required configuration file is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->