### PR TITLE
IEP-1599 Exception occurres when EIM config file is missing

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
@@ -1,10 +1,12 @@
 package com.espressif.idf.core.tools;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.core.runtime.Platform;
 
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.tools.vo.EimJson;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,35 +15,43 @@ public class EimIdfConfiguratinParser
 {
 	private EimJson eimJson;
 	private Gson gson;
-	
+
 	public EimIdfConfiguratinParser()
 	{
 		gson = new GsonBuilder().setPrettyPrinting().enableComplexMapKeySerialization()
 				.excludeFieldsWithoutExposeAnnotation().create();
 	}
-	
+
 	private void load() throws IOException
 	{
-		try (FileReader fileReader = new FileReader(
-				Platform.getOS().equals(Platform.OS_WIN32) ? EimConstants.EIM_WIN_PATH : EimConstants.EIM_POSIX_PATH))
+		String path = Platform.getOS().equals(Platform.OS_WIN32) ? EimConstants.EIM_WIN_PATH
+				: EimConstants.EIM_POSIX_PATH;
+
+		File file = new File(path);
+		if (!file.exists())
+		{
+			Logger.log("EIM config file not found: " + path); //$NON-NLS-1$
+			return;
+		}
+
+		try (FileReader fileReader = new FileReader(file))
 		{
 			eimJson = gson.fromJson(fileReader, EimJson.class);
 		}
 	}
 
-	
 	public EimJson getEimJson(boolean reload) throws IOException
 	{
 		if (reload)
 		{
 			load();
 		}
-		
+
 		if (eimJson == null)
 		{
 			load();
 		}
-		
+
 		return eimJson;
 	}
 }


### PR DESCRIPTION
## Description

Fixed an exception when eim.json is missing to keep log clean

Fixes # ([IEP-1599](https://jira.espressif.com:8443/browse/IEP-1599))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Delete eim.json -> restart the IDE -> verify no There is java.io.FileNotFoundException: \esp-config.json in the log

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
