### PR TITLE
IEP-1451 Activating the launch context in the UI thread

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/UIPlugin.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/UIPlugin.java
@@ -6,6 +6,7 @@ package com.espressif.idf.ui;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -41,8 +42,8 @@ public class UIPlugin extends AbstractUIPlugin
 	public void start(BundleContext context) throws Exception
 	{
 		super.start(context);
-		IContextService contextService = (IContextService) PlatformUI.getWorkbench().getService(IContextService.class);
-		contextService.activateContext(LAUNCH_CONTEXT);
+		IContextService contextService = PlatformUI.getWorkbench().getService(IContextService.class);
+		Display.getDefault().asyncExec(() -> contextService.activateContext(LAUNCH_CONTEXT));
 		plugin = this;
 	}
 


### PR DESCRIPTION
## Description

Sometimes, I see this error occur because the context is activated in an invalid thread.
![image](https://github.com/user-attachments/assets/9bf4a952-8501-4693-9fcd-130d68f49b2e)

Fixes # ([IEP-1451](https://jira.espressif.com:8443/browse/IEP-1451))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I see this error when restarting the Eclipse dev environment 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the startup behavior so that key UI initialization tasks are executed asynchronously. This enhancement leads to a smoother, more responsive launch experience, ensuring that the interface loads seamlessly without affecting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->