### PR TITLE
IEP-1386 Project Name with whitespaces: JTAG flash fails.

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/util/ESPFlashUtil.java
@@ -119,7 +119,7 @@ public class ESPFlashUtil
 			{
 				buildPath = buildPath.substring(1);
 			}
-			espFlashCommand = espFlashCommand.replace("<path-to-build-dir>", buildPath); //$NON-NLS-1$
+			espFlashCommand = espFlashCommand.replace("<path-to-build-dir>", buildPath.replace(" ", "\\ ")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
 		catch (CoreException e)
 		{


### PR DESCRIPTION
## Description

Adding escape characters to the spaces in the build path for jtag flash command

Fixes # ([IEP-1386](https://jira.espressif.com:8443/browse/IEP-1386))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command execution by properly escaping spaces in the build path for the flashing process.

- **Bug Fixes**
	- Improved reliability of the flash command execution with better handling of paths containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->