### PR TITLE
IEP-1279 Verify clangd editor features and find the gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To get a quick understanding of ESP-IDF and Eclipse plugin features, check our s
   <summary>Other IDE Features</summary>
 
 * [ Configuring the Project using sdkconfig Editor](#projectconfigure)<br>
+* [ LSP Editor](#lspeditor)<br>
 * [ CMake Editor](#cmakeproject)<br>
 * [ ESP-IDF Application Size Analysis Editor](#sizeanalysiseditor)<br>
 * [ Installing ESP-IDF Components](#espidfcomponents)<br>
@@ -259,6 +260,65 @@ To launch the SDK Configuration editor:
 1. To revert the sdkconfig editor changes, you can either close the editor without saving them or you can right-click on the `sdkconfig` file and select `Load sdkconfig` menu option to revert the changes from the editor.
 
 ![](docs_readme/images/13_sdkconfig_editor.png)
+
+<a name="lspeditor"></a>
+# LSP Editor
+Starting with Espressif IDE 3.0.0, the default code editor is the LSP Editor, which differs in several ways from the previous default editor. Below are the most notable differences:
+
+## Formatting
+To customize the formatting, open the .clang-format file located in your project. By default, the file contains the following content: 
+
+```
+BasedOnStyle: LLVM
+UseTab: Always
+IndentWidth: 4
+TabWidth: 4
+PackConstructorInitializers: NextLineOnly
+BreakConstructorInitializers: AfterColon
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+```
+You can also disable formatting for specific folders by using the `DisableFormat: true option.` For example, if you want to disable formatting for the managed_components folder in a project structured like this:
+```
+project
+ - managed_components
+        - .clang-format  
+ - main
+ - .clang-format
+``` 
+Add the `DisableFormat: true` option to the `.clang-format` file located in the managed_components folder. This flag tells ClangFormat to completely ignore this specific `.clang-format` file and its formatting rules within the managed-components directory.
+
+For more information about available style options, refer to [the Clang-Format Style Options guide](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options).
+
+## Search
+The “search text” option in the right-click menu is currently unavailable in the LSP-based C/C++ Editor. However, you can use the toolbar menu **Search > Text > Workspace** as a workaround.
+<a name="cmakeproject"></a>
+
+## Inlay Hints
+The LSP Editor has inlay hints enabled by default. If you prefer not to use them, you can disable this feature by editing the `.clangd` file:
+```
+CompileFlags:
+  CompilationDatabase: build
+  Remove: 
+    - -m*
+    - -f*
+
+InlayHints:
+  Enabled: No
+```
+## Searching ESP-IDF Components
+To browse ESP-IDF components, follow these steps:
+- Create a new project.
+- Add the ESP-IDF components folder as a virtual folder to the newly created project.
+- Press **Ctrl + Shift + T** or **Ctrl + Shift + R**.
+- You should now be able to browse the ESP-IDF component files.
+- To search for a specific function or keyword, use the Search menu in the toolbar.
+
+Creating a Virtual Folder
+- Navigate to **New > Folder.**
+- Click on **Advanced.**
+- Select **Link to alternate Location (Linked Folder)**.
+- Click **Browse** and select the `ESP-IDF components` folder.
 
 <a name="cmakeproject"></a>
 # CMake Editor

--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ Creating a Virtual Folder
 - Select **Link to alternate Location (Linked Folder)**.
 - Click **Browse** and select the `ESP-IDF components` folder.
 
+It is recommended to always create a new project instead of modifying your current one to avoid unnecessary Git files and error markers created by the indexer for the components folder. As both the projects will be in the same workspace, you should be able to search anywhere within your workspace.
+
 <a name="cmakeproject"></a>
 # CMake Editor
 


### PR DESCRIPTION
## Description

Updating the README to clarify differences with the old editor

Fixes # ([IEP-1279](https://jira.espressif.com:8443/browse/IEP-1279))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section on "LSP Editor" in the README, detailing features, functionalities, and customization options.
	- Included instructions for formatting and searching within the LSP Editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->