### PR TITLE
IEP-1470: Fix for exception on invalid file and editor for file open listener

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/FileOpenListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/FileOpenListener.java
@@ -42,21 +42,9 @@ public class FileOpenListener implements IPartListener2
 			if (project == null)
 				return;
 			
-			try
+			if (!isSourceOrHeaderFile(file))
 			{
-				IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
-				IContentType contentType = contentTypeManager.findContentTypeFor(file.getFullPath().toOSString());
-				if (contentType != null)
-				{
-					String id = contentType.getId();
-					if (!(id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header")))) {
-	                    return; // Skip files that are not C source/header files
-	                }
-				}
-			}
-			catch (Exception e)
-			{
-				Logger.log(e);
+				return;
 			}
 			
 			String buildDir = StringUtil.EMPTY;
@@ -75,6 +63,27 @@ public class FileOpenListener implements IPartListener2
 			lspService.restartLspServers();
 
 		}
+	}
+	
+	private boolean isSourceOrHeaderFile(IFile file)
+	{
+		try
+		{
+			IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
+			IContentType contentType = contentTypeManager.findContentTypeFor(file.getFullPath().toOSString());
+			if (contentType != null)
+			{
+				String id = contentType.getId();
+				if ((id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header")))) {
+                    return true;
+                }
+			}
+		}
+		catch (Exception e)
+		{
+			Logger.log(e);
+		}
+		return false;
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/FileOpenListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/FileOpenListener.java
@@ -17,6 +17,7 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.StringUtil;
+import com.espressif.idf.ui.tools.manager.ESPIDFManagerEditor;
 
 public class FileOpenListener implements IPartListener2
 {
@@ -34,6 +35,10 @@ public class FileOpenListener implements IPartListener2
 		if (part instanceof IEditorPart ieditorpart
 				&& ieditorpart.getEditorInput() instanceof FileEditorInput fileInput)
 		{
+			
+			if (ieditorpart instanceof ESPIDFManagerEditor)
+				return;
+			
 			IFile file = fileInput.getFile();
 			IProject project = file.getProject();
 			if (project == null)


### PR DESCRIPTION
## Description

Fix for exception on invalid file and editor for file open listener

Fixes # ([IEP-1470](https://jira.espressif.com:8443/browse/IEP-1470))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Read the original bug description on Jira and try to reproduce no exception in errors of similar nature should be visible.

**Test Configuration**:
* ESP-IDF Version: all
* OS (Windows,Linux and macOS): any

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file handling to skip processing for non-C source/header files when a dedicated editor view is active, enhancing the file opening experience and preventing potential conflicts during file interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->