### PR TITLE
fix: changing junit4 dependency to junit5 in unit tests

### DIFF
--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -8,10 +8,10 @@ Automatic-Module-Name: com.espressif.idf.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: com.espressif.idf.core;bundle-version="1.0.1",
  junit-jupiter-api,
- org.junit,
  junit-jupiter-params,
  org.eclipse.launchbar.core,
- org.eclipse.jface
+ org.eclipse.jface,
+ junit-jupiter-engine
 Bundle-ClassPath: .,
  lib/jmock-2.12.0.jar,
  lib/commons-collections4-4.4.jar,

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/actions/test/ApplyTargetJobTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/actions/test/ApplyTargetJobTest.java
@@ -4,8 +4,8 @@
  *******************************************************************************/
 package com.espressif.idf.core.actions.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -89,13 +89,11 @@ class ApplyTargetJobTest
 	@Test
 	void run_whenSuitableTargetFound_shouldSetActiveLaunchTarget() throws CoreException
 	{
-		// Available ILaunchTargets in provided by mocked target manager
 		ILaunchTarget target = Mockito.mock(ILaunchTarget.class);
 		when(target.getAttribute(LaunchBarTargetConstants.TARGET, StringUtil.EMPTY)).thenReturn(EXPECTED_TARGET_NAME);
 		when(target.getAttribute(LaunchBarTargetConstants.SERIAL_PORT, StringUtil.EMPTY)).thenReturn(SERIAL_PORT);
 		when(targetManager.getLaunchTargetsOfType(Mockito.anyString())).thenReturn(new ILaunchTarget[] { target });
 
-		// Mocked LaunchBarManager has the active launch target with expected target name
 		when(launchBarManager.getActiveLaunchTarget()).thenReturn(target);
 		when(launchBarManager.getActiveLaunchConfiguration()).thenReturn(mock(ILaunchConfiguration.class));
 		when(launchBarManager.getActiveLaunchConfiguration().getAttribute(eq(TARGET_NAME_ATTR), anyString()))
@@ -122,7 +120,7 @@ class ApplyTargetJobTest
 
 		TestableApplyTargetJobException exception = assertThrows(
 				TestableApplyTargetJob.TestableApplyTargetJobException.class, () -> applyTargetJob.run(monitor));
-		assertEquals(exception.getMessage(), NOT_EXISTING_TARGET_NAME);
+		assertEquals(NOT_EXISTING_TARGET_NAME, exception.getMessage());
 		verify(launchBarManager, never()).setActiveLaunchTarget(any());
 	}
 
@@ -136,5 +134,4 @@ class ApplyTargetJobTest
 
 		assertEquals(Status.CANCEL_STATUS, result);
 	}
-
 }

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/build/test/EspIdfErrorParserTest.java
@@ -4,9 +4,9 @@
  *******************************************************************************/
 package com.espressif.idf.core.build.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,8 +34,7 @@ class EspIdfErrorParserTest
 	void process_line_returns_true_if_hint_available_for_error_line()
 	{
 		List<ReHintPair> reHintPairs = new ArrayList<>();
-		reHintPairs.add(
-				new ReHintPair(ERROR_REGEX, StringUtil.EMPTY));
+		reHintPairs.add(new ReHintPair(ERROR_REGEX, StringUtil.EMPTY));
 		String errorLine = ERROR_LINE;
 		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);
 
@@ -48,8 +47,7 @@ class EspIdfErrorParserTest
 	void process_line_returns_false_if_no_hint_found_for_error_line()
 	{
 		List<ReHintPair> reHintPairs = new ArrayList<>();
-		reHintPairs.add(
-				new ReHintPair(NON_EXISTING_ERROR_REGEX, StringUtil.EMPTY));
+		reHintPairs.add(new ReHintPair(NON_EXISTING_ERROR_REGEX, StringUtil.EMPTY));
 		String errorLine = ERROR_LINE;
 		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);
 
@@ -70,8 +68,7 @@ class EspIdfErrorParserTest
 		});
 		List<ReHintPair> reHintPairs = new ArrayList<>();
 		String expectedHint = EXPECTED_HINT;
-		reHintPairs.add(
-				new ReHintPair(ERROR_REGEX, expectedHint));
+		reHintPairs.add(new ReHintPair(ERROR_REGEX, expectedHint));
 		String errorLine = ERROR_LINE;
 
 		EspIdfErrorParser ep = new EspIdfErrorParser(reHintPairs);

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ActiveLaunchConfigurationTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ActiveLaunchConfigurationTest.java
@@ -4,7 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.core.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +40,7 @@ class ActiveLaunchConfigurationTest
 		ActiveLaunchConfigurationProvider provider = new ActiveLaunchConfigurationProvider(launchBarManager);
 		runInitLaunchBarJob(launchBarManager, launchConfiguration);
 		ILaunchConfiguration configuration = provider.getActiveLaunchConfiguration();
