### PR TITLE
fix(lsp): Tag target builds with the lsp 3.2.0 and it's dependencies

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -78,7 +78,7 @@
 			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.4.0.202307251916"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.27.2/"/>
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.27.4/"/>
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
@@ -96,7 +96,7 @@
 			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.1/cdt-lsp-3.1.0/"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.2/cdt-lsp-3.2.0/"/>
 			<unit id="org.eclipse.cdt.lsp.feature.feature.group" version="0.0.0"/>
 			<unit id="org.yaml.snakeyaml" version="2.2.0"/> 
 		</location>


### PR DESCRIPTION
## Description

Tag target builds with the lsp 3.2.0 and it's dependencies

Fixes # ([IEP-1561](https://jira.espressif.com:8443/browse/IEP-1561))

## Type of change

- New feature (non-breaking change which adds functionality)


## How has this been tested?

- Update to the latest PR update site and it should work without any issues in the lsp editor

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Update site

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
