### PR TITLE
fix(target): update to tm4e latest plugins to avoid plugin loading issue

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -87,7 +87,7 @@
 			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
+			<repository location="https://download.eclipse.org/tm4e/releases/0.14.1/"/>
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 		</location>

--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -87,7 +87,7 @@
 			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/snapshots/"/>
+			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Eclipse TM4E repository URL to use the latest stable release instead of a snapshot version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->