### PR TITLE
IEP-1346 Make it possible to copy values ​​from fields with dynamic variables

### DIFF
--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/TextWithButton.java
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/TextWithButton.java
@@ -28,6 +28,7 @@ public class TextWithButton
 	private Text text;
 	private Label button;
 	private Composite baseComposite;
+	private String textWithDynamicVariables;
 
 	public TextWithButton(final Composite parent, int style)
 	{
@@ -54,30 +55,36 @@ public class TextWithButton
 		button.setImage(buttonShowImage);
 		button.addMouseListener(new MouseAdapter()
 		{
-			String textWhenButtonIsPressed;
-
-			@Override
-			public void mouseUp(final MouseEvent e)
-			{
-				button.setImage(buttonShowImage);
-				text.setText(textWhenButtonIsPressed);
-			}
 
 			@Override
 			public void mouseDown(final MouseEvent e)
 			{
-				button.setImage(buttonHideImage);
-				textWhenButtonIsPressed = text.getText();
+				// text is not editable means that the button isn't pressed now and we have to show dynamic variables
+				if (!text.getEditable())
+				{
+					showDynamicVariables();
+					return;
+				}
 
+				button.setImage(buttonHideImage);
+				textWithDynamicVariables = text.getText();
+				text.setEditable(false);
 				try
 				{
 					text.setText(VariablesPlugin.getDefault().getStringVariableManager()
-							.performStringSubstitution((textWhenButtonIsPressed), false));
+							.performStringSubstitution((textWithDynamicVariables), false));
 				}
 				catch (CoreException e1)
 				{
 					Logger.log(e1);
 				}
+			}
+
+			private void showDynamicVariables()
+			{
+				text.setEditable(true);
+				button.setImage(buttonShowImage);
+				text.setText(textWithDynamicVariables);
 			}
 
 		});
@@ -97,9 +104,12 @@ public class TextWithButton
 		text.addMouseTrackListener(mouseTrackAdapter);
 	}
 
+	/*
+	 * Always return text with dynamic variables.
+	 */
 	public String getText()
 	{
-		return text.getText();
+		return text.getEditable() ? text.getText() : textWithDynamicVariables;
 	}
 
 	public Control getControl()


### PR DESCRIPTION
## Description
Previously, when we clicked a button in a text box to show a dynamic variable, we had to hold it down. Users can now click on it once and the dynamic variables will be resolved, but the text will not be editable.

Fixes # ([IEP-1346](https://jira.espressif.com:8443/browse/IEP-1346))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?
- click resolve dynamic variables button (eye button in the text field) and save the setting in the main tab or the debugger tab -> click edit again -> the fields should be with dynamic variables 
- run flash, jtag flash, debug
- when we resolve dynamic variables the text field should not be editable, when we have dynamic variables or the eye icon isn't clicked we can edit it

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Main tab in the launch configuration
- Debugger tab in the debug configuration

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of dynamic variables in the text field for improved interactivity.
	- Added functionality to display dynamic variables when the text field is non-editable.
- **Bug Fixes**
	- Updated text retrieval to ensure dynamic variables are returned correctly when the text field is not editable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->