### PR TITLE
docs: add docs on How do I build multiple configurations in Espressif…

### DIFF
--- a/docs/en/faqs.rst
+++ b/docs/en/faqs.rst
@@ -151,3 +151,15 @@ IDF Eclipse plugin uses CMake commands to build the project, so it's possible to
 - Click on the editor configuration wizard.
 - Navigate to `Build Settings` tab.
 - Add `--debug-output` or other
+
+How do I build multiple configurations in Espressif-IDE?
+----------------------------------------------------------
+- Create a new project.
+- Open the `Launch Configuration` dialog.
+- Navigate to the `Build Settings` tab and enter `-B build_release` in the `Additional CMake Arguments` section. Here, `build_release` is the name of the build folder.
+- Click the `OK` button to save the configuration.
+- Reopen the `Launch Configuration` dialog.
+- Click the `Duplicate` button (located at the bottom left corner).
+- Navigate to the `Build Settings` tab and update the `Additional CMake Arguments` section to `-B build_dev`. Here, `build_dev` is the name of the build folder.
+- Click the `OK` button to save the configuration.
+- Click the Build icon from the toolbar (the leftmost icon) for the selected configuration. This will build the project and create a build folder for that configuration. Repeat the same process for the other configuration by selecting it from the dropdown.


### PR DESCRIPTION
## Description

Add FAQ doc on How do I build multiple configurations in Espressif-IDE to help the users
reference: https://www.esp32.com/viewtopic.php?f=40&t=45045&p=146314#p146314

Fixes # ([IEP-1501](https://jira.espressif.com:8443/browse/IEP-1501))

## Type of change

- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version: NA
* OS (Windows,Linux and macOS): BNA

## Dependent components impacted by this PR:

NA

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new FAQ section that provides detailed, step-by-step guidance for managing multiple build configurations in the IDE.
  - The guide walks users through creating a new project, accessing configuration settings, and executing builds for both release and development modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->