-		
+
 		assertEquals(EXPECTED_LAUNCH_CONFIG_NAME, configuration.getName());
 	}
 

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/DefaultBoardProviderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/DefaultBoardProviderTest.java
@@ -4,7 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.core.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
 
@@ -57,22 +57,25 @@ class DefaultBoardProviderTest
 						new String[] { "ESP32-S3 chip (via ESP-PROG)", "ESP32-S3 chip (via ESP USB Bridge)",
 								"ESP32-S3 chip (via builtin USB-JTAG)" },
 						ESP32S3_EXPECTED_INDEX),
-				Arguments.of("esp32c3", new String[] { "ESP32-C3 chip (via ESP USB Bridge)",
-						"ESP32-C3 chip (via builtin USB-JTAG)", "ESP32-C3 chip (via ESP-PROG)" },
+				Arguments.of("esp32c3",
+						new String[] { "ESP32-C3 chip (via ESP USB Bridge)", "ESP32-C3 chip (via builtin USB-JTAG)",
+								"ESP32-C3 chip (via ESP-PROG)" },
 						ESP32C3_EXPECTED_INDEX),
-				Arguments.of("esp32", new String[] { "ESP-WROVER-KIT 1.8V", "ESP32 chip (via ESP USB Bridge)",
-						"ESP-WROVER-KIT 3.3V" }, ESP32_EXPECTED_INDEX),
+				Arguments.of("esp32",
+						new String[] { "ESP-WROVER-KIT 1.8V", "ESP32 chip (via ESP USB Bridge)",
+								"ESP-WROVER-KIT 3.3V" },
+						ESP32_EXPECTED_INDEX),
 				Arguments.of("esp32s2",
 						new String[] { "ESP32-S2 chip (via ESP USB Bridge)", "ESP32-S2-KALUGA-1",
 								"ESP32-S2 chip (via ESP-PROG)" },
 						ESP32S2_EXPECTED_INDEX),
 				Arguments.of("esp32c2",
 						new String[] { "ESP32-C2 chip (via ESP-PROG)", "ESP32-C2 chip (via ESP USB Bridge)"
-						
+
 						}, ESP32C2_EXPECTED_INDEX),
-				Arguments.of(
-						"esp32c6", new String[] { "ESP32-C6 chip (via builtin USB-JTAG)",
-								"ESP32-C6 chip (via ESP-PROG)", "ESP32-C6 chip (via ESP USB Bridge)" },
+				Arguments.of("esp32c6",
+						new String[] { "ESP32-C6 chip (via builtin USB-JTAG)", "ESP32-C6 chip (via ESP-PROG)",
+								"ESP32-C6 chip (via ESP USB Bridge)" },
 						ESP32C6_EXPECTED_INDEX),
 				Arguments.of("esp32h2", new String[] { "ESP32-H2 chip (via ESP-PROG)",
 						"ESP32-H2 chip (via ESP USB Bridge)", "ESP32-H2 chip (via builtin USB-JTAG)" },

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ProcessBuilderFactoryTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ProcessBuilderFactoryTest.java
@@ -1,8 +1,8 @@
 package com.espressif.idf.core.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,8 +56,8 @@ class ProcessBuilderFactoryTest
 	{
 		Map<String, String> emptyEnvironment = new HashMap<>();
 
-		assertThrows(IOException.class, () ->
-		new ProcessBuilderFactory().run(dummyCommand, Path.EMPTY, emptyEnvironment));
+		assertThrows(IOException.class,
+				() -> new ProcessBuilderFactory().run(dummyCommand, Path.EMPTY, emptyEnvironment));
 	}
 
 	@Test

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ZipUtilityTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/test/ZipUtilityTest.java
@@ -1,7 +1,7 @@
 package com.espressif.idf.core.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/HintsUtilTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/HintsUtilTest.java
@@ -4,8 +4,8 @@
  *******************************************************************************/
 package com.espressif.idf.core.util.test;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -87,7 +87,6 @@ class HintsUtilTest
 		assertEquals(expectedSecondComplexRe, reHintsList.get(SECOND_SIMPLIFIED_ENTRY_INDEX).getRe().get().pattern());
 	}
 
-
 	@Test
 	void getReHintsList_returns_empty_array_when_not_existing_path_is_provided()
 	{
@@ -96,6 +95,5 @@ class HintsUtilTest
 		assertNotNull(reHintsList);
 		assertEquals(new ArrayList<>(), reHintsList);
 	}
-
 
 }

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchBarNameUtilTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchBarNameUtilTest.java
@@ -4,10 +4,10 @@
  *******************************************************************************/
 package com.espressif.idf.core.util.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchConfigFinderTest.java
@@ -4,7 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.core.util.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.core.resources.IProject;


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
