### PR TITLE
chore: Upgrade cmakeed plugin to CMakeEd-1.24.1 from 1.17.0

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -48,10 +48,6 @@
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.17.0"/>
-			<repository location="jar:https://dl.espressif.com/dl/cmakeed/updates/CMakeEd-1.17.0.zip!/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
 			<unit id="slf4j.api" version="0.0.0"/>
@@ -89,9 +85,9 @@
 			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/releases/0.13.0/" />
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tm4e/releases/0.13.0/"/>
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository"/>
@@ -105,6 +101,10 @@
 			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-2.0/"/>
 			<unit id="org.eclipse.cdt.lsp.feature.feature.group" version="2.0.0.202406041551"/>
 			<unit id="org.yaml.snakeyaml" version="2.2.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="jar:https://dl.espressif.com/dl/idf-eclipse-plugin/updates/CMakeEd-1.24.1.zip!/"/>
+			<unit id="com.cthing.cmakeed.feature.feature.group" version="1.24.1"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
## Description

 Upgrade cmakeed plugin to CMakeEd-1.24.1 from 1.17.0

Fixes # ([IEP-1459](https://jira.espressif.com:8443/browse/IEP-1459))

## Type of change
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
