### PR TITLE
IEP-1371 Language Server hangs on 28% when a project contains spaces

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -487,7 +487,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				paritionSizeHandler.startCheckingSize();
 
 				LspService lspService = new LspService();
-				lspService.updateAdditionalOptions(String.format("--compile-commands-dir=\"%s\"", buildDir)); //$NON-NLS-1$
+				lspService.updateAdditionalOptions(String.format("--compile-commands-dir=%s", buildDir)); //$NON-NLS-1$
 				lspService.restartLspServers();
 			}
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfiguration.java
@@ -283,7 +283,8 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		IToolChain toolChain = getToolChain();
 		if (toolChain == null)
 		{
-			throw new CoreException(new Status(IStatus.ERROR, IDFCorePlugin.PLUGIN_ID, Messages.IDFToolChainsMissingErrorMsg));
+			throw new CoreException(
+					new Status(IStatus.ERROR, IDFCorePlugin.PLUGIN_ID, Messages.IDFToolChainsMissingErrorMsg));
 		}
 		this.toolChainFile = manager.getToolChainFileFor(toolChain);
 		return toolChainFile;
@@ -395,8 +396,6 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 
 			return false;
 		}
-		
-		
 
 		return true;
 	}
@@ -430,10 +429,10 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 					}
 				}
 			}
-			
+
 			envVars.add(new EnvironmentVariable(IDFCorePreferenceConstants.IDF_TOOLS_PATH,
 					IDFUtil.getIDFToolsPathFromPreferences()));
-			
+
 			String buildCommand = getProperty(BUILD_COMMAND);
 			if (buildCommand.isBlank())
 			{
@@ -488,7 +487,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 				paritionSizeHandler.startCheckingSize();
 
 				LspService lspService = new LspService();
-				lspService.updateAdditionalOptions(String.format("--compile-commands-dir=%s", buildDir)); //$NON-NLS-1$
+				lspService.updateAdditionalOptions(String.format("--compile-commands-dir=\"%s\"", buildDir)); //$NON-NLS-1$
 				lspService.restartLspServers();
 			}
 
@@ -536,7 +535,7 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		{
 			command.add("-DIDF_TOOLCHAIN=clang"); //$NON-NLS-1$
 		}
