### PR TITLE
IEP-1445 GH #1148: Avoid creating '.clang-format' on each compilation

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFCorePreferenceConstants.java
@@ -27,6 +27,8 @@ public class IDFCorePreferenceConstants
 	public static final String CMAKE_CCACHE_STATUS = "cmakeCCacheStatus"; //$NON-NLS-1$
 	public static final String AUTOMATE_BUILD_HINTS_STATUS = "automateHintsStatus"; //$NON-NLS-1$
 	public static final String HIDE_ERRORS_IDF_COMPONENTS = "hideErrorsOnIdfDerivedFiles"; //$NON-NLS-1$
+	public static final String AUTOMATE_CLANGD_FORMAT_FILE = "automateClangFormatFileCreation"; //$NON-NLS-1$
+	public static final boolean AUTOMATE_CLANGD_FORMAT_FILE_DEFAULT = true;
 	public static final boolean CMAKE_CCACHE_DEFAULT_STATUS = true;
 	public static final boolean AUTOMATE_BUILD_HINTS_DEFAULT_STATUS = true;
 	public static final boolean HIDE_ERRORS_IDF_COMPONENTS_DEFAULT_STATUS = true;
@@ -40,6 +42,7 @@ public class IDFCorePreferenceConstants
 	public static final String IDF_TOOLS_PATH_DEFAULT = Platform.getOS().equals(Platform.OS_WIN32)
 			? IDFUtil.resolveEnvVariable("%USERPROFILE%\\.espressif") //$NON-NLS-1$
 			: IDFUtil.resolveEnvVariable("$HOME/.espressif"); //$NON-NLS-1$
+
 	/**
 	 * Returns the node in the preference in the given context.
 	 *

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangFormatFileHandler.java
@@ -10,7 +10,10 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
 
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.IDFCorePreferenceConstants;
 import com.espressif.idf.core.ILSPConstants;
 
 public class ClangFormatFileHandler
@@ -30,7 +33,8 @@ public class ClangFormatFileHandler
 	 */
 	public void update() throws IOException, CoreException
 	{
-		if (clangFormatFile.exists())
+
+		if (!shouldCreateClangFormat())
 		{
 			return;
 		}
@@ -38,5 +42,12 @@ public class ClangFormatFileHandler
 		{
 			clangFormatFile.create(source, true, new NullProgressMonitor());
 		}
+	}
+
+	private boolean shouldCreateClangFormat()
+	{
+		return !clangFormatFile.exists() && Platform.getPreferencesService().getBoolean(IDFCorePlugin.PLUGIN_ID,
+				IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE,
+				IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE_DEFAULT, null);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -43,6 +43,7 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 	private Combo gitAssetsCombo;
 	private Combo pythonWheelCombo;
 	private Text idfToolsPathText;
+	private Button automateClangdFormatCreationBtn;
 
 	public EspresssifPreferencesPage()
 	{
@@ -93,15 +94,17 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		Label githubAssetsLabel = new Label(toolsInstallationGroup, SWT.NONE);
 		githubAssetsLabel.setText(Messages.EspressifPreferencesPage_ToolsInstallationGitAssetUrlLabel);
 		gitAssetsCombo = new Combo(toolsInstallationGroup, SWT.DROP_DOWN | SWT.BORDER);
-		gitAssetsCombo.setItems(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_GLOBAL, IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_CHINA);
+		gitAssetsCombo.setItems(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_GLOBAL,
+				IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_CHINA);
 		gitAssetsCombo.select(0);
-		
+
 		Label pythonWheelsLabel = new Label(toolsInstallationGroup, SWT.NONE);
 		pythonWheelsLabel.setText(Messages.EspressifPreferencesPage_ToolsInstallationPythonPyWheelUrlLabel);
 		pythonWheelCombo = new Combo(toolsInstallationGroup, SWT.DROP_DOWN | SWT.BORDER);
-	    pythonWheelCombo.setItems(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_GLOBAL, IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_CHINA);
-	    pythonWheelCombo.select(0);
-	    
+		pythonWheelCombo.setItems(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_GLOBAL,
+				IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_CHINA);
+		pythonWheelCombo.select(0);
+
 		GridData gitTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1);
 		gitTextGridData.widthHint = 200;
 		GridData pythonTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1);
