### PR TITLE
IEP-1424 GH #1129: ESP-IDF Serial Monitor and IDF-Terminals "idf.py monitor" build and flash and build and app-flash fails

### DIFF
--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
@@ -55,6 +55,9 @@ public class IDFMonitor
 		List<String> args = new ArrayList<>();
 		args.add(pythonBinPath);
 		args.add(IDFUtil.getIDFMonitorPythonScriptFile().getAbsolutePath());
+		args.add("--make"); //$NON-NLS-1$
+		args.add(Path.fromOSString(IDFUtil.getIDFPythonEnvPath()) + " " //$NON-NLS-1$
+				+ Path.fromOSString(IDFUtil.getIDFPythonScriptFile().getAbsolutePath()));
 		if (!StringUtil.isEmpty(filterOptions))
 		{
 			args.add("--print_filter"); //$NON-NLS-1$

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
@@ -39,7 +39,7 @@ public class SerialPortHandler
 	{
 		if (System.getProperty("os.name").startsWith("Windows") && !portName.startsWith("\\\\.\\")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		{
-			return "\\\\.\\" + portName; //$NON-NLS-1$
+			return portName; // $NON-NLS-1$
 		}
 		else
 		{


### PR DESCRIPTION
## Description

Added --make argument to the idf monitor and removed windows adjustment for port. It seems like without this adjustment flashing and monitoring work fine

Fixes # ([IEP-1424](https://jira.espressif.com:8443/browse/IEP-1424))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Flash, monitor on different esp-idf versions. Use ctrl + T + ctrl + A or ctrl + T + ctrl + F inside the serial monitor

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the serial monitor launch process by adding new configuration options. These changes provide a more flexible setup, allowing the monitor to better integrate with various system environments.

- **Bug Fixes**
  - Improved the handling of serial port names on Windows, ensuring more accurate identification and compatibility when accessing serial ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->