### PR TITLE
SWTBot test case: SDKconfig Editor

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/common/utility/TestWidgetWaitUtility.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/common/utility/TestWidgetWaitUtility.java
@@ -65,7 +65,7 @@ public class TestWidgetWaitUtility
 			}
 		}, 99000000, 3000);
 	}
-	
+
 	public static void waitForOperationsInProgressToFinishSync(SWTWorkbenchBot bot)
 	{
 		bot.viewById(IPageLayout.ID_PROGRESS_VIEW).show();
@@ -111,7 +111,7 @@ public class TestWidgetWaitUtility
 			}
 		}, 99000000, 500);
 	}
-	
+
 	/**
 	 * Waits until the specified view contains the provided text, the view must contain a styled text
 	 * 
@@ -213,27 +213,31 @@ public class TestWidgetWaitUtility
 	 * @param dialogTitle  The title of the dialog to look for
 	 * @param timeout      Time to wait in ms before throwing {@link WidgetNotFoundException}
 	 */
-	public static void waitUntilDialogIsNotVisible(SWTWorkbenchBot workbenchBot, String dialogTitle, long timeout)
+	public static void waitForDialogToAppear(SWTWorkbenchBot workbenchBot, String dialogTitle, long timeout)
 	{
 		workbenchBot.waitUntil(new DefaultCondition()
 		{
-
 			@Override
 			public boolean test() throws Exception
 			{
-				SWTBotShell swtBotShell = workbenchBot.activeShell();
-				return swtBotShell.getText().contains(dialogTitle);
+				for (SWTBotShell shell : workbenchBot.shells())
+				{
+					if (shell.getText().contains(dialogTitle))
+					{
+						return true; // Dialog is now visible
+					}
+				}
+				return false; // Dialog is not yet visible
 			}
 
 			@Override
 			public String getFailureMessage()
 			{
-				return "View with title: " + dialogTitle + " not found";
+				return "Dialog with title: " + dialogTitle + " did not appear in time.";
 			}
 		}, timeout);
 	}
