### PR TITLE
IEP-1584 Avoid Simultaneous Modals on Old Config Detection

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/GlobalModalLock.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/GlobalModalLock.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui;
+
+import java.util.concurrent.Semaphore;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.eclipse.swt.widgets.Display;
+
+public class GlobalModalLock
+{
+	private static final Semaphore lock = new Semaphore(1);
+
+	private GlobalModalLock()
+	{
+	}
+
+	public static <T> void showModal(Supplier<T> dialogSupplier, Consumer<T> callback)
+	{
+		new Thread(() -> {
+			try
+			{
+				lock.acquire();
+				Display.getDefault().syncExec(() -> {
+					try
+					{
+						T result = dialogSupplier.get();
+						callback.accept(result);
+					} finally
+					{
+						lock.release();
+					}
+				});
+			}
+			catch (InterruptedException e)
+			{
+				Thread.currentThread().interrupt();
+			}
+		}, "GlobalModalLock-DialogThread").start(); //$NON-NLS-1$
+	}
+}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -19,8 +19,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchMode;
@@ -146,15 +144,17 @@ public class LaunchBarListener implements ILaunchBarListener
 						// If both are not same
 						if (currentTarget != null && !newTarget.equals(currentTarget))
 						{
-
-							boolean isDelete = MessageDialog.openQuestion(EclipseUtil.getShell(),
+							GlobalModalLock.showModal(() -> MessageDialog.openQuestion(EclipseUtil.getShell(),
 									Messages.LaunchBarListener_TargetChanged_Title,
 									MessageFormat.format(Messages.LaunchBarListener_TargetChanged_Msg,
-											project.getName(), currentTarget, newTarget));
-							if (isDelete)
-							{
-								deleteBuildFolder(project, buildLocation);
-							}
+											project.getName(), currentTarget, newTarget)),
+									isDelete -> {
+										if (isDelete)
+										{
+											deleteBuildFolder(project, buildLocation);
+
+										}
+									});
 						}
 					}
 				}

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -231,22 +231,19 @@ public class EspressifToolStartup implements IStartup
 
 	private void notifyMissingTools()
 	{
-		boolean[] userAgreed = new boolean[1];
-		Display.getDefault().syncExec(() -> {
-			userAgreed[0] = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
-					Messages.ToolsInitializationEimMissingMsgBoxTitle,
-					Messages.ToolsInitializationEimMissingMsgBoxMessage);
-		});
-
-		if (userAgreed[0])
-		{
-			// Download Launch EIM
-			downloadAndLaunchEim();
-		}
-		else
-		{
-			Logger.log("User selected No to download EIM");
-		}
+		GlobalModalLock.showModal(() -> MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
+				Messages.ToolsInitializationEimMissingMsgBoxTitle, Messages.ToolsInitializationEimMissingMsgBoxMessage),
+				response -> {
+					if (response)
+					{
+						// Download Launch EIM
+						downloadAndLaunchEim();
+					}
+					else
+					{
+						Logger.log("User selected No to download EIM");
+					}
+				});
 	}
 
 	private void downloadAndLaunchEim()
@@ -308,18 +305,22 @@ public class EspressifToolStartup implements IStartup
 			messageBox.setText(Messages.NoActiveEspIdfInWorkspaceMsgTitle);
 			messageBox.setMessage(Messages.NoActiveEspIdfInWorkspaceMsg);
 
