### PR TITLE
fix: Update the new docs link

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/help/EclipsePluginDocHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/help/EclipsePluginDocHandler.java
@@ -41,7 +41,7 @@ public class EclipsePluginDocHandler extends AbstractHandler {
 	}
 
 	protected URL getDocsUrl() throws MalformedURLException {
-		return new URL("https://github.com/espressif/idf-eclipse-plugin#esp-idf-eclipse-plugin"); //$NON-NLS-1$
+		return new URL("https://docs.espressif.com/projects/espressif-ide/en/latest/index.html"); //$NON-NLS-1$
 	}
 
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-1384](https://jira.espressif.com:8443/browse/IEP-1384))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Navigate to Help > ESP-IDF Eclipse Plugin and that should take you to the new documentation link https://docs.espressif.com/projects/espressif-ide/en/latest/index.html

**Test Configuration**:
* ESP-IDF Version: NA
* OS (Windows,Linux and macOS): NA

## Dependent components impacted by this PR:

- Help

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation link for the Eclipse plugin to point to the latest official documentation.
  
- **Bug Fixes**
	- Improved error handling for documentation retrieval without altering existing exception management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->