### PR TITLE
IEP-1336 Convert partitions.csv or nvs.csv model windows to editors

### DIFF
--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -713,6 +713,26 @@
 			id="com.espressif.idf.ui.manageespidf"
 			name="%editor.espidf.manager.name">
 		</editor>
+  <editor
+        class="com.espressif.idf.ui.nvs.dialog.NvsEditor"
+        default="false"
+        icon="icons/ESP-IDF_NVS_Table_Editor.png"
+        id="com.espressif.idf.ui.nvs_table_editor"
+        name="NVS Table Editor">
+     <contentTypeBinding
+           contentTypeId="com.espressif.idf.ui.nvs_editor_content_type">
+     </contentTypeBinding>
+  </editor>
+  <editor
+        class="com.espressif.idf.ui.partitiontable.dialog.PartitionTableEditor"
+        default="false"
+        icon="icons/ESP-IDF_Partition_Table_Editor.png"
+        id="com.espressif.idf.ui.partition_table_editor"
+        name="Partition Table Editor">
+     <contentTypeBinding
+           contentTypeId="com.espressif.idf.ui.partition_editor_content_type">
+     </contentTypeBinding>
+  </editor>
 	</extension>
 	<extension
 		point="org.eclipse.ui.views">
@@ -818,6 +838,18 @@
 			file-extensions="md"
 			file-names="README.md">
 		</file-association>
