### PR TITLE
IEP-1329 Application Size Analysis does not work.

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -189,11 +189,12 @@ public class IDFSizeDataManager
 
 	private List<String> addJsonParseCommand()
 	{
-		List<String> arguments = new ArrayList<String>();
+		List<String> arguments = new ArrayList<>();
 		IEnvironmentVariable idfVersionEnv = new IDFEnvironmentVariables()
 				.getEnv(IDFEnvironmentVariables.ESP_IDF_VERSION);
 		String idfVersion = idfVersionEnv != null ? idfVersionEnv.getValue() : null;
-		if (idfVersion != null && Double.parseDouble(idfVersion) >= 5.1)
+
+		if (idfVersion != null && parseVersionWithMultipleDotsToDouble(idfVersion) >= 5.1)
 		{
 			arguments.add("--format"); //$NON-NLS-1$
 			arguments.add("json"); //$NON-NLS-1$
@@ -203,6 +204,12 @@ public class IDFSizeDataManager
 			arguments.add("--json"); //$NON-NLS-1$
 		}
 		return arguments;
+	}
+
+	public double parseVersionWithMultipleDotsToDouble(String version)
+	{
+		String numericVersion = version.replace(".", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		return Double.parseDouble(numericVersion) / Math.pow(10, version.split("\\.").length - 1.0); //$NON-NLS-1$
 	}
 
 	protected List<String> getCommandArgsSymbolDetails(String pythonExecutablenPath, IFile file)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.ui.size;
 
+import java.lang.module.ModuleDescriptor.Version;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +20,6 @@ import org.eclipse.swt.widgets.Display;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.osgi.framework.Version;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
@@ -209,8 +209,8 @@ public class IDFSizeDataManager
 
 	public boolean isVersionAtLeast(String currentIDFVersion, String minimumIDFVersion)
 	{
-		Version currentVersion = Version.parseVersion(currentIDFVersion);
-		Version minVersion = Version.parseVersion(minimumIDFVersion);
+		Version currentVersion = Version.parse(currentIDFVersion);
+		Version minVersion = Version.parse(minimumIDFVersion);
 		return currentVersion.compareTo(minVersion) >= 0;
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -240,6 +240,12 @@ public class IDFSizeDataManager
 	protected JSONObject getJSON(String jsonOutput)
 	{
 		JSONObject jsonObj = null;
+		if (jsonOutput.indexOf("{") != 0) //$NON-NLS-1$
+		{
+			int begin = jsonOutput.indexOf("{") - 1; //$NON-NLS-1$
+			int end = jsonOutput.lastIndexOf("}") + 1; //$NON-NLS-1$
+			jsonOutput = jsonOutput.substring(begin, end);
+		}
 		try
 		{
 			jsonObj = (JSONObject) new JSONParser().parse(jsonOutput);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeDataManager.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.widgets.Display;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.osgi.framework.Version;
 
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.IDFEnvironmentVariables;
@@ -194,7 +195,7 @@ public class IDFSizeDataManager
 				.getEnv(IDFEnvironmentVariables.ESP_IDF_VERSION);
 		String idfVersion = idfVersionEnv != null ? idfVersionEnv.getValue() : null;
 
-		if (idfVersion != null && parseVersionWithMultipleDotsToDouble(idfVersion) >= 5.1)
+		if (idfVersion != null && isVersionAtLeast(idfVersion, "5.1")) //$NON-NLS-1$
 		{
 			arguments.add("--format"); //$NON-NLS-1$
 			arguments.add("json"); //$NON-NLS-1$
@@ -206,10 +207,11 @@ public class IDFSizeDataManager
 		return arguments;
 	}
 
-	public double parseVersionWithMultipleDotsToDouble(String version)
+	public boolean isVersionAtLeast(String currentIDFVersion, String minimumIDFVersion)
 	{
-		String numericVersion = version.replace(".", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		return Double.parseDouble(numericVersion) / Math.pow(10, version.split("\\.").length - 1.0); //$NON-NLS-1$
+		Version currentVersion = Version.parseVersion(currentIDFVersion);
+		Version minVersion = Version.parseVersion(minimumIDFVersion);
+		return currentVersion.compareTo(minVersion) >= 0;
 	}
 
 	protected List<String> getCommandArgsSymbolDetails(String pythonExecutablenPath, IFile file)


### PR DESCRIPTION
## Description

The issue was in parsing esp-idf version with multiple dots, f.e. 5.3.1 

Fixes # ([IEP-1329](https://jira.espressif.com:8443/browse/IEP-1329))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

download esp-idf 5.3.1 and try to open app size analysis

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for robust version comparison, ensuring clarity in version checks.
	- Enhanced JSON output handling for better formatting before parsing.
- **Bug Fixes**
	- Improved the accuracy of version comparisons with a streamlined parsing approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->