-			if (messageBox.open() == SWT.YES)
-			{
-				openEspIdfManager(eimJson);
-			}
+			GlobalModalLock.showModal(messageBox::open, response -> {
+				if (response == SWT.YES)
+				{
+					openEspIdfManager(eimJson);
+				}
+			});
 		});
 	}
 
 	private void promptUserToMoveEimToApplications()
 	{
-		Display.getDefault().asyncExec(() -> {
+		GlobalModalLock.showModal(() -> {
 			MessageDialog.openInformation(Display.getDefault().getActiveShell(), Messages.EIMNotInApplicationsTitle,
 					Messages.EIMNotInApplicationsMessage);
+			return null;
+		}, ignored -> {
 		});
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -117,7 +117,6 @@ public class EspressifToolStartup implements IStartup
 			toolInitializer.findAndSetEimPath();
 		}
 
-		showEimJsonStateChangeNotification();
 		if (stateChecker.wasModifiedSinceLastRun())
 		{
 			showEimJsonStateChangeNotification();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -164,41 +164,31 @@ public class EspressifToolStartup implements IStartup
 	{
 		try
 		{
-			IStatus status = toolInitializer.exportOldConfig(eimJson != null ? eimJson.getEimPath() : StringUtil.EMPTY);
+			// if eim json is present it means that it contains the updated path and we use that else we fallback to
+			// finding eim in default paths
+			Path eimPath;
+			String eimPathEnvVar = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.EIM_PATH);
+			if (eimJson != null)
+			{
+				eimPath = Paths.get(eimJson.getEimPath());
+			}
+			else if (!StringUtil.isEmpty(eimPathEnvVar))
+			{
+				eimPath = Paths.get(eimPathEnvVar);
+			}
+			else
+			{
+				eimPath = toolInitializer.getDefaultEimPath();
+			}
+
+			IStatus status = toolInitializer.exportOldConfig(eimPath);
 			Logger.log("Tools Conversion Process Message: ");
 			Logger.log(status.getMessage());
 			if (status.getSeverity() != IStatus.ERROR)
 			{
-				// if eim json is present it means that it contains the updated path and we use that else we fallback to finding eim in default paths
-				Path eimPath;
-				String eimPathEnvVar = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.EIM_PATH);
-				if (eimJson != null)
-				{
-					eimPath = Paths.get(eimJson.getEimPath());
-				}
-				else if (!StringUtil.isEmpty(eimPathEnvVar))
-				{
-					eimPath = Paths.get(eimPathEnvVar);
-				}
-				else 
-				{
-					eimPath = toolInitializer.getDefaultEimPath();
-				}
-				
-				IStatus status = toolInitializer.exportOldConfig(eimPath);
-				Logger.log("Tools Conversion Process Message: ");
-				Logger.log(status.getMessage());
-				if (status.getSeverity() != IStatus.ERROR)
-				{
-					preferences.putBoolean(EimConstants.OLD_CONFIG_EXPORTED_FLAG, true);
-					displayInformationMessageBox(Messages.OldConfigExportCompleteSuccessMsgTitle,
-							Messages.OldConfigExportCompleteSuccessMsg);
-				}
-				else
-				{
-					displayInformationMessageBox(Messages.OldConfigExportCompleteFailMsgTitle,
-							Messages.OldConfigExportCompleteFailMsg);
-				}
+				preferences.putBoolean(EimConstants.OLD_CONFIG_EXPORTED_FLAG, true);
+				displayInformationMessageBox(Messages.OldConfigExportCompleteSuccessMsgTitle,
+						Messages.OldConfigExportCompleteSuccessMsg);
 			}
 			else
 			{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -117,6 +117,7 @@ public class EspressifToolStartup implements IStartup
 			toolInitializer.findAndSetEimPath();
 		}
 
+		showEimJsonStateChangeNotification();
 		if (stateChecker.wasModifiedSinceLastRun())
 		{
 			showEimJsonStateChangeNotification();
@@ -226,8 +227,7 @@ public class EspressifToolStartup implements IStartup
 
 	private void showEimJsonStateChangeNotification()
 	{
-		int response = eimJsonUiChangeHandler.displayMessageToUser();
-		eimJsonUiChangeHandler.handleUserResponse(response);
+		eimJsonUiChangeHandler.displayMessageToUser();
 	}
 
 	private void notifyMissingTools()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -68,14 +68,13 @@ public class EspressifToolStartup implements IStartup
 	@Override
 	public void earlyStartup()
 	{
-		preferences = org.eclipse.core.runtime.preferences.InstanceScope.INSTANCE
-				.getNode(UIPlugin.PLUGIN_ID);
+		preferences = org.eclipse.core.runtime.preferences.InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 		toolInitializer = new ToolInitializer(preferences);
 		standardConsoleStream = getConsoleStream(false);
 		errorConsoleStream = getConsoleStream(true);
 		idfEnvironmentVariables = new IDFEnvironmentVariables();
-		eimLoader = new EimLoader(new StartupClassDownloadEimDownloadListener(), 
-				standardConsoleStream, errorConsoleStream, Display.getDefault());
+		eimLoader = new EimLoader(new StartupClassDownloadEimDownloadListener(), standardConsoleStream,
+				errorConsoleStream, Display.getDefault());
 		EimJsonStateChecker stateChecker = new EimJsonStateChecker(preferences);
 		eimJsonUiChangeHandler = new EimJsonUiChangeHandler(preferences);
 		stateChecker.updateLastSeenTimestamp();
@@ -87,7 +86,7 @@ public class EspressifToolStartup implements IStartup
 			notifyMissingTools();
 			return;
 		}
-		
+
 		eimJson = toolInitializer.loadEimJson();
 
 		if (toolInitializer.isOldEspIdfConfigPresent() && !toolInitializer.isOldConfigExported())
@@ -98,8 +97,8 @@ public class EspressifToolStartup implements IStartup
 			{
 				promptUserToMoveEimToApplications();
 			}
-			
-			EimJsonWatchService.withPausedListeners(()-> handleOldConfigExport());
+
+			EimJsonWatchService.withPausedListeners(() -> handleOldConfigExport());
 		}
 		else if (toolInitializer.isEimIdfJsonPresent() && !toolInitializer.isEspIdfSet())
 		{
@@ -111,7 +110,7 @@ public class EspressifToolStartup implements IStartup
 		{
 			idfEnvironmentVariables.addEnvVariable(IDFEnvironmentVariables.EIM_PATH, eimJson.getEimPath());
 		}
-		else 
+		else
 		{
 			// Fail-safe call to ensure if the eim is in Applications or user.home it is setup in env vars
 			toolInitializer.findAndSetEimPath();
@@ -127,14 +126,14 @@ public class EspressifToolStartup implements IStartup
 	{
 		if (!Platform.getOS().equals(Platform.OS_MACOSX))
 			return true;
-		
-		String eimPath = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.EIM_PATH); 
+
+		String eimPath = idfEnvironmentVariables.getEnvValue(IDFEnvironmentVariables.EIM_PATH);
 		if (!StringUtil.isEmpty(eimPath))
 		{
 			if (Files.exists(Paths.get(eimPath)))
 			{
-				boolean isInApplications = eimPath.startsWith("/Applications/") ||
-                        eimPath.startsWith(System.getProperty("user.home") + "/Applications/");
+				boolean isInApplications = eimPath.startsWith("/Applications/")
+						|| eimPath.startsWith(System.getProperty("user.home") + "/Applications/");
 				if (!isInApplications)
 				{
 					Logger.log("EIM_PATH not in applications: " + eimPath);
@@ -142,7 +141,7 @@ public class EspressifToolStartup implements IStartup
 				}
 			}
 		}
-		
+
 		return true;
 	}
 
@@ -218,13 +217,13 @@ public class EspressifToolStartup implements IStartup
 
 	private void notifyMissingTools()
 	{
-		boolean [] userAgreed = new boolean[1];
+		boolean[] userAgreed = new boolean[1];
 		Display.getDefault().syncExec(() -> {
 			userAgreed[0] = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
 					Messages.ToolsInitializationEimMissingMsgBoxTitle,
 					Messages.ToolsInitializationEimMissingMsgBoxMessage);
 		});
-		
+
 		if (userAgreed[0])
 		{
 			// Download Launch EIM
@@ -301,13 +300,12 @@ public class EspressifToolStartup implements IStartup
 			}
 		});
 	}
-	
+
 	private void promptUserToMoveEimToApplications()
 	{
 		Display.getDefault().asyncExec(() -> {
-			MessageDialog.openInformation(
-				    Display.getDefault().getActiveShell(),
-				    Messages.EIMNotInApplicationsTitle, Messages.EIMNotInApplicationsMessage);
+			MessageDialog.openInformation(Display.getDefault().getActiveShell(), Messages.EIMNotInApplicationsTitle,
+					Messages.EIMNotInApplicationsMessage);
 		});
 	}
 
@@ -328,7 +326,7 @@ public class EspressifToolStartup implements IStartup
 			}
 		});
 	}
