### PR TITLE
IEP-1556: fix for NPE on windows for system python

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -120,7 +120,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 
 	protected String getPythonExecutablePath()
 	{
-		pythonExecutablenPath = IDFUtil.getPythonExecutable();
+		pythonExecutablenPath = IDFUtil.getIDFPythonEnvPath();
 		return pythonExecutablenPath;
 	}
 


### PR DESCRIPTION
## Description

NPE on windows for system python getting called for product information

Fixes # ([IEP-1556](https://jira.espressif.com:8443/browse/IEP-1556))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Install tools and see product information should not be any null error 

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): Windows

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability in detecting the Python executable path used by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->