### PR TITLE
IEP-1543 Set the default setCompilationDatabase to false

### DIFF
--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
@@ -24,6 +24,7 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 	{
 		Set<String> filteredKeys = Set.of(Predefined.clangdPath.identifer(), Predefined.queryDriver.identifer(),
 				Predefined.setCompilationDatabase.identifer());
+
 		var filteredDefaults = Predefined.defaults.stream().filter(pref -> filteredKeys.contains(pref.identifer()))
 				.toList();
 

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
@@ -22,8 +22,8 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 	@Override
 	protected List<PreferenceMetadata<?>> definePreferences()
 	{
-		Set<String> filteredKeys = Set.of(Predefined.clangdPath.identifer(), Predefined.queryDriver.identifer());
-
+		Set<String> filteredKeys = Set.of(Predefined.clangdPath.identifer(), Predefined.queryDriver.identifer(),
+				Predefined.setCompilationDatabase.identifer());
 		var filteredDefaults = Predefined.defaults.stream().filter(pref -> filteredKeys.contains(pref.identifer()))
 				.toList();
 
@@ -38,10 +38,12 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 
 		var queryDriverMetadataWithDefault = wrapWithCustomDefaultValue(defaultIdfQueryDriver,
 				ClangdMetadata.Predefined.queryDriver);
+		var setCompilationDatabaseDefault = wrapWithCustomDefaultValue(false, Predefined.setCompilationDatabase);
 
 		List<PreferenceMetadata<?>> mergedPreferences = new ArrayList<>(filteredDefaults);
 		mergedPreferences.add(clangdMetadataWithDefault);
 		mergedPreferences.add(queryDriverMetadataWithDefault);
+		mergedPreferences.add(setCompilationDatabaseDefault);
 
 		return mergedPreferences;
 	}


### PR DESCRIPTION
## Description

Set the default setCompilationDatabase to false

Fixes # ([IEP-1543](https://jira.espressif.com:8443/browse/IEP-1543))

## Type of change
- New feature (non-breaking change which adds functionality)

## How has this been tested?

restore values on the clangd preferences page to default -> set compilation database should be false

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Clangd preferences

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new preference option to control the compilation database setting, defaulting to disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->