### PR TITLE
IEP-1570 Improve EIM Tool Detection Message in IDE

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -29,7 +29,7 @@ IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the 
 IDFToolChainsMissingErrorMsg=Toolchains are missing. Please use ESP-IDF Manager for configuring
 
 NoActiveEspIdfInWorkspaceMsgTitle=ESP-IDF Setup
-NoActiveEspIdfInWorkspaceMsg=ESP-IDF is required to use Espressif IDE. Would you like to configure it now?
+NoActiveEspIdfInWorkspaceMsg=ESP-IDF tools installed via EIM have been detected, but this workspace is not configured yet. The IDE needs to complete setup to enable full functionality. Would you like to proceed now?
 
 OldConfigFoundMsgBoxTitle=Old Configuration Detected
 OldConfigFoundMsgBoxMsg=Espressif IDE now uses the EIM system to manage ESP-IDF installations. A legacy configuration was found in your current workspace. Converting it to the EIM format will allow proper environment setup and ensure the IDE works seamlessly with your existing projects. Would you like to convert the configuration now?


### PR DESCRIPTION
## Description

In my opinion, the current message — "ESP-IDF is required to use Espressif IDE. Would you like to configure it now?" — might be a bit confusing, since users have already installed ESP-IDF via the EIM manager, and we've detected those tools.

The goal of this PR to make this message a little bit more informative

Fixes # ([IEP-1570](https://jira.espressif.com:8443/browse/IEP-1570))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
