### PR TITLE
fix: write openocd debug output to a file

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/process/monitors/StreamsProxy.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/process/monitors/StreamsProxy.java
@@ -62,14 +62,14 @@ public class StreamsProxy implements IBinaryStreamsProxy {
 	 * @param charset the process's charset or <code>null</code> if default
 	 * @param processLabel The name for the process label
 	 */
-	public StreamsProxy(IProcess iProcess, Process process, Charset charset, String processLabel) {
+	public StreamsProxy(IProcess iProcess, Process process, Charset charset, String processLabel, String outputFile, boolean append) {
 		if (process == null) {
 			return;
 		}
 		fOutputMonitor = new CustomOutputStreamMonitor(process.getInputStream(), charset);
 		fErrorMonitor = new CustomOutputStreamMonitor(process.getErrorStream(), charset);
 		// Our own addition to make sure that we utilize only one listener for all streams
-		StreamListener streamListener = new StreamListener(iProcess, fErrorMonitor, fOutputMonitor, charset);
+		StreamListener streamListener = new StreamListener(iProcess, fErrorMonitor, fOutputMonitor, charset, outputFile, append);
 		fOutputMonitor.addListener(streamListener);
 		fErrorMonitor.addListener(streamListener);
 		fInputMonitor = new InputStreamMonitor(process.getOutputStream(), charset);


### PR DESCRIPTION
## Description

This PR adds the capability to capture and write OpenOCD debug output to a file, providing better debugging and logging capabilities 

Fixes # ([IEP-1536](https://jira.espressif.com:8443/browse/IEP-1536))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- Open Debug configuraiton
- Navigate to common tab and choose output file
- Debug the application
- Verify that output is written to a selected file

Scenarios verified

- Tested with existing directory paths
- Tested with non-existent directory paths (auto-creation)
- Tested with explicit file paths
- Tested append 

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Debugging

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
