### PR TITLE
IEP-1385 ESP-IDF:MenuConfig: feature uses any sdkconfig file if multiple projects open.

### DIFF
--- a/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/OpenSdkConfigEditor.java
+++ b/bundles/com.espressif.idf.sdk.config.ui/src/com/espressif/idf/sdk/config/ui/OpenSdkConfigEditor.java
@@ -5,13 +5,13 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.ide.IDE;
+
+import com.espressif.idf.ui.EclipseUtil;
 
 public class OpenSdkConfigEditor extends AbstractHandler
 {
@@ -22,7 +22,7 @@ public class OpenSdkConfigEditor extends AbstractHandler
 	public Object execute(ExecutionEvent event) throws ExecutionException
 	{
 		IWorkbenchPage page = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage();
-		IProject project = getCurrentProject();
+		IProject project = EclipseUtil.getSelectedProjectInExplorer();
 		try
 		{
 			IFile sdkConfigFile = project.getFile(SDKCONFIG_FILE_NAME);
@@ -41,23 +41,6 @@ public class OpenSdkConfigEditor extends AbstractHandler
 			throw new ExecutionException("Error opening sdkconfig file", e);
 		}
 
-		return null;
-	}
-
-	/**
-	 * Get the currently selected project in the workspace.
-	 */
-	private IProject getCurrentProject()
-	{
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject[] projects = root.getProjects();
-		for (IProject project : projects)
-		{
-			if (project.isOpen() && project.getFile(SDKCONFIG_FILE_NAME).exists())
-			{
-				return project;
-			}
-		}
 		return null;
 	}
 }


### PR DESCRIPTION
## Description

Providing selected project in the project explorer instead of a first open project with SDK config

Fixes # ([IEP-1385](https://jira.espressif.com:8443/browse/IEP-1385))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Create two projects -> build one of them -> Try to use menu config command on the project without sdkconfig -> error expected

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- sdkconfig

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced project selection process in the SDK configuration editor.

- **Bug Fixes**
	- Improved reliability of project retrieval by directly accessing the selected project in the explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->