### PR TITLE
fix: CI for signing jars

### DIFF
--- a/.github/workflows/signjars.yml
+++ b/.github/workflows/signjars.yml
@@ -76,11 +76,20 @@ jobs:
           # Clean up extracted directory (but leave the signed JAR in SIGNED_JARS_DIR)
           rm -rf "$TEMP_DIR"
         done
-
-    - name: Check if signed JAR files exist
+    
+    - name: Verify Signed JAR Files Before Upload
       run: |
-        echo "Checking signed JAR files in ${SIGNED_JARS_DIR}:"
-        ls -al ${SIGNED_JARS_DIR}
+          for jar in ${{ runner.temp }}/signed-jars/*; do
+            echo "Verifying signed JAR: ${jar}"
+            /usr/bin/codesign -dvv "${jar}"
+          done
+
+    - name: Display Signed JAR Files
+      run: |
+        echo "Displaying the signed JAR directory:"
+        ls -al ${{ runner.temp }}/signed-jars/
+        echo "Listing all files in the signed JAR directory:"
+        find ${{ runner.temp }}/signed-jars/ -type f
 
     - name: Upload Signed JAR Files
       if: ${{ !cancelled() }}

--- a/.github/workflows/signjars.yml
+++ b/.github/workflows/signjars.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: Sign jars and internal native libraries
 
 on:
   push:
@@ -8,49 +8,83 @@ on:
 
 jobs:
   build:
-
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
-   
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Sign JARs
+    - name: Codesign JARs and Internal Native Libraries
+      env: 
+        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
       run: |
-        # Export secrets as environment variables
-        export JARSIGNER_KEYSTORE_B64=${{ secrets.JARSIGNER_REL_KEYSTORE_B64 }}
-        export JARSIGNER_STOREPASS=${{ secrets.JARSIGNER_REL_STOREPASS }}
-        export JARSIGNER_ALIAS=${{ secrets.JARSIGNER_REL_ALIAS }}
+        # Step 1: Decode and import the certificate into a keychain
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+        /usr/bin/security create-keychain -p espressif build.keychain
+        /usr/bin/security default-keychain -s build.keychain
+        /usr/bin/security unlock-keychain -p espressif build.keychain
+        /usr/bin/security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+        /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
 
-        # Set up the keystore file path
-        KEYSTORE_FILE="${PWD}/{{secrets.JARSIGNER_KEYSTORE}}"
-        echo "Keystore file: ${KEYSTORE_FILE}"
-
-        # Decode and save the base64-encoded keystore to the file
-        printf "%s" "${JARSIGNER_KEYSTORE_B64}" | base64 -d > "${KEYSTORE_FILE}"
-
-        # Sign all JAR files located in the specified directory
+        # Step 2: Define the directory containing the JARs and native libraries and the temp directory for signed JARs
         LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.serial.monitor/lib"
-        echo "Signing JAR files in ${LIB_DIR}"
+        SIGNED_JARS_DIR="${RUNNER_TEMP}/signed-jars"  # Use GitHub's RUNNER_TEMP for storing signed JARs
+        mkdir -p "$SIGNED_JARS_DIR"
+
+        # Step 3: Extract, sign native libraries, repackage, and sign the JARs with Apple codesign
         for jar in "${LIB_DIR}"/*.jar; do
-          echo "Signing JAR file: ${jar}"
-          jarsigner -keystore "${KEYSTORE_FILE}" \
-                    -storepass "${JARSIGNER_STOREPASS}" \
-                    -signedjar "${jar}" \
-                    "${jar}" "${JARSIGNER_ALIAS}"
+          echo "Processing JAR file: ${jar}"
+
+          # Check if the JAR exists
+          if [ -f "$jar" ]; then
+            echo "JAR file found: ${jar}"
+          else
+            echo "JAR file not found: ${jar}"
+            continue
+          fi
+
+          # Create a temporary directory to extract the JAR contents
+          TEMP_DIR=$(mktemp -d)
+          unzip -q "$jar" -d "$TEMP_DIR"
+
+          # Find and sign all .jnilib and .dylib files in the extracted JAR directory
+          find "$TEMP_DIR" -name "*.jnilib" -o -name "*.dylib" | while read lib; do
+            echo "Signing native library: ${lib}"
+            /usr/bin/codesign -vvvv --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" --timestamp --deep "$lib"
+          done
+
+          # Repackage the signed JAR
+          pushd "$TEMP_DIR"
+          zip -r "${SIGNED_JARS_DIR}/$(basename "$jar")" *  # Save signed JAR to the temporary signed directory
+          popd
+
+          # Sign the entire JAR with Apple codesign, using the same entitlements
+          echo "Signing repackaged JAR: ${SIGNED_JARS_DIR}/$(basename "$jar")"
+          /usr/bin/codesign -vvvv --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --force --deep --options runtime --timestamp -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" "${SIGNED_JARS_DIR}/$(basename "$jar")"
+
+          # Verify the signed JAR
+          echo "Verifying signed JAR: ${SIGNED_JARS_DIR}/$(basename "$jar")"
+          /usr/bin/codesign -dvv "${SIGNED_JARS_DIR}/$(basename "$jar")"
+
+          # Clean up extracted directory (but leave the signed JAR in SIGNED_JARS_DIR)
+          rm -rf "$TEMP_DIR"
         done
 
-        # Clean up the keystore file
-        rm -v "${KEYSTORE_FILE}"
+    - name: Check if signed JAR files exist
+      run: |
+        echo "Checking signed JAR files in ${SIGNED_JARS_DIR}:"
+        ls -al ${SIGNED_JARS_DIR}
 
     - name: Upload Signed JAR Files
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: signed-jar-files
-        path: BUNDLES/com.espressif.idf.serial.monitor/lib/*.jar
+        path: ${{ runner.temp }}/signed-jars/*

--- a/.github/workflows/signjars.yml
+++ b/.github/workflows/signjars.yml
@@ -34,7 +34,7 @@ jobs:
         /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
 
         # Step 2: Define the directory containing the JARs and native libraries and the temp directory for signed JARs
-        LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.serial.monitor/lib"
+        LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.launch.serial.ui/lib"
         SIGNED_JARS_DIR="${RUNNER_TEMP}/signed-jars"  # Use GitHub's RUNNER_TEMP for storing signed JARs
         mkdir -p "$SIGNED_JARS_DIR"
 
@@ -79,10 +79,10 @@ jobs:
     
     - name: Verify Signed JAR Files Before Upload
       run: |
-          for jar in ${{ runner.temp }}/signed-jars/*; do
-            echo "Verifying signed JAR: ${jar}"
-            /usr/bin/codesign -dvv "${jar}"
-          done
+        for jar in ${{ runner.temp }}/signed-jars/*; do
+          echo "Verifying signed JAR: ${jar}"
+          /usr/bin/codesign -dvv "${jar}"
+        done
 
     - name: Display Signed JAR Files
       run: |

--- a/.github/workflows/signjars.yml
+++ b/.github/workflows/signjars.yml
@@ -1,0 +1,56 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+   
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Sign JARs
+      run: |
+        # Export secrets as environment variables
+        export JARSIGNER_KEYSTORE_B64=${{ secrets.JARSIGNER_REL_KEYSTORE_B64 }}
+        export JARSIGNER_STOREPASS=${{ secrets.JARSIGNER_REL_STOREPASS }}
+        export JARSIGNER_ALIAS=${{ secrets.JARSIGNER_REL_ALIAS }}
+
+        # Set up the keystore file path
+        KEYSTORE_FILE="${PWD}/{{secrets.JARSIGNER_KEYSTORE}}"
+        echo "Keystore file: ${KEYSTORE_FILE}"
+
+        # Decode and save the base64-encoded keystore to the file
+        printf "%s" "${JARSIGNER_KEYSTORE_B64}" | base64 -d > "${KEYSTORE_FILE}"
+
+        # Sign all JAR files located in the specified directory
+        LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.serial.monitor/lib"
+        echo "Signing JAR files in ${LIB_DIR}"
+        for jar in "${LIB_DIR}"/*.jar; do
+          echo "Signing JAR file: ${jar}"
+          jarsigner -keystore "${KEYSTORE_FILE}" \
+                    -storepass "${JARSIGNER_STOREPASS}" \
+                    -signedjar "${jar}" \
+                    "${jar}" "${JARSIGNER_ALIAS}"
+        done
+
+        # Clean up the keystore file
+        rm -v "${KEYSTORE_FILE}"
+
+    - name: Upload Signed JAR Files
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: signed-jar-files
+        path: BUNDLES/com.espressif.idf.serial.monitor/lib/*.jar

--- a/.github/workflows/signjars.yml
+++ b/.github/workflows/signjars.yml
@@ -34,7 +34,7 @@ jobs:
         /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
 
         # Step 2: Define the directory containing the JARs and native libraries and the temp directory for signed JARs
-        LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.launch.serial.ui/lib"
+        LIB_DIR="${PWD}/BUNDLES/com.espressif.idf.launch.serial.ui/libs"
         SIGNED_JARS_DIR="${RUNNER_TEMP}/signed-jars"  # Use GitHub's RUNNER_TEMP for storing signed JARs
         mkdir -p "$SIGNED_JARS_DIR"
 


### PR DESCRIPTION
## Description

Use this PR for Apple code signing of internal libraries, as it is mandatory for notarization approval.

This will produce the signed artifacts, download them and replace them in the plugins.

