### PR TITLE
IEP-1331 Info message in CMakeMainTab is barely visible on Ubuntu

### DIFF
--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/StyledInfoText.java
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/StyledInfoText.java
@@ -1,5 +1,6 @@
 package com.espressif.idf.swt.custom;
 
+import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
@@ -15,6 +16,8 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.themes.CascadingColorRegistry;
 
 import com.espressif.idf.swt.messages.Messages;
 
@@ -33,8 +36,11 @@ public class StyledInfoText
 		var gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.widthHint = 100;
 		styledText.setLayoutData(gd);
-		Color grayColor = parent.getDisplay().getSystemColor(SWT.COLOR_INFO_BACKGROUND);
-		styledText.setBackground(grayColor);
+		@SuppressWarnings("restriction")
+		ColorRegistry colorRegistry = new CascadingColorRegistry(
+				PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry());
+		Color colorInfo = colorRegistry.get("org.eclipse.ui.workbench.INFORMATION_BACKGROUND"); //$NON-NLS-1$
+		styledText.setBackground(colorInfo);
 		styledText.setText(text);
 
 		linkStyleRange = new StyleRange(text.indexOf(Messages.styledTextRestoreDefaultsLinkMsg),


### PR DESCRIPTION
## Description

The system background info color could be barely visible on Ubuntu and other OS:
![image](https://github.com/user-attachments/assets/5ed46596-9fa1-4c25-9249-480854b50bd9)

To fix it, but keep the colors look and feel like in the OS, I've changed the system color to the information background color from the color registry which is different based on the selected theme, which is also helpful with different color themes.
The color is also changeable via eclipse preferences like this: General -> Appearance -> Colors and Fonts ->  Basic -> Information background color

Fixes # ([IEP-1331](https://jira.espressif.com:8443/browse/IEP-1331)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
verify background color on ubuntu 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced background color management for the `StyledText` component to align with the current theme. 

- **Bug Fixes**
	- Improved flexibility in color retrieval by using a theme-based color registry instead of a static system color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->