### PR TITLE
IEP-1548 Clangd NullPointerException: Incorrect Configuration Settings

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/toolchain/ESPToolChainManager.java
@@ -155,7 +155,7 @@ public class ESPToolChainManager
 		return toolchainElements.values().stream()
 				.filter(espToolChainElement -> espToolChainElement.name.equals(target))
 				.map(espToolChainElement -> findToolChain(getAllPaths(), espToolChainElement.compilerPattern))
-				.findFirst().orElse(null);
+				.filter(java.util.Objects::nonNull).findFirst().orElse(null);
 	}
 
 	public File findToolChain(List<String> paths, String filePattern)

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
@@ -23,12 +23,14 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 	protected List<PreferenceMetadata<?>> definePreferences()
 	{
 		Set<String> filteredKeys = Set.of(Predefined.clangdPath.identifer(), Predefined.queryDriver.identifer());
+
 		var filteredDefaults = Predefined.defaults.stream().filter(pref -> filteredKeys.contains(pref.identifer()))
 				.toList();
 
-		var clangdMetadataWithDefault = wrapWithCustomDefaultValue(
-				IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE),
-				ClangdMetadata.Predefined.clangdPath);
+		String clangdPath = Optional.ofNullable(IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE))
+				.orElse(ClangdMetadata.Predefined.clangdPath.defaultValue());
+
+		var clangdMetadataWithDefault = wrapWithCustomDefaultValue(clangdPath, ClangdMetadata.Predefined.clangdPath);
 
 		ESPToolChainManager toolChainManager = new ESPToolChainManager();
 		String defaultIdfQueryDriver = Optional.ofNullable(toolChainManager.findCompiler("esp32")) //$NON-NLS-1$
@@ -49,5 +51,4 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 		return new PreferenceMetadata<>(metadata.valueClass(), metadata.identifer(), customDefaultValue,
 				metadata.name(), metadata.description());
 	}
-
 }


### PR DESCRIPTION
## Description

The NPE occurs when we try to open the Clangd preferences page, and one of the values is null. This can occur before the tools are installed or if the installation process goes wrong.

An ideal solution would be to refactor the public File findToolChain(List<String> paths, String filePattern) method to return an Optional<File>. We can consider this refactoring as a separate ticket.

Fixes # ([IEP-1548](https://jira.espressif.com:8443/browse/IEP-1548))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- 
## How has this been tested?

New workspace -> open prefrences before installing tools

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when selecting compiler files by ensuring only valid, non-null files are considered.
  - Enhanced handling of the clangd executable path to provide a more robust fallback to default values if the path is not found.

- **Style**
  - Minor whitespace cleanup for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->