### PR TITLE
IEP-1471 ESP-IDF Path with whitespaces leads to python error during FLASH

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/DfuCommandsUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/DfuCommandsUtil.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.cdt.utils.CommandLineUtil;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.variables.VariablesPlugin;
@@ -118,7 +119,7 @@ public class DfuCommandsUtil
 			String flashCommand = configuration.getAttribute(IDFLaunchConstants.ATTR_DFU_FLASH_ARGUMENTS,
 					getDfuFlashCommand());
 			flashCommand = resolveExpressionFromVariableManager(flashCommand);
-			flashCommandList = Arrays.asList(flashCommand.split(" ")); //$NON-NLS-1$
+			flashCommandList = Arrays.asList(CommandLineUtil.argumentsToArray(flashCommand));
 		}
 		catch (CoreException e1)
 		{

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/internal/SerialFlashLaunchConfigDelegate.java
@@ -32,6 +32,7 @@ import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigDelegate;
 import org.eclipse.cdt.debug.core.launch.NullProcess;
 import org.eclipse.cdt.debug.internal.core.Messages;
 import org.eclipse.cdt.serial.SerialPort;
+import org.eclipse.cdt.utils.CommandLineUtil;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -150,11 +151,13 @@ public class SerialFlashLaunchConfigDelegate extends CoreBuildGenericLaunchConfi
 		{
 			return;
 		}
-		String arguments = configuration.getAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS, espFlashCommand);
-		arguments = varManager.performStringSubstitution(arguments);
-		if (!arguments.isEmpty())
+		String args = configuration.getAttribute(IDFLaunchConstants.ATTR_SERIAL_FLASH_ARGUMENTS, espFlashCommand);
+
+		if (!args.isEmpty())
 		{
-			commands.addAll(Arrays.asList(varManager.performStringSubstitution(arguments).split(" "))); //$NON-NLS-1$
+			args = varManager.performStringSubstitution(args);
+			String[] arguments = CommandLineUtil.argumentsToArray(args);
+			commands.addAll(Arrays.asList((arguments)));
 		}
 
 		String workingDirectory = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY,

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/BuildFolderVariableResolver.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/BuildFolderVariableResolver.java
@@ -43,6 +43,11 @@ public class BuildFolderVariableResolver implements IDynamicVariableResolver
 				buildFolder = projectBuildFolder;
 		}
 
+		if (buildFolder != null && buildFolder.contains(" ")) //$NON-NLS-1$
+		{
+			buildFolder = "\"" + buildFolder + "\""; //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
 		return buildFolder;
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/IDFDynamicVariableResolver.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/IDFDynamicVariableResolver.java
@@ -14,29 +14,45 @@ import com.espressif.idf.core.util.IDFUtil;
 
 /**
  * Variable resolver for our added dynamic variables
+ *
  * @author Ali Azam Rana
  *
  */
-public class IDFDynamicVariableResolver implements IDynamicVariableResolver {
+public class IDFDynamicVariableResolver implements IDynamicVariableResolver
+{
 
 	@Override
-	public String resolveValue(IDynamicVariable variable, String argument) throws CoreException {
+	public String resolveValue(IDynamicVariable variable, String argument) throws CoreException
+	{
 		IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
-
 		IDFDynamicVariables idfVariable = IDFDynamicVariables.valueOf(variable.getName());
 
-		switch (idfVariable) {
+		String resolvedValue = null;
+
+		switch (idfVariable)
+		{
 		case IDF_PATH:
-			return idfEnvironmentVariables.getEnvValue(IDFDynamicVariables.IDF_PATH.name());
+			resolvedValue = idfEnvironmentVariables.getEnvValue(IDFDynamicVariables.IDF_PATH.name());
+			break;
 
 		case IDF_PYTHON_ENV_PATH:
-			return IDFUtil.getIDFPythonEnvPath();
+			resolvedValue = IDFUtil.getIDFPythonEnvPath();
+			break;
 
 		case IDF_PY:
-			return IDFUtil.getIDFPythonScriptFile().getAbsolutePath();
+			resolvedValue = IDFUtil.getIDFPythonScriptFile().getAbsolutePath();
+			break;
 
 		default:
 			return null;
 		}
+
+		// Wrap the resolved value in quotes if it contains spaces or special characters
+		if (resolvedValue != null && resolvedValue.contains(" ")) //$NON-NLS-1$
+		{
+			resolvedValue = "\"" + resolvedValue + "\""; //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		return resolvedValue;
 	}
 }


### PR DESCRIPTION
## Description

 Fixed an issue with flash when esp-idf path contains spaces.

Fixes # ([IEP-1471](https://jira.espressif.com:8443/browse/IEP-1471))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- Install ESP-IDF to the directory that contains spaces
- Create a new project
- build flash using uart
- build flash using jtag
- build flash using dfu

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch configuration
- Flash
- Dynamic variables

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of command-line arguments to better support quoted strings and special characters during flashing operations.
	- Enhanced variable resolution to automatically quote values containing spaces, reducing potential errors in command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->