### PR TITLE
Espressif-IDE is not clearing serial port before trying to upload (IEP-1398) 

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunch.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunch.java
@@ -15,10 +15,6 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial.internal;
 
-import java.io.IOException;
-
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -55,14 +51,7 @@ public class SerialFlashLaunch extends TargetedLaunch
 			wasOpen = serialPort.isOpen();
 			if (wasOpen)
 			{
-				try
-				{
-					serialPort.pause();
-				}
-				catch (IOException e)
-				{
-					Activator.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, Messages.SerialFlashLaunch_Pause, e));
-				}
+				serialPort.pause();
 			}
 		}
 		else
@@ -77,14 +66,7 @@ public class SerialFlashLaunch extends TargetedLaunch
 		super.handleDebugEvents(events);
 		if (isTerminated() && wasOpen)
 		{
-			try
-			{
-				serialPort.resume();
-			}
-			catch (IOException e)
-			{
-				Activator.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, Messages.SerialFlashLaunch_Resume, e));
-			}
+			serialPort.resume();
 			wasOpen = false;
 		}
 	}

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package com.espressif.idf.terminal.connector.serial.connector;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,7 +27,8 @@ import org.eclipse.tm.internal.terminal.provisional.api.provider.TerminalConnect
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.terminal.connector.serial.activator.Activator;
 
-public class SerialConnector extends TerminalConnectorImpl {
+public class SerialConnector extends TerminalConnectorImpl
+{
 
 	private SerialSettings settings = new SerialSettings();
 	protected Process process;
@@ -40,43 +40,51 @@ public class SerialConnector extends TerminalConnectorImpl {
 
 	private static Set<String> openPorts = new HashSet<>();
 
-	public static boolean isOpen(String portName) {
+	public static boolean isOpen(String portName)
+	{
 		return openPorts.contains(portName);
 	}
 
 	@Override
-	public OutputStream getTerminalToRemoteStream() {
+	public OutputStream getTerminalToRemoteStream()
+	{
 		return process.getOutputStream();
 	}
 
-	public SerialSettings getSettings() {
+	public SerialSettings getSettings()
+	{
 		return settings;
 	}
 
 	@Override
-	public String getSettingsSummary() {
+	public String getSettingsSummary()
+	{
 		return settings.getSummary();
 	}
 
 	@Override
-	public void load(ISettingsStore store) {
+	public void load(ISettingsStore store)
+	{
 		settings.load(store);
 	}
 
 	@Override
-	public void save(ISettingsStore store) {
+	public void save(ISettingsStore store)
+	{
 		settings.save(store);
 	}
 
 	@Override
-	public void connect(ITerminalControl control) {
+	public void connect(ITerminalControl control)
+	{
 		super.connect(control);
 		this.control = control;
 
-		//Get selected project - which is required for IDF Monitor
+		// Get selected project - which is required for IDF Monitor
 		project = settings.getProject();
 
-		if (project == null) {
+		if (project == null)
+		{
 			String message = "project can't be null. Make sure you select a project before launch a serial monitor"; //$NON-NLS-1$
 			Activator.log(new Status(IStatus.ERROR, Activator.getUniqueIdentifier(), message, null));
 			return;
@@ -94,15 +102,13 @@ public class SerialConnector extends TerminalConnectorImpl {
 	}
 
 	@Override
-	protected void doDisconnect() {
+	protected void doDisconnect()
+	{
 
-		if (serialPort != null && serialPort.isOpen()) {
+		if (serialPort != null && serialPort.isOpen())
+		{
 			openPorts.remove(serialPort.getPortName());
-			try {
-				serialPort.close();
-			} catch (IOException e) {
-				Activator.log(e);
-			}
+			serialPort.close();
 		}
 	}
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -30,25 +30,30 @@ import org.eclipse.tm.terminal.view.ui.launcher.AbstractLauncherDelegate;
 import com.espressif.idf.terminal.connector.serial.connector.SerialSettings;
 import com.espressif.idf.terminal.connector.serial.controls.SerialConfigPanel;
 
-public class SerialLauncherDelegate extends AbstractLauncherDelegate {
+public class SerialLauncherDelegate extends AbstractLauncherDelegate
+{
 
 	@Override
-	public boolean needsUserConfiguration() {
+	public boolean needsUserConfiguration()
+	{
 		return true;
 	}
 
 	@Override
-	public IConfigurationPanel getPanel(IConfigurationPanelContainer container) {
+	public IConfigurationPanel getPanel(IConfigurationPanelContainer container)
+	{
 		return new SerialConfigPanel(container);
 	}
 
 	@Override
-	public ITerminalConnector createTerminalConnector(Map<String, Object> properties) {
+	public ITerminalConnector createTerminalConnector(Map<String, Object> properties)
+	{
 		Assert.isNotNull(properties);
 
 		// Check for the terminal connector id
 		String connectorId = (String) properties.get(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID);
-		if (connectorId == null) {
+		if (connectorId == null)
+		{
 			connectorId = "com.espressif.idf.terminal.connector.serial.SerialConnector"; //$NON-NLS-1$
 		}
 
@@ -63,7 +68,8 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 
 		// Construct the terminal connector instance
 		ITerminalConnector connector = TerminalConnectorExtension.makeTerminalConnector(connectorId);
-		if (connector != null) {
+		if (connector != null)
+		{
 			// Apply default settings
 			connector.setDefaultSettings();
 			// And load the real settings
@@ -74,7 +80,8 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, Done done) {
+	public void execute(Map<String, Object> properties, Done done)
+	{
 		Assert.isNotNull(properties);
 
 		// Set the terminal tab title
@@ -83,14 +90,17 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 
 		// Force a new terminal tab each time it is launched, if not set otherwise from outside
 		// TODO need a command shell service routing to get this
-		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW)) {
+		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW))
+		{
 			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.TRUE);
 		}
 
 		// Get the terminal service
 		ITerminalService terminal = TerminalServiceFactory.getService();
 		// If not available, we cannot fulfill this request
-		if (terminal != null) {
+		if (terminal != null)
+		{
+			terminal.closeConsole(properties, done);
 			terminal.openConsole(properties, done);
 		}
 	}


### PR DESCRIPTION
## Description

clean-up the code and use try-with-resources for better resource management. Also, forcing closing terminal before re-opening it to avoid "port is not available" issue

Fixes # ([IEP-1398](https://jira.espressif.com:8443/browse/IEP-1398))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Open serial monitor with different conditions. 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Serial monitor

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
