### PR TITLE
bucket link fix

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -291,10 +291,10 @@ jobs:
 
         aws cloudfront create-invalidation --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} --paths "/dl/idf-eclipse-plugin/updates/latest/*"
 
-        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin-test/ide/Espressif-IDE-win32.win32.x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${{ env.VERSION }}-win32.win32.x86_64.zip"
+        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-win32.win32.x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${{ env.VERSION }}-win32.win32.x86_64.zip"
 
-        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin-test/ide/Espressif-IDE-macosx-cocoa-x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64-v${{ env.VERSION }}.dmg"
+        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-x86_64-v${{ env.VERSION }}.dmg"
 
-        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin-test/ide/Espressif-IDE-macosx-cocoa-aarch64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64-v${{ env.VERSION }}.dmg"
+        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-macosx-cocoa-aarch64-v${{ env.VERSION }}.dmg"
 
-        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin-test/ide/Espressif-IDE-linux.gtk.x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${{ env.VERSION }}-linux.gtk.x86_64.tar.gz"
+        aws s3api put-object --acl=public-read --bucket espdldata --key "dl/idf-eclipse-plugin/ide/Espressif-IDE-linux.gtk.x86_64/latest" --website-redirect-location "/dl/idf-eclipse-plugin/ide/Espressif-IDE-${{ env.VERSION }}-linux.gtk.x86_64.tar.gz"


### PR DESCRIPTION
## Description

Fixed the link for ci release bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the upload paths for Eclipse plugin IDE artifacts in the release workflow, removing the "-test" suffix from S3 object keys for Windows, macOS, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->