### PR TITLE
IEP-1375 Master branch: unable to flash projects.

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -174,7 +174,10 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 
 		// Reading CDT build environment variables
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
-
+		if (envMap.containsKey("PATH") && envMap.containsKey("Path")) //$NON-NLS-1$
+		{
+			envMap.remove("Path"); //$NON-NLS-1$
+		}
 		// Turn it into an envp format
 		List<String> strings = new ArrayList<>(envMap.size());
 		for (Entry<String, String> entry : envMap.entrySet())
@@ -184,6 +187,7 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 			strings.add(buffer.toString());
 		}
 		Logger.log(String.format("flash command: %s", String.join(" ", commands))); //$NON-NLS-1$ //$NON-NLS-2$
+
 		String[] envArray = strings.toArray(new String[strings.size()]);
 		Process p = DebugPlugin.exec(commands.toArray(new String[0]), workingDir, envArray);
 		DebugPlugin.newProcess(launch, p, String.join(" ", commands)); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
@@ -193,7 +193,10 @@ public class ToolsActivationJob extends ToolsJob
 
 		IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
 		idfEnvironmentVariables.removeAllEnvVariables();
-		idfToolSet.getEnvVars().forEach(idfEnvironmentVariables::addEnvVariable);
+		idfToolSet.getEnvVars().forEach((key, value) -> {
+			if (value != null)
+				idfEnvironmentVariables.addEnvVariable(key, value);
+		});
 		String path = replacePathVariable(idfToolSet.getEnvVars().get(IDFEnvironmentVariables.PATH));
 
 		idfEnvironmentVariables.addEnvVariable(IDFEnvironmentVariables.PATH, path);


### PR DESCRIPTION
## Description

The problem happens because some environmental variables are missing in the eclipse. Fixed by adding all variables from idfToolSet like this:
`idfToolSet.getEnvVars().forEach(idfEnvironmentVariables::addEnvVariable);`

Fixes # ([IEP-1375](https://jira.espressif.com:8443/browse/IEP-1375))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Download esp-idf master
- Install tools
- Build and Flash new project

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build/Flash
- Tools

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for null `idfToolSet`, ensuring proper error status is returned.
	- Enhanced logging for flash commands to provide clearer output.

- **New Features**
	- Enhanced clarity in comments and documentation for better understanding.
	- Streamlined the addition of environment variables, simplifying the process.

- **Refactor**
	- Simplified logic in the `run` method and improved code readability.
	- Updated handling of the `PATH` variable for better processing.
	- Refined environment variable management to prevent conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->