### PR TITLE
fix(lsp):Update cdt-lsp to v3.1.0

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -96,7 +96,7 @@
 			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.0/cdt-lsp-3.0.0//"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.1/cdt-lsp-3.1.0/"/>
 			<unit id="org.eclipse.cdt.lsp.feature.feature.group" version="0.0.0"/>
 			<unit id="org.yaml.snakeyaml" version="2.2.0"/> 
 		</location>


### PR DESCRIPTION
## Description

Update cdt-lsp to v3.1.0

Fixes # ([IEP-1526](https://jira.espressif.com:8443/browse/IEP-1526))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Install the PR build on the eclipse cdt 2025-03 and espressif-ide v3.3.0

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Update site


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the repository URL for the Eclipse CDT LSP feature group to version 3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->