### PR TITLE
IEP-1601 Fix NullPointerException in updateLspQueryDrivers method

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -47,6 +47,10 @@ public class LspService
 
 	public void updateAdditionalOptions(String additionalOptions)
 	{
+		if (additionalOptions == null)
+		{
+			return;
+		}
 		String qualifier = configuration.qualifier();
 		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.additionalOptions.identifer(),
 				additionalOptions);
@@ -54,18 +58,26 @@ public class LspService
 
 	public void updateLspQueryDrivers()
 	{
+		String toolchainPath = IDFUtil.getToolchainExePathForActiveTarget();
 		String qualifier = configuration.qualifier();
+		if (toolchainPath == null)
+		{
+			return;
+		}
 		// By passing --query-driver argument to clangd helps to resolve the
 		// cross-compiler toolchain headers.
-		String toolchainPath = IDFUtil.getToolchainExePathForActiveTarget();
 		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.queryDriver.identifer(), toolchainPath);
 	}
 
 	public void updateClangdPath()
 	{
+		String clangdPath = IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE);
+		if (clangdPath == null)
+		{
+			return;
+		}
 		String qualifier = configuration.qualifier();
-		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.clangdPath.identifer(),
-				IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE));
+		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.clangdPath.identifer(), clangdPath);
 	}
 
 	public void updateCompileCommandsDir(String buildDir)

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -17,6 +17,7 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.ui.PlatformUI;
 
 import com.espressif.idf.core.ILSPConstants;
+import com.espressif.idf.core.logging.Logger;
 
 @SuppressWarnings("restriction")
 public class LspService
@@ -49,6 +50,7 @@ public class LspService
 	{
 		if (additionalOptions == null)
 		{
+			Logger.log("Skipped updating additional options: value is null"); //$NON-NLS-1$
 			return;
 		}
 		String qualifier = configuration.qualifier();
@@ -62,6 +64,7 @@ public class LspService
 		String qualifier = configuration.qualifier();
 		if (toolchainPath == null)
 		{
+			Logger.log("Toolchain path not found. Skipping update of --query-driver for LSP"); //$NON-NLS-1$
 			return;
 		}
 		// By passing --query-driver argument to clangd helps to resolve the
@@ -74,6 +77,7 @@ public class LspService
 		String clangdPath = IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE);
 		if (clangdPath == null)
 		{
+			Logger.log("clangd executable not found in build environment path. Skipping clangd path update."); //$NON-NLS-1$
 			return;
 		}
 		String qualifier = configuration.qualifier();


### PR DESCRIPTION
## Description

NPE like this happens when the IDE is installed for the first time and no tools are yet installed:
java.lang.NullPointerException
at org.eclipse.core.internal.preferences.EclipsePreferences.put(EclipsePreferences.java:840)
at com.espressif.idf.core.util.LspService.updateLspQueryDrivers(LspService.java:61)
at com.espressif.idf.ui.LaunchBarListener.lambda$0(LaunchBarListener.java:100)

Fixes # ([IEP-1601](https://jira.espressif.com:8443/browse/IEP-1601))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

To reproduce an issue on the master:
- Install tools -> create a project -> delete tools and clean env variables -> restart the IDE

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing configuration updates when required values are missing, reducing potential errors caused by null values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->