### PR TITLE
IEP-1301: Null Build error if you're building a project with out any esp-idf version

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -66,8 +66,10 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.debug.core.DebugPlugin;
@@ -278,7 +280,12 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 	public ICMakeToolChainFile getToolChainFile() throws CoreException
 	{
 		ICMakeToolChainManager manager = IDFCorePlugin.getService(ICMakeToolChainManager.class);
-		this.toolChainFile = manager.getToolChainFileFor(getToolChain());
+		IToolChain toolChain = getToolChain();
+		if (toolChain == null)
+		{
+			throw new CoreException(new Status(IStatus.ERROR, IDFCorePlugin.PLUGIN_ID, Messages.IDFToolChainsMissingErrorMsg));
+		}
+		this.toolChainFile = manager.getToolChainFileFor(toolChain);
 		return toolChainFile;
 	}
 
@@ -388,6 +395,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 			return false;
 		}
+		
+		
 
 		return true;
 	}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -32,6 +32,7 @@ public class Messages extends NLS
 	public static String ToolsInitializationDifferentPathMessageBoxTitle;
 	public static String ToolsInitializationDifferentPathMessageBoxOptionYes;
 	public static String ToolsInitializationDifferentPathMessageBoxOptionNo;
+	public static String IDFToolChainsMissingErrorMsg;
 
 	public static String RefreshingProjects_JobName;
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -24,4 +24,4 @@ ToolsInitializationDifferentPathMessageBoxOptionYes=Use New Path
 ToolsInitializationDifferentPathMessageBoxOptionNo=Use Old Path
 RefreshingProjects_JobName=Refreshing Projects...
 IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path.\nThe currently active ESP-IDF path in the IDE is {1}.\nPlease clean the project using "ESP-IDF:Project Full Clean" menu option to use the active ESP-IDF configuration. 
-IDFToolChainsMissingErrorMsg=Toolchains are missing please verify that idf tools are installed
+IDFToolChainsMissingErrorMsg=Toolchains are missing. Please use ESP-IDF Manager for configuring

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -24,3 +24,4 @@ ToolsInitializationDifferentPathMessageBoxOptionYes=Use New Path
 ToolsInitializationDifferentPathMessageBoxOptionNo=Use Old Path
 RefreshingProjects_JobName=Refreshing Projects...
 IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path.\nThe currently active ESP-IDF path in the IDE is {1}.\nPlease clean the project using "ESP-IDF:Project Full Clean" menu option to use the active ESP-IDF configuration. 
+IDFToolChainsMissingErrorMsg=Toolchains are missing please verify that idf tools are installed


### PR DESCRIPTION
## Description

Fixed the error message in case the toolchains are missing

Fixes # ([IEP-1301](https://jira.espressif.com:8443/browse/IEP-1301))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please follow steps in Jira ticket

**Test Configuration**:
* ESP-IDF Version: any 
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for toolchain retrieval in the build configuration.
	- Added a specific error message for missing toolchains to assist users in troubleshooting.

- **Bug Fixes**
	- Improved validation process for project description IDF path against the environment variable IDF path.

- **Documentation**
	- Updated messaging capabilities with a new localized error message for missing toolchains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->