### PR TITLE
fix: update idf.py reconfigure msg in the new project wizard

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/NewProjectCreationWizardPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/NewProjectCreationWizardPage.java
@@ -135,6 +135,7 @@ public class NewProjectCreationWizardPage extends AbstractTemplatesSelectionPage
 		runIdfReconfigureCheckBoxButton = new Button(projectNameGroup, SWT.CHECK | SWT.RIGHT);
 		GridData buttonData = new GridData();
 		buttonData.horizontalSpan = 4;
+		buttonData.verticalIndent = 4;
 		runIdfReconfigureCheckBoxButton.setLayoutData(buttonData);
 		runIdfReconfigureCheckBoxButton.setSelection(true);
 		runIdfReconfigureCheckBoxButton.setText(Messages.RunIdfCommandButtonTxt);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/templates/messages.properties
@@ -8,4 +8,4 @@ NewProjectWizardPage_NoTemplateFoundMessage=No Templates were found on the syste
 TemplateGroupHeader=Template Selection
 NewProjectTargetSelection_Tooltip=Select a project target from the list. This setting is not final and can be changed later in the Launchbar target configuration, where you'll also configure the serial port.
 NewProjectTargetSelection_Label=Select Project Target:
-RunIdfCommandButtonTxt=Execute idf.py reconfigure with Project Creation
+RunIdfCommandButtonTxt=Run idf.py reconfigure after project creation to initialize the CMake build configuration


### PR DESCRIPTION
## Description

Update idf.py reconfigure msg in the new project wizard based on the Ivan's feedback in teh Q4 demo. 

Fixes # ([IEP-1466](https://jira.espressif.com:8443/browse/IEP-1466))

<img width="698" alt="Screenshot 2025-03-04 at 11 21 07 AM" src="https://github.com/user-attachments/assets/ccb5b8bf-45e3-449e-8cae-64d8b4d8a50f" />


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Make sure message updated in the new project wizard to "Run idf.py reconfigure after project creation to initialize the CMake build configuration" from the 

**Test Configuration**:
* ESP-IDF Version: NA
* OS (Windows,Linux and macOS): NA

## Dependent components impacted by this PR:

- New Project wizard

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted spacing in the project creation interface for a more balanced visual layout.
- **Documentation**
  - Updated the on-screen command text for clearer guidance on initializing the build configuration after project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->