### PR TITLE
fix(jre): package platform specific jre with the espressif-ide

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -56,7 +56,10 @@
       <feature id="com.espressif.idf.feature" installMode="root"/>
       <feature id="org.eclipse.cdt" installMode="root"/>
       <feature id="org.eclipse.cdt.gdb" installMode="root"/>
-      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full.macosx.aarch64" installMode="root" os="macosx" ws="cocoa" arch="aarch64"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full.macosx.x86_64" installMode="root" os="macosx" ws="cocoa" arch="x86_64"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full.linux.x86_64" installMode="root" os="linux" ws="gtk" arch="x86_64"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full.win32.x86_64" installMode="root" os="win32" ws="win32" arch="x86_64"/>
       <feature id="org.eclipse.cdt.gnu.build" installMode="root"/>
       <feature id="org.eclipse.cdt.gnu.debug" installMode="root"/>
       <feature id="org.eclipse.cdt.gnu.dsf" installMode="root"/>


### PR DESCRIPTION
## Description

Package platform specific jre with the espressif-ide.


## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Make sure update site contain only platform specific jre

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated product configuration to use platform-specific JRE features for improved compatibility across macOS (aarch64, x86_64), Linux (x86_64), and Windows (x86_64).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->