### PR TITLE
IEP-1419 Clean up CDT LSP/CDT internal dependencies

### DIFF
--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.runtime,
  com.sun.jna.platform,
  org.eclipse.cdt.lsp.clangd,
  org.eclipse.cdt.lsp,
- org.eclipse.lsp4e
+ org.eclipse.lsp4e,
+ org.eclipse.lsp4j
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -4,14 +4,14 @@
  *******************************************************************************/
 package com.espressif.idf.core.util;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import org.eclipse.cdt.lsp.clangd.ClangdConfiguration;
 import org.eclipse.cdt.lsp.clangd.ClangdMetadata;
 import org.eclipse.cdt.lsp.config.Configuration;
-import org.eclipse.cdt.lsp.util.LspUtils;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.lsp4e.LanguageServerWrapper;
+import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.ui.PlatformUI;
 
 import com.espressif.idf.core.logging.Logger;
@@ -20,14 +20,16 @@ import com.espressif.idf.core.logging.Logger;
 public class LspService
 {
 	private final Configuration configuration;
-	private final Stream<LanguageServerWrapper> languageServerWrappers;
+	private final List<LanguageServerWrapper> languageServerWrappers;
 
 	public LspService()
 	{
-		this(PlatformUI.getWorkbench().getService(ClangdConfiguration.class), LspUtils.getLanguageServers());
+		this(PlatformUI.getWorkbench().getService(ClangdConfiguration.class),
+				LanguageServiceAccessor.getStartedWrappers(null, true).stream()
+						.filter(w -> "org.eclipse.cdt.lsp.server".equals(w.serverDefinition.id)).toList()); //$NON-NLS-1$
 	}
 
-	public LspService(Configuration configuration, Stream<LanguageServerWrapper> languageServerWrappers)
+	public LspService(Configuration configuration, List<LanguageServerWrapper> languageServerWrappers)
 	{
 		this.configuration = configuration;
 		this.languageServerWrappers = languageServerWrappers;


### PR DESCRIPTION
## Description

Replaced the Eclipse LSP CDT restart server utility call with the corresponding class from LSP4E to avoid errors during updating LSP CDT plugin to the master.

Fixes # ([IEP-1419](https://jira.espressif.com:8443/browse/IEP-1419))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Verify that the Language Server works the same way as before. 
- Create New Project -> Build -> no errors in the editor
- Switch projects -> build -> no errors in the editor
- Change target -> No -> no errors in the editor

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Language Server 

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency configuration to support advanced language server capabilities.
- **Refactor**
	- Enhanced the integration and processing of language server interactions for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->