### PR TITLE
IEP-1577: Eim default directory added based on documentation

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -110,6 +110,11 @@ public class EspressifToolStartup implements IStartup
 		{
 			idfEnvironmentVariables.addEnvVariable(IDFEnvironmentVariables.EIM_PATH, eimJson.getEimPath());
 		}
+		else 
+		{
+			// Fail-safe call to ensure if the eim is in Applications or user.home it is setup in env vars
+			toolInitializer.findAndSetEimPath();
+		}
 
 		if (stateChecker.wasModifiedSinceLastRun())
 		{


### PR DESCRIPTION
## Description

Added a default path validation for EIM as in documentation I added the instructions for a case where users (rarely) may go through documentation when upgrading and they may have already downloaded the EIM to the specified directory.

Fixes # ([IEP-1577](https://jira.espressif.com:8443/browse/IEP-1577))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Download and place the eim executable in __USER_HOME__/.espressif/eim_gui/eim.exe
For macos eim.app must be in Applications not in the directory mentioned above

launch the IDE it should not notify you to download the EIM again.

@AndriiFilippov kindly only verify this testing scenario only 

**Test Configuration**: 
* ESP-IDF Version: doesn't matter here
* OS (Windows,Linux and macOS): all

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
