### PR TITLE
IEP-1525 Terminal: can't build project

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
@@ -386,6 +386,11 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 		Map<String, String> envMap = new IDFEnvironmentVariables().getSystemEnvMap();
 		Set<String> keySet = envMap.keySet();
 
+		//Removing path, since we are using PATH
+		if (envMap.containsKey("PATH") && envMap.containsKey("Path")) { //$NON-NLS-1$ //$NON-NLS-2$
+			envMap.remove("Path"); //$NON-NLS-1$
+		}
+
 		for (String envKey : keySet) {
 			String envValue = envMap.get(envKey);
 			if (envKey.equals("PATH")) //$NON-NLS-1$
@@ -397,10 +402,7 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 			}
 			envpList.add(envKey + "=" + envValue); //$NON-NLS-1$
 		}
-		//Removing path, since we are using PATH
-		if (envMap.containsKey("PATH") && envMap.containsKey("Path")) { //$NON-NLS-1$ //$NON-NLS-2$
-			envMap.remove("Path"); //$NON-NLS-1$
-		}
+
 		// Convert back into a string array
 		envp = envpList.toArray(new String[envpList.size()]);
 


### PR DESCRIPTION
## Description

The initial issue with the terminal was fixed in another PR related to the idf.py reconfigure command. The code that was supposed to fix the terminal was placed after the environment (envp) initialization, but due to a lack of testing, since the initial PR was focused on something else, we missed it at first.

Fixes # ([IEP-1525](https://jira.espressif.com:8443/browse/IEP-1525))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Run the terminal inside the IDE and use different idf.py commands

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

-Terminal 

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of environment variables to prevent potential conflicts between "PATH" and "Path" when launching the terminal connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->