### PR TITLE
IEP-1585: Fixed eim old config import handling

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/ToolInitializer.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/ToolInitializer.java
@@ -84,15 +84,26 @@ public class ToolInitializer
 		return getOldConfigFile().exists();
 	}
 
-	public IStatus exportOldConfig(String eimPath) throws IOException
+	public IStatus exportOldConfig(Path eimPath) throws IOException
 	{
 		File oldConfig = getOldConfigFile();
 		if (oldConfig.exists())
 		{
 			// eim import pathToOldConfigJson
 			List<String> commands = new ArrayList<>();
-			commands.add(StringUtil.isEmpty(eimPath) ? 
-					idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.EIM_PATH) : eimPath);
+			String eimPathStr = StringUtil.EMPTY;
+			
+			if (eimPath != null && Files.exists(eimPath))
+			{
+				eimPathStr = eimPath.toString();
+			}
+			else 
+			{
+				return new Status(IStatus.ERROR, IDFCorePlugin.getId(), -1, "Cannot Convert EIM is not installed", null); //$NON-NLS-1$
+			}
+			
+			
+			commands.add(eimPathStr);
 			commands.add("import"); //$NON-NLS-1$
 			commands.add(oldConfig.getAbsolutePath());
 			Logger.log("Running: " + commands.toString()); //$NON-NLS-1$
@@ -123,7 +134,7 @@ public class ToolInitializer
 		return preferences.getBoolean(EimConstants.INSTALL_TOOLS_FLAG, false);
 	}
 
-	private Path getDefaultEimPath()
+	public Path getDefaultEimPath()
 	{
 		String userHome = System.getProperty("user.home"); //$NON-NLS-1$
         Path defaultEimPath;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -161,7 +161,8 @@ public class EspressifToolStartup implements IStartup
 		{
 			try
 			{
-				IStatus status = toolInitializer.exportOldConfig(eimJson != null ? eimJson.getEimPath() : StringUtil.EMPTY);
+				// if eim json is present it means that it contains the updated path and we use that else we fallback to finding eim in default paths
+				IStatus status = toolInitializer.exportOldConfig(eimJson != null ? Paths.get(eimJson.getEimPath()) : toolInitializer.getDefaultEimPath());
 				Logger.log("Tools Conversion Process Message: ");
 				Logger.log(status.getMessage());
 				if (status.getSeverity() != IStatus.ERROR)


### PR DESCRIPTION
## Description

The issue is that we are detecting if the eim executable is present in the system in user home directory under the .espressif/eim_gui/eim

or in applications on macos but when handling old config export the path passed was still null.

Fixes # ([IEP-1585](https://jira.espressif.com:8443/browse/IEP-1585))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Use an older workspace for this that has preconfigured IDF inside.
Make sure that eim is placed in user home under .espressif/eim_gui/eim or .espressif/eim_gui/eim.exe (Windows only)
For Mac put eim.app in Applications.
eim_idf.json must be removed and eim must not be launched.

Open the IDE and it should be able to detect old configuration and convert it.



**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): all

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Verified on all platforms - Windows,Linux and macOS
