### PR TITLE
IEP-1345: Fix for refreshing the manager after installation

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/InitializeToolsStartup.java
@@ -47,6 +47,8 @@ import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.dialogs.BuildView;
 import com.espressif.idf.ui.dialogs.MessageLinkDialog;
 import com.espressif.idf.ui.tools.ToolsActivationJob;
+import com.espressif.idf.ui.tools.ToolsActivationJobListener;
+import com.espressif.idf.ui.tools.manager.pages.ESPIDFMainTablePage;
 
 @SuppressWarnings("restriction")
 public class InitializeToolsStartup implements IStartup
@@ -180,8 +182,9 @@ public class InitializeToolsStartup implements IStartup
 					Logger.log(e);
 				}
 				ToolsActivationJob toolsActivationJob = new ToolsActivationJob(newToolSet, pythonExecutablePath, gitExecutablePath);
+				ToolsActivationJobListener toolsActivationJobListener = new ToolsActivationJobListener(ESPIDFMainTablePage.getInstance());
+				toolsActivationJob.addJobChangeListener(toolsActivationJobListener);
 				toolsActivationJob.schedule();
-
 			}
 
 			// save state

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/ESPIDFManagerEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/ESPIDFManagerEditor.java
@@ -53,7 +53,7 @@ public class ESPIDFManagerEditor extends EditorPart
 	@Override
 	public void createPartControl(Composite parent)
 	{
-		ESPIDFMainTablePage espidfMainTablePage = new ESPIDFMainTablePage();
+		ESPIDFMainTablePage espidfMainTablePage = ESPIDFMainTablePage.getInstance();
 		espidfMainTablePage.createPage(parent);
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/pages/ESPIDFMainTablePage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/pages/ESPIDFMainTablePage.java
@@ -67,6 +67,22 @@ public class ESPIDFMainTablePage
 	private static final String RELOAD_ICON = "icons/tools/reload.png"; //$NON-NLS-1$
 	private static final String IDF_TOOL_SET_BTN_KEY = "IDFToolSet"; //$NON-NLS-1$
 	
+	private static ESPIDFMainTablePage espidfMainTablePage;
+	
+	private ESPIDFMainTablePage()
+	{
+	}
+	
+	public static ESPIDFMainTablePage getInstance()
+	{
+		if (espidfMainTablePage == null)
+		{
+			espidfMainTablePage = new ESPIDFMainTablePage();
+		}
+		
+		return espidfMainTablePage;
+	}
+	
 	public Composite createPage(Composite composite)
 	{
 		toolSetConfigurationManager = new ToolSetConfigurationManager();
@@ -81,6 +97,8 @@ public class ESPIDFMainTablePage
 
 	public void refreshEditorUI()
 	{
+		if (container == null)
+			return;
 		for (TableItem item : tableViewer.getTable().getItems())
 		{
 			String EDITOR_KEY = "action_editor";


### PR DESCRIPTION
## Description

ESP-IDF Manager: refresh page after tools installed.

Fixes # ([IEP-1345](https://jira.espressif.com:8443/browse/IEP-1345))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please use the esp-idf.json from the offline installer in the root directory of the ide to test this and verify the tools installation normally as well

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): windows primarily for offline (all others OS should be fine as well)

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a singleton pattern for the `ESPIDFMainTablePage`, ensuring a single instance is used throughout the application.
	- Enhanced job management in the startup process with a new job listener for better state change notifications.

- **Bug Fixes**
	- Improved error handling in the UI refresh logic to prevent null pointer exceptions.

- **Refactor**
	- Updated instantiation method for `ESPIDFMainTablePage` to utilize a singleton instance rather than creating new instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->