### PR TITLE
fix: script for removing unwanted flags from compile_commands.json

### DIFF
--- a/docs/en/additionalfeatures/clangd_cdt_support.rst
+++ b/docs/en/additionalfeatures/clangd_cdt_support.rst
@@ -9,7 +9,7 @@ In line with this enhancement, we've discontinued support for the standard CDT E
 
 The LSP powered C/C++ editor greatly benefits ESP-IDF developers by aligning with the latest language standards and compiler versions, enhancing productivity, and improving code quality.
 
-You can find more details on the LSP based C/C++ Editor features `here <https://github.com/eclipse-cdt/cdt-lsp/>`_.
+You can find more details on the LSP based C/C++ Editor features in the `Eclipse CDT-LSP documentation <https://github.com/eclipse-cdt/cdt-lsp/>`_.
 
 Prerequisites
 -------------
@@ -59,7 +59,7 @@ If you are seeing the following error markers while navigating to the esp-idf co
 
 Please follow the steps below to fix it:
 
-1. Download the script from `here <https://github.com/espressif/idf-eclipse-plugin/tree/master/resources/resources/fix_compile_commands/fix_compile_commands.py>`_.
+1. Download the script for `fix_compile_commands.py <https://github.com/espressif/idf-eclipse-plugin/tree/master/resources/resources/fix_compile_commands/fix_compile_commands.py>`_.
 
 2. Invoke the script from the project post build step. Here is example for `CMakeLists.txt <https://github.com/espressif/idf-eclipse-plugin/blob/master/resources/resources/fix_compile_commands/CMakeLists.txt>`_:
 

--- a/docs/en/additionalfeatures/clangd_cdt_support.rst
+++ b/docs/en/additionalfeatures/clangd_cdt_support.rst
@@ -45,6 +45,40 @@ However, if you are dealing with an existing project, please create a `.clangd` 
       CompilationDatabase: build
       Remove: [-m*, -f*]
 
+How to fix Unknown argument error when navigating to the esp-idf components
+----------------------------------------------------------------------------------------
+
+If you are seeing the following error markers while navigating to the esp-idf components source code:
+
+.. code-block:: none
+
+    Multiple markers at this line
+    - Unknown argument: '-fno-tree-switch-conversion' [drv_unknown_argument]
+    - Unknown argument: '-fno-shrink-wrap' [drv_unknown_argument]
+    - Unknown argument: '-fstrict-volatile-bitfields' [drv_unknown_argument]
+
+Please follow the steps below to fix it:
+
+1. Download the script from `here <https://github.com/espressif/idf-eclipse-plugin/tree/master/resources/resources/fix_compile_commands/fix_compile_commands.py>`_.
+
+2. Invoke the script from the project post build step. Here is example for `CMakeLists.txt <https://github.com/espressif/idf-eclipse-plugin/blob/master/resources/resources/fix_compile_commands/CMakeLists.txt>`_:
+
+   .. code-block:: cmake
+
+      if(EXISTS "${CMAKE_SOURCE_DIR}/fix_compile_commands.py")
+        add_custom_target(
+            fix_clangd ALL
+            COMMAND ${CMAKE_COMMAND} -E echo "Running fix_compile_commands.py..."
+            COMMAND ${CMAKE_COMMAND} -E env python3 ${CMAKE_SOURCE_DIR}/fix_compile_commands.py
+            COMMENT "Cleaning compile_commands.json for clangd"
+            VERBATIM
+        )
+      endif()
+
+3. Now run the build, the script will remove the -m* and -f* flags from the compile_commands.json file which are unknown to clangd.
+
+4. Now, you can navigate to the esp-idf components source code without any errors.
+
 Disable CDT Indexer
 -------------------
 

--- a/resources/fix_compile_commands/CMakeLists.txt
+++ b/resources/fix_compile_commands/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(blink)
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/fix_compile_commands.py")
+    add_custom_target(
+        fix_clangd ALL
+        COMMAND ${CMAKE_COMMAND} -E echo "Running fix_compile_commands.py..."
+        COMMAND ${CMAKE_COMMAND} -E env python3 ${CMAKE_SOURCE_DIR}/fix_compile_commands.py
+        COMMENT "Cleaning compile_commands.json for clangd"
+        VERBATIM
+    )
+endif()

--- a/resources/fix_compile_commands/fix_compile_commands.py
+++ b/resources/fix_compile_commands/fix_compile_commands.py
@@ -1,0 +1,50 @@
+# Author: Kondal Kolipaka <kondal.kolipaka@espressif.com>
+#
+# Copyright 2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+# Use is subject to license terms.
+
+"""
+This script is used to remove all '-m*' and '-f*' flags from the compile_commands.json file.
+"""
+
+import os
+import json
+import re
+
+def find_compile_commands_json(start_dir):
+    for root, dirs, files in os.walk(start_dir):
+        if 'compile_commands.json' in files:
+            return os.path.join(root, 'compile_commands.json')
+    return None
+
+def remove_mf_flags(compile_commands):
+    for entry in compile_commands:
+        args = entry.get("arguments") or entry.get("command", "").split()
+        filtered_args = [arg for arg in args if not re.match(r"^-([mf]).*", arg)]
+        
+        if "arguments" in entry:
+            entry["arguments"] = filtered_args
+        elif "command" in entry:
+            entry["command"] = " ".join(filtered_args)
+    return compile_commands
+
+def main():
+    build_dir = os.path.join(os.path.dirname(__file__), "build")
+    cc_path = find_compile_commands_json(build_dir)
+
+    if not cc_path:
+        print("compile_commands.json not found.")
+        return
+
+    with open(cc_path, "r") as f:
+        compile_commands = json.load(f)
+
+    cleaned_commands = remove_mf_flags(compile_commands)
+
+    with open(cc_path, "w") as f:
+        json.dump(cleaned_commands, f, indent=2)
+    
+    print(f"Removed all '-m*' and '-f*' flags from: {cc_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Write a script to remove -m and -f arguments from compile_commands.json so that we can avoid errors when navigating the ESP-IDF internal component source code

Why? Those arguments are applicable to the GCC compiler, but when Clangd uses the compile_commands.json file, it throws errors saying the arguments are invalid.

This PR includes the script and the steps required to use it, so we can recommend it to users. Going forward, we can consider implementing it by default as part of project creation, along with updating the CMakeLists.txt.

Fixes # ([IEP-1550](https://jira.espressif.com:8443/browse/IEP-1550))
Triggered by https://esp32.com/viewtopic.php?t=45824

## Type of change
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a script and build integration to automatically clean problematic compiler flags from compile_commands.json, improving navigation in LSP-based C/C++ editors for ESP-IDF projects.

- **Documentation**
  - Updated documentation with detailed instructions for resolving "Unknown argument" errors in clangd, including usage of the new script and build integration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->