### PR TITLE
IEP-1467 Update clangd path based on the esp-idf and tools

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/Messages.java
@@ -10,7 +10,8 @@ import org.eclipse.osgi.util.NLS;
  * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
  *
  */
-public class Messages extends NLS {
+public class Messages extends NLS
+{
 	private static final String BUNDLE_NAME = "com.espressif.idf.core.util.messages"; //$NON-NLS-1$
 	public static String FileUtil_CopyingMsg;
 	public static String FileUtil_DesDirNotavailable;
@@ -43,15 +44,20 @@ public class Messages extends NLS {
 	public static String NvsValidation_EncodingValidationErr_1;
 	public static String NvsValidation_KeyValidationErr_1;
 	public static String NvsValidation_KeyValidationErr_2;
-	
+
 	public static String PortChecker_AttemptLimitExceededMsg;
 	public static String PortChecker_PortIsAvailable;
 	public static String PortChecker_PortNotAvailable;
 
-	static {
+	public static String LspService_RestartJobMsg;
+
+	static
+	{
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
 	}
-	private Messages() {
+
+	private Messages()
+	{
 	}
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/messages.properties
@@ -32,3 +32,4 @@ NvsValidation_KeyValidationErr_2=Maximum key length is 15 characters
 PortChecker_AttemptLimitExceededMsg=The port selection attempt limit was exceeded. Returning last checked port
 PortChecker_PortIsAvailable=Port %d is available
 PortChecker_PortNotAvailable=Port %d is not available, trying next port: %d
+LspService_RestartJobMsg=Restarting LSP server...

--- a/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
@@ -3,7 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: com.espressif.idf.lsp;singleton:=true
 Bundle-Vendor: ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD
 Bundle-Version: 1.0.1.qualifier
-Export-Package: com.espressif.idf.lsp
+Export-Package: com.espressif.idf.lsp,
+ com.espressif.idf.lsp.preferences
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.cdt.lsp.clangd,

--- a/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.ui/META-INF/MANIFEST.MF
@@ -59,3 +59,4 @@ Bundle-ClassPath: .,
  lib/ini4j-0.5.4.jar,
  lib/gson-2.8.7.jar,
  lib/commonmark-0.16.1.jar
+Import-Package: com.espressif.idf.lsp.preferences

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
@@ -28,6 +28,7 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.toolchain.ESPToolChainManager;
 import com.espressif.idf.core.tools.vo.IDFToolSet;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.UIPlugin;
 import com.espressif.idf.ui.update.ExportIDFTools;
@@ -94,7 +95,7 @@ public class ToolsActivationJob extends ToolsJob
 
 		toolSetConfigurationManager.export(idfToolSet);
 		console.println("Tools Activated");
-
+		new LspService().updateClangdPath();
 		Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 		scopedPreferenceStore.putBoolean(INSTALL_TOOLS_FLAG, true);
 		try


### PR DESCRIPTION
## Description

Updating the clangd path after tools activation and shutting down the server before the restart to avoid this issue:
![image](https://github.com/user-attachments/assets/7c8e83ff-95bf-46c8-997f-98759f59cbf3)


Fixes # ([IEP-1467](https://jira.espressif.com:8443/browse/IEP-1467))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

1) install ESP-IDF (master in my case) and simply create a project - then open main.c - no errors and function definition and auto-completion are available 
2) Install multiple esp-idf versions and change between them -> check clangd path is updated accordingly 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- LSP server

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an update that automatically adjusts language service configuration paths during tool activation.
  - Added a user-visible message indicating when the language server is restarting.

- **Refactor**
  - Streamlined the language server restart workflow for improved reliability.
  - Improved message formatting for clearer display.

- **Chores**
  - Updated package dependencies to support enhanced language service preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->