+  <content-type
+        file-patterns="nvs.csv"
+        id="com.espressif.idf.ui.nvs_editor_content_type"
+        name="NVS Table"
+        priority="normal">
+  </content-type>
+  <content-type
+        file-patterns="partitions.csv"
+        id="com.espressif.idf.ui.partition_editor_content_type"
+        name="Partition Table"
+        priority="normal">
+  </content-type>
 	</extension>
 	<extension
 		point="org.eclipse.ltk.core.refactoring.renameParticipants">

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/nvs/dialog/NvsEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/nvs/dialog/NvsEditor.java
@@ -1,0 +1,50 @@
+package com.espressif.idf.ui.nvs.dialog;
+
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.ui.part.MultiPageEditorPart;
+
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.ui.nvs.handlers.NvsEditorHandler;
+
+public class NvsEditor extends MultiPageEditorPart
+{
+
+	public NvsEditor()
+	{
+		try
+		{
+			new NvsEditorHandler().execute(null);
+		}
+		catch (ExecutionException e)
+		{
+			Logger.log(e);
+		}
+
+	}
+
+	protected void createPages()
+	{
+		// TODO Auto-generated method stub
+		getSite().getPage().closeEditor(this, false);
+	}
+
+	public void doSave(IProgressMonitor monitor)
+	{
+		// TODO Auto-generated method stub
+
+	}
+
+	public void doSaveAs()
+	{
+		// TODO Auto-generated method stub
+
+	}
+
+	public boolean isSaveAsAllowed()
+	{
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/nvs/dialog/NvsEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/nvs/dialog/NvsEditor.java
@@ -2,6 +2,9 @@ package com.espressif.idf.ui.nvs.dialog;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.MultiPageEditorPart;
 
 import com.espressif.idf.core.logging.Logger;
@@ -9,41 +12,43 @@ import com.espressif.idf.ui.nvs.handlers.NvsEditorHandler;
 
 public class NvsEditor extends MultiPageEditorPart
 {
-
 	public NvsEditor()
 	{
-		try
-		{
-			new NvsEditorHandler().execute(null);
-		}
-		catch (ExecutionException e)
-		{
-			Logger.log(e);
-		}
+		PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+			try
+			{
+				new NvsEditorHandler().execute(null);
+			}
+			catch (ExecutionException e)
+			{
+				Logger.log(e);
+			}
+		});
 
 	}
 
 	protected void createPages()
 	{
-		// TODO Auto-generated method stub
-		getSite().getPage().closeEditor(this, false);
+		Composite emptyPage = new Composite(getContainer(), SWT.NONE);
+
+		int index = addPage(emptyPage);
+		setPageText(index, "Empty Page"); //$NON-NLS-1$
+		getSite().getShell().getDisplay().asyncExec(() -> getSite().getPage().closeEditor(this, false));
+
 	}
 
 	public void doSave(IProgressMonitor monitor)
 	{
-		// TODO Auto-generated method stub
-
+		// Nothing to do
 	}
 
 	public void doSaveAs()
 	{
-		// TODO Auto-generated method stub
-
+		// Nothing to do
 	}
 
 	public boolean isSaveAsAllowed()
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/partitiontable/dialog/PartitionTableEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/partitiontable/dialog/PartitionTableEditor.java
@@ -1,0 +1,48 @@
+package com.espressif.idf.ui.partitiontable.dialog;
+
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.ui.part.MultiPageEditorPart;
+
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.ui.partitiontable.handlers.PartitionTableEditorHandler;
+
+public class PartitionTableEditor extends MultiPageEditorPart
+{
+
+	public PartitionTableEditor()
+	{
+		try
+		{
+			new PartitionTableEditorHandler().execute(null);
+		}
+		catch (ExecutionException e)
+		{
+			Logger.log(e);
+		}
+	}
+
+	protected void createPages()
+	{
+		getSite().getPage().closeEditor(this, false);
+	}
+
+	public void doSave(IProgressMonitor monitor)
+	{
+		// TODO Auto-generated method stub
+
+	}
+
+	public void doSaveAs()
+	{
+		// TODO Auto-generated method stub
+
+	}
+
+	public boolean isSaveAsAllowed()
+	{
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/partitiontable/dialog/PartitionTableEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/partitiontable/dialog/PartitionTableEditor.java
@@ -2,6 +2,9 @@ package com.espressif.idf.ui.partitiontable.dialog;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.MultiPageEditorPart;
 
 import com.espressif.idf.core.logging.Logger;
@@ -12,36 +15,41 @@ public class PartitionTableEditor extends MultiPageEditorPart
 
 	public PartitionTableEditor()
 	{
-		try
-		{
-			new PartitionTableEditorHandler().execute(null);
-		}
-		catch (ExecutionException e)
-		{
-			Logger.log(e);
-		}
+		PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+			try
+			{
+				new PartitionTableEditorHandler().execute(null);
+			}
+			catch (ExecutionException e)
+			{
+				Logger.log(e);
+			}
+		});
+
 	}
 
 	protected void createPages()
 	{
-		getSite().getPage().closeEditor(this, false);
+		Composite emptyPage = new Composite(getContainer(), SWT.NONE);
+
+		int index = addPage(emptyPage);
+		setPageText(index, "Empty Page"); //$NON-NLS-1$
+		getSite().getShell().getDisplay().asyncExec(() -> getSite().getPage().closeEditor(this, false));
 	}
 
 	public void doSave(IProgressMonitor monitor)
 	{
-		// TODO Auto-generated method stub
+		// Nothing to do
 
 	}
 
 	public void doSaveAs()
 	{
-		// TODO Auto-generated method stub
-
+		// Nothing to do
 	}
 
 	public boolean isSaveAsAllowed()
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 


### PR DESCRIPTION
## Description

To avoid overriding and adjusting a lot of code, I'm using MultiPageEditor as a handler to call a TitleAreaDialog. 

Fixes # ([IEP-1336](https://jira.espressif.com:8443/browse/IEP-1336))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Use the NVS table editor and partition table editor In the old way once to create nvs.csv and partititons.csv
- Verify it opens and works correctly with double click, similar to sdkconfig

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- NVS table editor
- Partition table editor

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new editors: NVS Table Editor and Partition Table Editor.
	- Added support for new content types for handling `.nvs.csv` and `.partitions.csv` files.

- **Improvements**
	- Enhanced command and menu structures to integrate new editors and functionalities, improving user accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->