### PR TITLE
IEP-1521 Update build folder after project renaming

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/Messages.java
@@ -28,6 +28,7 @@ public class Messages extends NLS
 	public static String MissingDebugConfigurationTitle;
 	public static String DebugConfigurationNotFoundMsg;
 
+	public static String RenameIdfProjectParticipant_RenameBuildFolderPathChangeName;
 	public static String RunActionHandler_NoProjectQuestionText;
 	public static String RunActionHandler_NoProjectQuestionTitle;
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
@@ -1,8 +1,12 @@
 package com.espressif.idf.ui.handlers;
 
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -11,15 +15,74 @@ import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
 import org.eclipse.ltk.core.refactoring.participants.RenameParticipant;
 import org.eclipse.swt.widgets.Display;
 
+import com.espressif.idf.core.IDFConstants;
 import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.ui.LaunchBarListener;
 
 public class RenameIdfProjectParticipant extends RenameParticipant
 {
 
+	private IProject project;
+
+	class UpdateBuildFolderChange extends Change
+	{
+
+		private String oldBuildFolderPath;
+		private String newBuildPath;
+		private IProject newProject;
+
+		@Override
+		public String getName()
+		{
+			return String.format(Messages.RenameIdfProjectParticipant_RenameBuildFolderPathChangeName,
+					oldBuildFolderPath, newBuildPath);
+		}
+
+		@Override
+		public RefactoringStatus isValid(IProgressMonitor pm)
+		{
+			return RefactoringStatus.create(Status.OK_STATUS);
+		}
+
+		@Override
+		public void initializeValidationData(IProgressMonitor pm)
+		{
+			try
+			{
+				oldBuildFolderPath = IDFUtil.getBuildDir(project);
+				String newProjectName = getArguments().getNewName();
+				newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(newProjectName);
+				IFolder newBuildFolder = newProject.getFolder(IDFConstants.BUILD_FOLDER);
+				newBuildPath = newBuildFolder.getFullPath().toOSString();
+			}
+			catch (CoreException e)
+			{
+				Logger.log(e);
+			}
+		}
+
+		@Override
+		public Change perform(IProgressMonitor pm) throws CoreException
+		{
+			IDFUtil.setBuildDir(newProject, newBuildPath);
+			return null;
+		}
+
+		@Override
+		public Object getModifiedElement()
+		{
+			return project;
+		}
+	}
+
 	protected boolean initialize(Object element)
 	{
+		if (element instanceof IProject projectElement)
+		{
+			this.project = projectElement;
+		}
 		return true;
 	}
 
@@ -39,20 +102,22 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 		// workaround to save active launch target when renaming the project
 		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
 		ILaunchTarget activeLaunchTarget = launchBarManager.getActiveLaunchTarget();
+		launchBarManager.getActiveLaunchConfiguration().getAttributes();
 		LaunchBarListener.setIgnoreTargetChange(true);
-		Display.getDefault().syncExec(() ->
-			Display.getDefault().getActiveShell().addDisposeListener(disposeEvent -> {
-				try
-				{
-					LaunchBarListener.setIgnoreTargetChange(false);
-					launchBarManager.setActiveLaunchTarget(activeLaunchTarget);
-				}
-				catch (CoreException e)
-				{
-					Logger.log(e);
-				}
+		Display.getDefault().syncExec(() -> Display.getDefault().getActiveShell().addDisposeListener(disposeEvent -> {
+			try
+			{
+				LaunchBarListener.setIgnoreTargetChange(false);
+				launchBarManager.setActiveLaunchTarget(activeLaunchTarget);
+			}
+			catch (CoreException e)
+			{
+				Logger.log(e);
+			}
+
 		}));
-		return null;
+
+		return new UpdateBuildFolderChange();
 	}
 
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
@@ -32,6 +32,7 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 		private String oldBuildFolderPath;
 		private String newBuildPath;
 		private IProject newProject;
+		private IFolder newBuildFolder;
 
 		@Override
 		public String getName()
@@ -54,7 +55,7 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 				oldBuildFolderPath = IDFUtil.getBuildDir(project);
 				String newProjectName = getArguments().getNewName();
 				newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(newProjectName);
-				IFolder newBuildFolder = newProject.getFolder(IDFConstants.BUILD_FOLDER);
+				newBuildFolder = newProject.getFolder(IDFConstants.BUILD_FOLDER);
 				newBuildPath = newBuildFolder.getFullPath().toOSString();
 			}
 			catch (CoreException e)
@@ -66,7 +67,7 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 		@Override
 		public Change perform(IProgressMonitor pm) throws CoreException
 		{
-			IDFUtil.setBuildDir(newProject, newBuildPath);
+			IDFUtil.setBuildDir(newProject, newBuildFolder.getLocation().toOSString());
 			return null;
 		}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RenameIdfProjectParticipant.java
@@ -102,7 +102,6 @@ public class RenameIdfProjectParticipant extends RenameParticipant
 		// workaround to save active launch target when renaming the project
 		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
 		ILaunchTarget activeLaunchTarget = launchBarManager.getActiveLaunchTarget();
-		launchBarManager.getActiveLaunchConfiguration().getAttributes();
 		LaunchBarListener.setIgnoreTargetChange(true);
 		Display.getDefault().syncExec(() -> Display.getDefault().getActiveShell().addDisposeListener(disposeEvent -> {
 			try

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/messages.properties
@@ -20,5 +20,6 @@ UpdateEspIdfCommand_InstallToolsJobMsg=Installing tools...
 UpdateEspIdfCommand_SuggestToOpenInstallToolsWizard = A new set of tools might be required to install. Do you want to open the Install Tools dialog? 
 MissingDebugConfigurationTitle=Missing debug configuration
 DebugConfigurationNotFoundMsg=No matching debug configuration was found for the selected project. Do you want to create it?
+RenameIdfProjectParticipant_RenameBuildFolderPathChangeName=Update build folder path from "%s" to "%s"
 RunActionHandler_NoProjectQuestionText=The selected configuration does not include a project. Would you like to edit the active launch configuration and specify the project?
 RunActionHandler_NoProjectQuestionTitle=Edit Active Configuration?


### PR DESCRIPTION
## Description

After renaming the project, we need to update its configuration settings and regenerate the saved build folder to ensure consistency and avoid build issues.
![image](https://github.com/user-attachments/assets/2497845f-523f-4c18-a720-b19119593a72)


Fixes # ([IEP-1521](https://jira.espressif.com:8443/browse/IEP-1521))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

build project -> rename project -> build project -> built to the new folder

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Build
- Rename

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The build folder path is now automatically updated when an IDF project is renamed, streamlining project management.
- **Documentation**
	- Added a new message for displaying updates when the build folder path changes during project renaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->