### PR TITLE
IEP-1530 IDF console cleared when GDB starts

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/process/StreamListener.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/process/StreamListener.java
@@ -51,7 +51,12 @@ public class StreamListener implements IStreamListener
 		fOutputStreamMonitor = outputStreamMonitor;
 
 		idfProcessConsole = IdfProcessConsoleFactory.showAndActivateConsole(charset);
-		idfProcessConsole.clearConsole();
+
+		// Clear the console only at the beginning, when OpenOCD starts
+		if (iProcess.getLabel().contains("openocd")) //$NON-NLS-1$
+		{
+			idfProcessConsole.clearConsole();
+		}
 		fConsoleErrorOutputStream = idfProcessConsole.getErrorStream();
 		fConsoleErrorOutputStream.setActivateOnWrite(true);
 		fConsoleOutputStream = idfProcessConsole.getOutputStream();


### PR DESCRIPTION
## Description

When the GDB client is started, the IDF process console output is cleared. This results in the removal of OpenOCD startup messages, which are often essential for understanding initialization status, connection issues, or board-specific output.

Check the video before the fix:

https://github.com/user-attachments/assets/0458c69e-225d-4c76-abee-bfc93c2f4899

And after the fix:

https://github.com/user-attachments/assets/4c72cc77-4e62-4dac-b2bb-16748e672521

Note: The current implementation has a drawback: when users start only GDB clients without OpenOCD, the console will not be cleared on each start. However, I believe this case is rare and not critical, as it's still possible to clear the console manually.

Fixes # ([IEP-1530](https://jira.espressif.com:8443/browse/IEP-1530))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

- run debug

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Idf process console

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The console will now only be cleared at the start of OpenOCD processes, preventing unnecessary clearing for other processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->