@@ -115,37 +118,36 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		GridData idfToolsPathTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
 		idfToolsPathTextGridData.widthHint = 200;
 		idfToolsPathText.setLayoutData(idfToolsPathTextGridData);
-		 // Add browse button
-	    Button browseButtonIdfToolsPath = new Button(toolsInstallationGroup, SWT.PUSH);
-	    browseButtonIdfToolsPath.setText(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathBrowseButton);
-	    browseButtonIdfToolsPath.addSelectionListener(new SelectionAdapter() {
-	        @Override
-	        public void widgetSelected(SelectionEvent e) {
-	            DirectoryDialog dialog = new DirectoryDialog(mainComposite.getShell());
-	            dialog.setText(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathTitle);
-	            dialog.setMessage(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathMessage);
-	            String dir = dialog.open();
-	            if (dir != null) {
-	                idfToolsPathText.setText(dir);
-	            }
-	        }
-	    });
-		
+		// Add browse button
+		Button browseButtonIdfToolsPath = new Button(toolsInstallationGroup, SWT.PUSH);
+		browseButtonIdfToolsPath.setText(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathBrowseButton);
+		browseButtonIdfToolsPath.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				DirectoryDialog dialog = new DirectoryDialog(mainComposite.getShell());
+				dialog.setText(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathTitle);
+				dialog.setMessage(Messages.EspressifPreferencesPage_DirectorySelectionIDFToolsPathMessage);
+				String dir = dialog.open();
+				if (dir != null)
+				{
+					idfToolsPathText.setText(dir);
+				}
+			}
+		});
+
 		String idfToolsPath = getPreferenceStore().getString(IDFCorePreferenceConstants.IDF_TOOLS_PATH);
 		idfToolsPath = StringUtil.isEmpty(idfToolsPath)
 				? getPreferenceStore().getDefaultString(IDFCorePreferenceConstants.IDF_TOOLS_PATH)
 				: idfToolsPath;
 		idfToolsPathText.setText(idfToolsPath);
-		
+
 		String gitUrl = getPreferenceStore().getString(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS);
 		String pyWheelUrl = getPreferenceStore().getString(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL);
-		gitUrl = StringUtil.isEmpty(gitUrl)
-				? gitAssetsCombo.getItem(0)
-				: gitUrl;
-		pyWheelUrl = StringUtil.isEmpty(pyWheelUrl)
-				? pythonWheelCombo.getItem(0)
-				: pyWheelUrl;
-		
+		gitUrl = StringUtil.isEmpty(gitUrl) ? gitAssetsCombo.getItem(0) : gitUrl;
+		pyWheelUrl = StringUtil.isEmpty(pyWheelUrl) ? pythonWheelCombo.getItem(0) : pyWheelUrl;
+
 		gitAssetsCombo.setText(gitUrl);
 		pythonWheelCombo.setText(pyWheelUrl);
 	}
@@ -169,6 +171,13 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		hideErrorsOnIdfComponentsBtn.setToolTipText(Messages.EspresssifPreferencesPage_HideErrprOnIdfComponentsToolTip);
 		hideErrorsOnIdfComponentsBtn
 				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS));
+
+		automateClangdFormatCreationBtn = new Button(buildGroup, SWT.CHECK);
+		automateClangdFormatCreationBtn.setText(Messages.EspresssifPreferencesPage_AutoCreateClangFormatBtnName);
+		automateClangdFormatCreationBtn.setToolTipText(
+				Messages.EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg);
+		automateClangdFormatCreationBtn
+				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE));
 	}
 
 	private void addccacheControl(Composite mainComposite)
@@ -240,7 +249,8 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS,
 					automateHintsBtn.getSelection());
 
-			boolean prevMarkerValue = getPreferenceStore().getBoolean(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS);
+			boolean prevMarkerValue = getPreferenceStore()
+					.getBoolean(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS);
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS,
 					hideErrorsOnIdfComponentsBtn.getSelection());
 			// need to initiate a cleanup for initial clean of markers after they are enabled
@@ -248,12 +258,15 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 			{
 				IDFCorePlugin.ERROR_MARKER_LISTENER.initialMarkerCleanup();
 			}