-	
-	
+
 	/**
 	 * Waits while the provided bot has a dialog with the title visible
 	 * 
@@ -245,33 +249,56 @@ public class TestWidgetWaitUtility
 	{
 		workbenchBot.waitWhile(new DefaultCondition()
 		{
-
 			@Override
 			public boolean test() throws Exception
 			{
-				SWTBotShell swtBotShell = workbenchBot.activeShell();
-				return swtBotShell.getText().contains(dialogTitle);
+				for (SWTBotShell shell : workbenchBot.shells())
+				{
+					if (shell.getText().contains(dialogTitle))
+					{
+						return true;
+					}
+				}
+				return false;
 			}
 
 			@Override
 			public String getFailureMessage()
 			{
-				return "View with title: " + dialogTitle + " not found";
+				return "Dialog with title: " + dialogTitle + " did not close in time.";
 			}
 		}, timeout);
 	}
-	
+
+	public static void waitForSDKConfigurationTab(SWTWorkbenchBot workbenchBot, long timeout)
+	{
+		workbenchBot.waitUntil(new DefaultCondition()
+		{
+			@Override
+			public boolean test() throws Exception
+			{
+				return workbenchBot.cTabItem("SDK Configuration (sdkconfig)").isActive();
+			}
+
+			@Override
+			public String getFailureMessage()
+			{
+				return "SDK Configuration tab did not open in time.";
+			}
+		}, timeout);
+	}
+
 	private static OperationResponse getOperationResponse()
 	{
 		TestWidgetWaitUtility testWidgetWaitUtility = new TestWidgetWaitUtility();
 		return testWidgetWaitUtility.getOperationResponseObject();
 	}
-	
+
 	private OperationResponse getOperationResponseObject()
 	{
 		return new OperationResponse();
 	}
-	
+
 	private class OperationResponse
 	{
 		private boolean itemStillPending = true;

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectPartitionTableEditorTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectPartitionTableEditorTest.java
@@ -171,13 +171,13 @@ public class NewEspressifIDFProjectPartitionTableEditorTest
 		private static void whenOpenPartitionTableEditor() throws IOException
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Partition Table Editor");
-			TestWidgetWaitUtility.waitUntilDialogIsNotVisible(bot, "Partition Table Editor", 10000);
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Partition Table Editor", 10000);
 		}
 
 		private static void whenOpenEmptyPartitionTableEditor() throws IOException
 		{
 			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Partition Table Editor");
-			TestWidgetWaitUtility.waitUntilDialogIsNotVisible(bot, "Information", 10000);
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Information", 10000);
 		}
 
 		private static void ThenInformationMessagePopUp() throws IOException

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSDKconfigTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSDKconfigTest.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright 2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui.test.executable.cases.project;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
+import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+import com.espressif.idf.ui.test.operations.EnvSetupOperations;
+import com.espressif.idf.ui.test.operations.ProjectTestOperations;
+
+/**
+ * Test class to test the project creation, build and basic operations
+ * 
+ * @author Andrii Filippov
+ *
+ */
+@SuppressWarnings("restriction")
+@RunWith(SWTBotJunit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NewEspressifIDFProjectSDKconfigTest
+{
+	@BeforeClass
+	public static void beforeTestClass() throws Exception
+	{
+		Fixture.loadEnv();
+	}
+
+	@After
+	public void afterEachTest()
+	{
+		Fixture.cleanTestEnv();
+	}
+
+	@Test
+	public void givenNewProjectIsCreatedThenTestFullSDKconfigWorkflowForNewProject() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSDKconfigTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.thenSDKconfigFileIsPresent();
+		Fixture.whenSDKconfigFileOpenedViaDoubleClickthenVerifiedthenClosed();
+		Fixture.whenSDKconfigFileOpenedViaContextMenuthenVerifiedthenClosed();
+		Fixture.whenSDKconfigFileOpenedEditedSavedthenReopenedAndChecked();
+		Fixture.whenSDKconfigFileDeletedWhenBuildProjectThenSDKconfigFileGeneratedAndVerified();
+	}
+
+	@Test
+	public void givenNewProjectIsCreatedWhenSDKconfigFileOpenedEditedSavedThenBuiltReopenedAndChecked() throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSDKconfigTest2");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenSDKconfigFileOpenedEditedSaved();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenSDKconfigFileOpenedUsingContextMenu();
+		Fixture.thenCheckChangesAreSaved();
+	}
+
+	private static class Fixture
+	{
+		private static SWTWorkbenchBot bot;
+		private static String category;
+		private static String subCategory;
+		private static String projectName;
+
+		private static void loadEnv() throws Exception
+		{
+			bot = WorkBenchSWTBot.getBot();
+			EnvSetupOperations.setupEspressifEnv(bot);
+			bot.sleep(1000);
+			ProjectTestOperations.deleteAllProjects(bot);
+		}
+
+		public static void whenSDKconfigFileOpenedViaDoubleClickthenVerifiedthenClosed() throws Exception
+		{
+			whenSDKconfigFileOpenedUsingDoubleClick();
+			thenSDKconfigFileContentChecked();
+			thenSDKconfigShellClosed();
+		}
+
+		public static void whenSDKconfigFileOpenedViaContextMenuthenVerifiedthenClosed() throws Exception
+		{
+			whenSDKconfigFileOpenedUsingContextMenu();
+			thenSDKconfigFileContentChecked();
+			thenSDKconfigShellClosed();
+		}
+
+		public static void whenSDKconfigFileOpenedEditedSavedthenReopenedAndChecked() throws Exception
+		{
+			whenSDKconfigFileOpenedUsingContextMenu();
+			thenSDKconfigFileContentEdited();
+			whenSDKconfigFileIsSaved();
+			whenSDKconfigFileOpenedUsingContextMenu();
+			thenCheckChangesAreSaved();
+			thenSDKconfigShellClosed();
+		}
+
+		private static void whenSDKconfigFileOpenedEditedSaved() throws Exception
+		{
+			whenSDKconfigFileOpenedUsingContextMenu();
+			thenSDKconfigFileContentEdited();
+			whenSDKconfigFileIsSaved();
+		}
+
+		private static void whenSDKconfigFileDeletedWhenBuildProjectThenSDKconfigFileGeneratedAndVerified()
+				throws Exception
+		{
+			bot.tree().getTreeItem(projectName).getNode("sdkconfig").select();
+			bot.tree().getTreeItem(projectName).getNode("sdkconfig").contextMenu("Delete").click();
+			bot.shell("Delete Resources").bot().button("OK").click();
+			bot.sleep(1000);
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Refresh");
+			thenSDKconfigFileIsAbsent();
+			whenProjectIsBuiltUsingContextMenu();
+			thenSDKconfigFileIsPresent();
+			whenSDKconfigFileOpenedViaContextMenuthenVerifiedthenClosed();
+		}
+
+		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)
+		{
+			Fixture.category = category;
+			Fixture.subCategory = subCategory;
+		}
+
+		private static void givenProjectNameIs(String projectName)
+		{
+			Fixture.projectName = projectName;
+		}
+
+		private static void whenNewProjectIsSelected() throws Exception
+		{
+			ProjectTestOperations.setupProject(projectName, category, subCategory, bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishSync(bot);
+			SWTBotView projectExplorView = bot.viewByTitle("Project Explorer");
+			projectExplorView.show();
+			projectExplorView.setFocus();
+			bot.tree().getTreeItem(projectName).select();
+			bot.tree().getTreeItem(projectName).expand();
+			bot.sleep(1000);
+		}
+
+		private static void whenProjectIsBuiltUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
+			ProjectTestOperations.waitForProjectBuild(bot);
+		}
+
+		private static void thenSDKconfigFileIsPresent() throws IOException
+		{
+			assertTrue(bot.tree().getTreeItem(projectName).getNode("sdkconfig") != null);
+		}
+
+		private static void thenSDKconfigFileIsAbsent() throws IOException
+		{
+			assertTrue(!bot.tree().getTreeItem(projectName).getNodes().contains("sdkconfig"));
+		}
+
+		private static void whenSDKconfigFileOpenedUsingDoubleClick() throws IOException
+		{
+			bot.tree().getTreeItem(projectName).getNode("sdkconfig").doubleClick();
+			TestWidgetWaitUtility.waitWhileDialogIsVisible(bot, "Progress Information", 40000);
+			TestWidgetWaitUtility.waitForSDKConfigurationTab(bot, 5000);
+		}
+
+		private static void whenSDKconfigFileOpenedUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Menu Config");
+			TestWidgetWaitUtility.waitWhileDialogIsVisible(bot, "Progress Information", 40000);
+			TestWidgetWaitUtility.waitForSDKConfigurationTab(bot, 5000);
+		}
+
+		private static void thenSDKconfigFileContentChecked() throws Exception
+		{
+			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
+			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
+			bot.tree(1).getTreeItem("Partition Table").click();
+			bot.sleep(1000);
+			assertTrue(bot.textWithLabel("Offset of partition table (hex)").getText().matches("0x8000"));
+		}
+
+		private static void thenSDKconfigFileContentEdited() throws Exception
+		{
+			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
+			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
+			bot.tree(1).getTreeItem("Partition Table").click();
+			bot.sleep(1000);
+			bot.textWithLabel("Offset of partition table (hex)").setText("0x4000");
+			bot.comboBoxWithLabel("Partition Table").setSelection("Custom partition table CSV");
+			bot.checkBox("Generate an MD5 checksum for the partition table").click();
+		}
+
+		private static void thenSDKconfigShellClosed() throws IOException
+		{
+			bot.cTabItem("SDK Configuration (sdkconfig)").close();
+		}
+
+		private static void whenSDKconfigFileIsSaved() throws IOException
+		{
+			bot.cTabItem("*SDK Configuration (sdkconfig)").activate();
+			bot.cTabItem("*SDK Configuration (sdkconfig)").close();
+			bot.sleep(5000);
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Save Resource", 5000);
+			bot.shell("Save Resource").bot().button("Save").click();
+		}
+
+		private static void thenCheckChangesAreSaved() throws Exception
+		{
+			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
+			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
+			bot.tree(1).getTreeItem("Partition Table").click();
+			bot.sleep(2000);
+			assertTrue(bot.textWithLabel("Offset of partition table (hex)").getText().matches("0x4000"));
+			assertTrue(bot.comboBoxWithLabel("Partition Table").selection().equals("Custom partition table CSV"));
+			assertTrue(!bot.checkBox("Generate an MD5 checksum for the partition table").isChecked());
+		}
+
+		private static void cleanTestEnv()
+		{
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+			ProjectTestOperations.closeAllProjects(bot);
+			ProjectTestOperations.deleteAllProjects(bot);
+		}
+	}
+}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-1407)) 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
 
Tests: 

І.
after project created with "reconfigure command" selected - verify SDKconfig is generated ✅ 
after project creation - open SDKconfig file using DoubleClick - verify basic content presents ✅
after project creation - open SDKconfig file using ESP-IDF Menu - verify basic content presents ✅
after project creation - open SDKconfig file - edit - save - close - reopen - verify changes are saved ✅
after project creation - delete SDKconfig file - rebuild - verify SDKconfig file is generated - verify basic content ✅

ІІ.
after project creation - open SDKconfig file - edit - save - close - build - reopen - verify changes are saved✅
 
ІІІ. 
after project creation - open SDKconfig file - close - rebuild - check if it start the full re-build process ❗  
This test is commented out until the old bug with the repeated project build is fixed.❗ 

## Checklist
- [X] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [X] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test class for Espressif IDF project testing:
		- `NewEspressifIDFProjectSDKconfigTest` to validate project creation and configuration workflows.
	- Updated `NewEspressifIDFProjectPartitionTableEditorTest` to improve dialog visibility handling.
	- Enhanced test utility `TestWidgetWaitUtility` with improved methods for synchronous management of UI operations and dialog visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->