-		
+
 		String userArgs = getProperty(CMAKE_ARGUMENTS);
 		if (userArgs != null && !userArgs.isBlank())
 		{
@@ -554,10 +553,11 @@ public class IDFBuildConfiguration extends CBuildConfiguration
 		// Set PYTHONUNBUFFERED to 1/TRUE to dump the messages back immediately without
 		// buffering
 		IEnvironmentVariable bufferEnvVar = new EnvironmentVariable("PYTHONUNBUFFERED", "1"); //$NON-NLS-1$ //$NON-NLS-2$
-		IEnvironmentVariable idfToolsPathEnvVar = new EnvironmentVariable(IDFCorePreferenceConstants.IDF_TOOLS_PATH, IDFUtil.getIDFToolsPathFromPreferences());
+		IEnvironmentVariable idfToolsPathEnvVar = new EnvironmentVariable(IDFCorePreferenceConstants.IDF_TOOLS_PATH,
+				IDFUtil.getIDFToolsPathFromPreferences());
 
-		Process p = startBuildProcess(command, new IEnvironmentVariable[] { bufferEnvVar, idfToolsPathEnvVar }, workingDir, errConsole,
-				monitor);
+		Process p = startBuildProcess(command, new IEnvironmentVariable[] { bufferEnvVar, idfToolsPathEnvVar },
+				workingDir, errConsole, monitor);
 		if (p == null)
 		{
 			console.getErrorStream().write(String.format(Messages.CMakeBuildConfiguration_Failure, "")); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.espressif.idf.lsp
 Bundle-ActivationPolicy: lazy
 Bundle-Name: ESP-IDF LSP Plugin
-Service-Component: OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdEnable.xml,
- OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdOptionsDefaults.xml
+Service-Component: OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdEnable.xml,OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdOptionsDefaults.xml,
+ OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccess.xml

--- a/bundles/com.espressif.idf.lsp/OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccess.xml
+++ b/bundles/com.espressif.idf.lsp/OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccess.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccess">
+   <property name="service.ranking" type="Integer" value="100"/>
+   <service>
+      <provide interface="org.eclipse.cdt.lsp.clangd.ClangdConfiguration"/>
+   </service>
+   <reference cardinality="1..1" field="metadata" interface="org.eclipse.cdt.lsp.clangd.ClangdMetadata" name="metadata"/>
+   <reference cardinality="1..1" field="workspace" interface="org.eclipse.core.resources.IWorkspace" name="workspace"/>
+   <implementation class="com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccess"/>
+</scr:component>

--- a/bundles/com.espressif.idf.lsp/build.properties
+++ b/bundles/com.espressif.idf.lsp/build.properties
@@ -10,9 +10,10 @@
 # Contributors:
 #     See git history
 ###############################################################################
+
 bin.includes = META-INF/,\
                OSGI-INF/,\
                plugin.xml,\
-               .,\
-source.. = src/
+               .
 output.. = bin/
+source.. = src/

--- a/bundles/com.espressif.idf.lsp/build.properties
+++ b/bundles/com.espressif.idf.lsp/build.properties
@@ -14,6 +14,5 @@ bin.includes = META-INF/,\
                OSGI-INF/,\
                plugin.xml,\
                .,\
-               OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccessTests.xml
 source.. = src/
 output.. = bin/

--- a/bundles/com.espressif.idf.lsp/build.properties
+++ b/bundles/com.espressif.idf.lsp/build.properties
@@ -10,10 +10,10 @@
 # Contributors:
 #     See git history
 ###############################################################################
-
 bin.includes = META-INF/,\
                OSGI-INF/,\
                plugin.xml,\
-               .
-output.. = bin/
+               .,\
+               OSGI-INF/com.espressif.idf.lsp.preferences.IDFClangdConfigurationAccessTests.xml
 source.. = src/
+output.. = bin/

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdConfigurationAccess.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdConfigurationAccess.java
@@ -1,0 +1,114 @@
+package com.espressif.idf.lsp.preferences;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
+import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
+import org.eclipse.cdt.lsp.clangd.ClangdOptions;
+import org.eclipse.cdt.lsp.clangd.ClangdQualifier;
+import org.eclipse.cdt.lsp.config.ConfigurationAccess;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IPreferenceMetadataStore;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.OsgiPreferenceMetadataStore;
+import org.eclipse.osgi.util.NLS;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = ClangdConfiguration.class, property = "service.ranking:Integer=100")
+public class IDFClangdConfigurationAccess extends ConfigurationAccess implements ClangdConfiguration
+{
+
+	@Reference
+	private ClangdMetadata metadata;
+
+	@Reference
+	private IWorkspace workspace;
+
+	public IDFClangdConfigurationAccess()
+	{
+		super(new ClangdQualifier().get());
+	}
+
+	@Override
+	public ClangdMetadata metadata()
+	{
+		return metadata;
+	}
+
+	@Override
+	public ClangdOptions defaults()
+	{
+		return new IDFClangdPreferredOptions(qualifier, new IScopeContext[] { DefaultScope.INSTANCE }, metadata);
+	}
+
+	@Override
+	public ClangdOptions options(Object context)
+	{
+		Optional<ProjectScope> project = projectScope(workspace, context);
+		IScopeContext[] scopes;
+		if (project.isPresent())
+		{
+			scopes = new IScopeContext[] { project.get(), InstanceScope.INSTANCE, DefaultScope.INSTANCE };
+		}
+		else
+		{
+			scopes = new IScopeContext[] { InstanceScope.INSTANCE, DefaultScope.INSTANCE };
+		}
+		return new IDFClangdPreferredOptions(qualifier, scopes, metadata);
+
+	}
+
+	@Override
+	public IPreferenceMetadataStore storage(Object context)
+	{
+		return new OsgiPreferenceMetadataStore(//
+				preferences(//
+						projectScope(workspace, context)//
+								.map(IScopeContext.class::cast)//
+								.orElse(InstanceScope.INSTANCE)));
+	}
+
+	@Override
+	public String qualifier()
+	{
+		return qualifier;
+	}
+
+	@Override
+	public List<String> commands(Object context)
+	{
+		ClangdOptions options = options(context);
+		List<String> list = new ArrayList<>();
+		list.add(options.clangdPath());
+		if (options.useTidy())
+		{
+			list.add("--clang-tidy"); //$NON-NLS-1$
+		}
+		if (options.useBackgroundIndex())
+		{
+			list.add("--background-index"); //$NON-NLS-1$
+		}
+		if (!options.completionStyle().isBlank())
+		{
+			list.add(NLS.bind("--completion-style={0}", options.completionStyle())); //$NON-NLS-1$
+		}
+		if (options.prettyPrint())
+		{
+			list.add("--pretty"); //$NON-NLS-1$
+		}
+		if (!options.queryDriver().isBlank())
+		{
+			list.add(NLS.bind("--query-driver={0}", options.queryDriver())); //$NON-NLS-1$
+		}
+
+		list.addAll(options.additionalOptions());
+		return list;
+	}
+
+}

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdPreferredOptions.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdPreferredOptions.java
@@ -1,0 +1,94 @@
+package com.espressif.idf.lsp.preferences;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
+import org.eclipse.cdt.lsp.clangd.ClangdOptions;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.PreferenceMetadata;
+
+public class IDFClangdPreferredOptions implements ClangdOptions
+{
+	private final String qualifier;
+	private final IScopeContext[] scopes;
+	private final ClangdMetadata metadata;
+
+	IDFClangdPreferredOptions(String qualifier, IScopeContext[] scopes, ClangdMetadata metadata)
+	{
+		this.qualifier = Objects.requireNonNull(qualifier);
+		this.scopes = Objects.requireNonNull(scopes);
+		this.metadata = Objects.requireNonNull(metadata);
+	}
+
+	@Override
+	public String clangdPath()
+	{
+		return stringValue(metadata.clangdPath());
+	}
+
+	@Override
+	public boolean useTidy()
+	{
+		return booleanValue(metadata.useTidy());
+	}
+
+	@Override
+	public boolean useBackgroundIndex()
+	{
+		return booleanValue(metadata.useBackgroundIndex());
+	}
+
+	@Override
+	public String completionStyle()
+	{
+		return stringValue(metadata.completionStyle());
+	}
+
+	@Override
+	public boolean prettyPrint()
+	{
+		return booleanValue(metadata.prettyPrint());
+	}
+
+	@Override
+	public String queryDriver()
+	{
+		return stringValue(metadata.queryDriver());
+	}
+
+	@Override
+	public List<String> additionalOptions()
+	{
+		var options = stringValue(metadata.additionalOptions());
+		if (options.isBlank())
+		{
+			return new ArrayList<>();
+		}
+		return Arrays.asList(options.split(System.lineSeparator()));
+	}
+
+	private String stringValue(PreferenceMetadata<?> meta)
+	{
+		String actual = String.valueOf(meta.defaultValue());
+		for (int i = scopes.length - 1; i >= 0; i--)
+		{
+			IScopeContext scope = scopes[i];
+			String previous = actual;
+			actual = scope.getNode(qualifier).get(meta.identifer(), previous);
+		}
+		return actual;
+	}
+
+	private boolean booleanValue(PreferenceMetadata<Boolean> meta)
+	{
+		return Optional.of(meta)//
+				.map(this::stringValue)//
+				.map(Boolean::valueOf)//
+				.orElseGet(meta::defaultValue);
+	}
+
+}


### PR DESCRIPTION
## Description

Language Server hangs on 28% when a project contains spaces. Fixed by enclosing build folder path in quoting marks 

Fixes # ([IEP-1371](https://jira.espressif.com:8443/browse/IEP-1371))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Build and check language server initialization process with different scenarios (project has/hasn't white spaces etc.)

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration access component for managing Clangd settings.
	- Added structured management for Clangd configuration options.

- **Bug Fixes**
	- Improved error handling for missing toolchain with clearer exception messages.

- **Refactor**
	- Updated formatting for better readability in several methods, including multi-line declarations.
	- Consolidated service component declarations for improved clarity.

- **Chores**
	- Removed unnecessary blank lines for a cleaner codebase.
	- Updated build properties to include new configuration access tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->