-			
+
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS, gitAssetsCombo.getText());
 
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL, pythonWheelCombo.getText());
-			
+
 			getPreferenceStore().setValue(IDFCorePreferenceConstants.IDF_TOOLS_PATH, idfToolsPathText.getText());
+
+			getPreferenceStore().setValue(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE,
+					automateClangdFormatCreationBtn.getSelection());
 		}
 		catch (Exception e)
 		{
@@ -275,6 +288,8 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_STATUS));
 		hideErrorsOnIdfComponentsBtn
 				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS));
+		automateClangdFormatCreationBtn
+				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE));
 		gitAssetsCombo.setText(gitAssetsCombo.getItem(0));
 		pythonWheelCombo.setText(pythonWheelCombo.getItem(0));
 		idfToolsPathText.setText(getPreferenceStore().getDefaultString(IDFCorePreferenceConstants.IDF_TOOLS_PATH));
@@ -291,9 +306,14 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 				IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS);
 		getPreferenceStore().setDefault(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS,
 				IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS_DEFAULT_STATUS);
-		
-		getPreferenceStore().setDefault(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS, IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_GLOBAL);
-		getPreferenceStore().setDefault(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL, IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_GLOBAL);
-		getPreferenceStore().setDefault(IDFCorePreferenceConstants.IDF_TOOLS_PATH, IDFCorePreferenceConstants.IDF_TOOLS_PATH_DEFAULT);
+
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.IDF_GITHUB_ASSETS,
+				IDFCorePreferenceConstants.IDF_GITHUB_ASSETS_DEFAULT_GLOBAL);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL,
+				IDFCorePreferenceConstants.PIP_EXTRA_INDEX_URL_DEFAULT_GLOBAL);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.IDF_TOOLS_PATH,
+				IDFCorePreferenceConstants.IDF_TOOLS_PATH_DEFAULT);
+		getPreferenceStore().setDefault(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE,
+				IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -82,7 +82,22 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 
 		addToolsInstallationSettings(mainComposite);
 
+		addClangdSettings(mainComposite);
 		return mainComposite;
+	}
+
+	private void addClangdSettings(Composite mainComposite)
+	{
+		Group clangdOptionsGroup = new Group(mainComposite, SWT.SHADOW_ETCHED_IN);
+		clangdOptionsGroup.setText(Messages.EspresssifPreferencesPage_ClangdSettingsGroupName);
+		clangdOptionsGroup.setLayout(new GridLayout(1, false));
+
+		automateClangdFormatCreationBtn = new Button(clangdOptionsGroup, SWT.CHECK);
+		automateClangdFormatCreationBtn.setText(Messages.EspresssifPreferencesPage_AutoCreateClangFormatBtnName);
+		automateClangdFormatCreationBtn
+				.setToolTipText(Messages.EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg);
+		automateClangdFormatCreationBtn
+				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE));
 	}
 
 	private void addToolsInstallationSettings(Composite mainComposite)
@@ -171,13 +186,6 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		hideErrorsOnIdfComponentsBtn.setToolTipText(Messages.EspresssifPreferencesPage_HideErrprOnIdfComponentsToolTip);
 		hideErrorsOnIdfComponentsBtn
 				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.HIDE_ERRORS_IDF_COMPONENTS));
-
-		automateClangdFormatCreationBtn = new Button(buildGroup, SWT.CHECK);
-		automateClangdFormatCreationBtn.setText(Messages.EspresssifPreferencesPage_AutoCreateClangFormatBtnName);
-		automateClangdFormatCreationBtn.setToolTipText(
-				Messages.EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg);
-		automateClangdFormatCreationBtn
-				.setSelection(getPreferenceStore().getBoolean(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE));
 	}
 
 	private void addccacheControl(Composite mainComposite)

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/EspresssifPreferencesPage.java
@@ -314,6 +314,6 @@ public class EspresssifPreferencesPage extends PreferencePage implements IWorkbe
 		getPreferenceStore().setDefault(IDFCorePreferenceConstants.IDF_TOOLS_PATH,
 				IDFCorePreferenceConstants.IDF_TOOLS_PATH_DEFAULT);
 		getPreferenceStore().setDefault(IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE,
-				IDFCorePreferenceConstants.AUTOMATE_BUILD_HINTS_DEFAULT_STATUS);
+				IDFCorePreferenceConstants.AUTOMATE_CLANGD_FORMAT_FILE_DEFAULT);
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
@@ -9,6 +9,7 @@ public class Messages extends NLS
 	public static String EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg;
 	public static String EspresssifPreferencesPage_BuildGroupTxt;
 	public static String EspresssifPreferencesPage_CCacheToolTip;
