### PR TITLE
IEP-1597 Remove redundant editor-closing code

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EspressifToolStartup.java
@@ -269,7 +269,6 @@ public class EspressifToolStartup implements IStartup
 
 	private void downloadAndLaunchEim()
 	{
-		closeWelcomePage();
 		Job downloadJob = new Job("Download and Launch EIM")
 		{
 
@@ -282,25 +281,6 @@ public class EspressifToolStartup implements IStartup
 		};
 		downloadJob.setUser(true);
 		downloadJob.schedule();
-	}
-
-	private void closeWelcomePage()
-	{
-		Display.getDefault().asyncExec(() -> {
-			IWorkbench workbench = PlatformUI.getWorkbench();
-			if (workbench != null)
-			{
-				IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-				if (window != null)
-				{
-					IIntroManager introManager = workbench.getIntroManager();
-					if (introManager.getIntro() != null)
-					{
-						introManager.closeIntro(introManager.getIntro());
-					}
-				}
-			}
-		});
 	}
 
 	private MessageConsoleStream getConsoleStream(boolean errorStream)


### PR DESCRIPTION
## Description

I think closeWelcomePage is a redundant method since it was introduced to fix an exception related to the tools manager editor

Fixes # ([IEP-1597](https://jira.espressif.com:8443/browse/IEP-1597))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
