### PR TITLE
IEP-1395: Removing system env vars from IDE while executing scripts

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsInstallationJob.java
@@ -75,6 +75,8 @@ public class ToolsInstallationJob extends ToolsJob
 		{
 			return status;
 		}
+		
+		Logger.log(status.getMessage());
 		processExportCmdOutput(status.getMessage());
 
 		monitor.worked(1);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsJob.java
@@ -349,6 +349,11 @@ public abstract class ToolsJob extends Job
 			Logger.log(environment.toString());
 			environment.put("PYTHONUNBUFFERED", "1"); //$NON-NLS-1$ //$NON-NLS-2$
 			loadIdfPathWithSystemPath(environment);
+			environment.remove(IDFEnvironmentVariables.IDF_PYTHON_ENV_PATH);
+			environment.remove(IDFEnvironmentVariables.ESP_IDF_VERSION);
+			environment.remove(IDFEnvironmentVariables.IDF_PATH);
+			environment.remove(IDFEnvironmentVariables.OPENOCD_SCRIPTS);
+			
 			if (gitExecutablePath != null)
 			{
 				addPathToEnvironmentPath(environment, gitExecutablePath);
@@ -399,7 +404,7 @@ public abstract class ToolsJob extends Job
 			return IDFCorePlugin.errorStatus(e1.getMessage(), e1);
 		}
 	}
-	
+
 	private void addPathToEnvironmentPath(Map<String, String> environment, String gitExecutablePath)
 	{
 		IPath gitPath = new org.eclipse.core.runtime.Path(gitExecutablePath);


### PR DESCRIPTION
## Description

The original bug reported here https://github.com/espressif/idf-eclipse-plugin/issues/1105

Fixes # ([IEP-1395](https://jira.espressif.com:8443/browse/IEP-1395))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Please try to put the system env vars in windows as mentioned on original reported issues and then try to install tools to test if they are getting installed with correct path in the IDE.


**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Logging Improvements**
	- Enhanced logging in tools installation process to capture more detailed status messages.

- **Environment Configuration**
	- Refined environment variable management for IDF tools by removing unnecessary entries.
	- Updated handling of Git executable path in command execution environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->