+	public static String EspresssifPreferencesPage_ClangdSettingsGroupName;
 	public static String EspresssifPreferencesPage_EnableCCache;
 	public static String EspresssifPreferencesPage_IDFSpecificPrefs;
 	public static String EspresssifPreferencesPage_SearchHintsCheckBtn;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/Messages.java
@@ -5,6 +5,8 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.espressif.idf.ui.preferences.messages"; //$NON-NLS-1$
+	public static String EspresssifPreferencesPage_AutoCreateClangFormatBtnName;
+	public static String EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg;
 	public static String EspresssifPreferencesPage_BuildGroupTxt;
 	public static String EspresssifPreferencesPage_CCacheToolTip;
 	public static String EspresssifPreferencesPage_EnableCCache;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
@@ -1,3 +1,5 @@
+EspresssifPreferencesPage_AutoCreateClangFormatBtnName=Auto-create .clang-format
+EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg=Ensures .clang-format exists, generating it if missing after project creation and on each build.
 EspresssifPreferencesPage_BuildGroupTxt=Build Settings
 EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build, if the CCache tool is installed
 EspresssifPreferencesPage_EnableCCache=Enable Ccache

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/preferences/messages.properties
@@ -2,6 +2,7 @@ EspresssifPreferencesPage_AutoCreateClangFormatBtnName=Auto-create .clang-format
 EspresssifPreferencesPage_AutoCreateClangFormatTooltipMsg=Ensures .clang-format exists, generating it if missing after project creation and on each build.
 EspresssifPreferencesPage_BuildGroupTxt=Build Settings
 EspresssifPreferencesPage_CCacheToolTip=This sets CCACHE_ENABLE=1 to the IDF CMake build, if the CCache tool is installed
+EspresssifPreferencesPage_ClangdSettingsGroupName=Clangd Settings
 EspresssifPreferencesPage_EnableCCache=Enable Ccache
 EspresssifPreferencesPage_IDFSpecificPrefs=ESP-IDF Specific Preferences.
 EspresssifPreferencesPage_SearchHintsCheckBtn=Search hints for build errors (may affect build performance)

--- a/docs_readme/clangd_cdt_support.md
+++ b/docs_readme/clangd_cdt_support.md
@@ -51,3 +51,16 @@ If, for some reason, it is not disabled, please follow the steps below to disabl
    
    
    ![](images/clangd/cdt_indexer_disable.png)
+```
+
+
+## Automatic .clang-format Creation
+
+To ensure consistent code formatting across all projects, including those imported from the old plugin 2.x version, Espressif-IDE automatically creates a .clang-format file for each project.
+
+If you want to disable this option or enable this functionality manually, follow these steps:
+
+1. Go to Window > Preferences > Espressif
+2. Locate the `Auto-create .clang-format` option
+3. Enable or disable the option as needed.
+4. Click on `Apply and Close`.


### PR DESCRIPTION
## Description

Added an option to disable/enable auto-creation of clang-format file
![image](https://github.com/user-attachments/assets/f0ae0f61-f519-4acb-853d-89cc5597a008)


Fixes # ([IEP-1445](https://jira.espressif.com:8443/browse/IEP-1445))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?
Created/built the project with this option turned off and on, then checked if clang-format was created accordingly

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- clang-format file
- Espressif preference page

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new option in the preferences that lets users enable or disable the automatic creation of the `.clang-format` file.
	- The new setting includes an informative tooltip and defaults to an enabled state, ensuring a consistent formatting configuration during builds.
	- Introduced new constants for preference management related to Clang format file automation.
- **Localization**
	- Added new strings for button naming and tooltip messages to enhance user interface localization for the preferences page.
- **Documentation**
	- Updated the documentation to include instructions on the automatic creation of `.clang-format` files and how to manage this setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->