-	
+
 	private class StartupClassDownloadEimDownloadListener implements DownloadListener
 	{
 
@@ -347,7 +345,7 @@ public class EspressifToolStartup implements IStartup
 					Logger.log(e);
 				}
 			});
-			
+
 		}
 
 		@Override
@@ -363,7 +361,7 @@ public class EspressifToolStartup implements IStartup
 					Logger.log(e);
 				}
 			});
-			
+
 			Process process = null;
 			String appToLaunch = filePath;
 			try
@@ -372,15 +370,17 @@ public class EspressifToolStartup implements IStartup
 				{
 					appToLaunch = eimLoader.installAndLaunchDmg(Paths.get(filePath));
 				}
-				
+
 				idfEnvironmentVariables.addEnvVariable(IDFEnvironmentVariables.EIM_PATH, appToLaunch);
 				process = eimLoader.launchEim(appToLaunch);
 			}
-			catch (IOException | InterruptedException e)
+			catch (
+					IOException
+					| InterruptedException e)
 			{
 				Logger.log(e);
 			}
-			
+
 			eimLoader.waitForEimClosure(process, () -> {
 				if (toolInitializer.isOldEspIdfConfigPresent() && !toolInitializer.isOldConfigExported())
 				{


### PR DESCRIPTION
## Description

Added global modal lock to avoid simultaneous modals. 

https://github.com/user-attachments/assets/f2589094-e487-4f0e-a3af-ad4f67ad6995


Fixes # ([IEP-1584](https://jira.espressif.com:8443/browse/IEP-1584))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

build the project on the master -> change the target -> click no -> close the IDE -> change the branch to the 4.0.0 release -> open without cleaning the environment -> verify that no two modals at the same time 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
