### PR TITLE
IEP-1583: Closing old editor window when old workspace is found

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -18,8 +18,11 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -92,6 +95,7 @@ public class EspressifToolStartup implements IStartup
 		if (toolInitializer.isOldEspIdfConfigPresent() && !toolInitializer.isOldConfigExported())
 		{
 			Logger.log("Old configuration found and not converted");
+			closeEspIdfManager();
 			boolean isEimInApplications = checkIfEimPathMacOsIsInApplications();
 			if (!isEimInApplications)
 			{
@@ -192,6 +196,33 @@ public class EspressifToolStartup implements IStartup
 			MessageDialog.openInformation(display.getActiveShell(), messageTitle, message);
 		});
 	}
+	
+	private void closeEspIdfManager()
+	{
+		Display.getDefault().asyncExec(() -> {
+			IWorkbenchWindow window = EclipseHandler.getActiveWorkbenchWindow();
+			if (window != null)
+			{
+				IWorkbenchPage page = window.getActivePage();
+				if (page != null)
+				{
+					IEditorReference[] editors = page.getEditorReferences();
+					for (IEditorReference editorRef : editors)
+					{
+						if (ESPIDFManagerEditor.EDITOR_ID.equals(editorRef.getId()))
+						{
+							IEditorPart editor = editorRef.getEditor(false);
+							if (editor != null)
+							{
+								page.closeEditor(editor, false);
+							}
+						}
+					}
+				}
+			}
+		});
+	}
+
 
 	private void showEimJsonStateChangeNotification()
 	{


### PR DESCRIPTION
## Description

https://jira.espressif.com:8443/browse/IEP-1583

Fixes # ([IEP-1583](https://jira.espressif.com:8443/browse/IEP-1583))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Start old workspace which was close with ESP-IDF Manager opened. The newer workspace should close the ESP-IDF Manager previously opened

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
