### PR TITLE
GH #1118: Espressif's Eclipse debugger missing MCU Reset button

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -48,7 +48,9 @@
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</windows>
    </vm>
 
+
    <plugins>
+      <plugin id="org.eclipse.embedcdt.debug.gdbjtag.restart.ui"/>
    </plugins>
 
    <features>


### PR DESCRIPTION
## Description

Added MCU Restart button by default 
![image](https://github.com/user-attachments/assets/908bc5a9-f7ab-44f1-b137-7cfff7b34b91)


Fixes # ([IEP-1400](https://jira.espressif.com:8443/browse/IEP-1400))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Install Espressif-IDE ->  Verify the functionality of the restart button during the debugging 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new plugin for debugging capabilities in Espressif-IDE
	- Expanded IDE functionality with additional debugging support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->