### PR TITLE
IEP-1509 GH #1200: Terminal monitor still cannot build, flash or app flash

### DIFF
--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/core/IDFMonitor.java
@@ -40,13 +40,16 @@ public class IDFMonitor
 	private IProject project;
 	private String filterOptions;
 	private int serverPort;
+	private boolean encryptionOption;
 
-	public IDFMonitor(IProject project, String port, String filterOptions, String pythonBinPath, int serverPort)
+	public IDFMonitor(IProject project, String port, String filterOptions, boolean encryptionOption,
+			String pythonBinPath, int serverPort)
 	{
 		this.project = project;
 		this.port = port;
 		this.pythonBinPath = pythonBinPath;
 		this.filterOptions = filterOptions;
+		this.encryptionOption = encryptionOption;
 		this.serverPort = serverPort;
 	}
 
@@ -71,6 +74,10 @@ public class IDFMonitor
 		args.add(port);
 		args.add("-b"); //$NON-NLS-1$
 		args.add(getMonitorBaudRate());
+		if (encryptionOption)
+		{
+			args.add("--encrypted"); //$NON-NLS-1$
+		}
 		args.add("--ws"); //$NON-NLS-1$
 		args.add("ws://localhost:".concat(String.valueOf(serverPort))); //$NON-NLS-1$
 		args.add(getElfFilePath(project).toString());

--- a/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/handlers/SerialMonitorHandler.java
+++ b/bundles/com.espressif.idf.serial.monitor/src/com/espressif/idf/serial/monitor/handlers/SerialMonitorHandler.java
@@ -17,13 +17,16 @@ public class SerialMonitorHandler
 	private String serialPort;
 	private String filterOptions;
 	private int serverPort;
+	private boolean encryptionOption;
 
-	public SerialMonitorHandler(IProject project, String serialPort, String filterOptions, int serverPort)
+	public SerialMonitorHandler(IProject project, String serialPort, String filterOptions, boolean encryptionOption,
+			int serverPort)
 	{
 		this.project = project;
 		this.serialPort = serialPort;
 		this.filterOptions = filterOptions;
 		this.serverPort = serverPort;
+		this.encryptionOption = encryptionOption;
 	}
 
 	public Process invokeIDFMonitor()
@@ -31,7 +34,8 @@ public class SerialMonitorHandler
 		// python path
 		String pythonPath = IDFUtil.getIDFPythonEnvPath();
 
-		IDFMonitor monitor = new IDFMonitor(project, serialPort, filterOptions, pythonPath, serverPort);
+		IDFMonitor monitor = new IDFMonitor(project, serialPort, filterOptions, encryptionOption, pythonPath,
+				serverPort);
 		try
 		{
 			return monitor.start();

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
@@ -36,6 +36,7 @@ public class SerialConnector extends TerminalConnectorImpl
 	protected Thread thread;
 	protected IProject project;
 	protected String filterOptions;
+	protected boolean encryptionOption;
 	protected ITerminalControl control;
 	private SerialPortHandler serialPort;
 
@@ -94,7 +95,7 @@ public class SerialConnector extends TerminalConnectorImpl
 		String portName = settings.getPortName();
 		filterOptions = settings.getFilterText();
 		filterOptions = StringUtil.isEmpty(filterOptions) ? StringUtil.EMPTY : filterOptions;
-
+		encryptionOption = settings.getExtraMonitorOptions();
 		serialPort = new SerialPortHandler(portName, this, project);
 		serialPort.open();
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
@@ -95,7 +95,7 @@ public class SerialConnector extends TerminalConnectorImpl
 		String portName = settings.getPortName();
 		filterOptions = settings.getFilterText();
 		filterOptions = StringUtil.isEmpty(filterOptions) ? StringUtil.EMPTY : filterOptions;
-		encryptionOption = settings.getExtraMonitorOptions();
+		encryptionOption = settings.getEncryptionOption();
 		serialPort = new SerialPortHandler(portName, this, project);
 		serialPort.open();
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialConnector.java
@@ -28,7 +28,8 @@ import org.eclipse.tm.internal.terminal.provisional.api.provider.TerminalConnect
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.terminal.connector.serial.activator.Activator;
 
-public class SerialConnector extends TerminalConnectorImpl {
+public class SerialConnector extends TerminalConnectorImpl
+{
 
 	private SerialSettings settings = new SerialSettings();
 	protected Process process;
@@ -40,43 +41,51 @@ public class SerialConnector extends TerminalConnectorImpl {
 
 	private static Set<String> openPorts = new HashSet<>();
 
-	public static boolean isOpen(String portName) {
+	public static boolean isOpen(String portName)
+	{
 		return openPorts.contains(portName);
 	}
 
 	@Override
-	public OutputStream getTerminalToRemoteStream() {
+	public OutputStream getTerminalToRemoteStream()
+	{
 		return process.getOutputStream();
 	}
 
-	public SerialSettings getSettings() {
+	public SerialSettings getSettings()
+	{
 		return settings;
 	}
 
 	@Override
-	public String getSettingsSummary() {
+	public String getSettingsSummary()
+	{
 		return settings.getSummary();
 	}
 
 	@Override
-	public void load(ISettingsStore store) {
+	public void load(ISettingsStore store)
+	{
 		settings.load(store);
 	}
 
 	@Override
-	public void save(ISettingsStore store) {
+	public void save(ISettingsStore store)
+	{
 		settings.save(store);
 	}
 
 	@Override
-	public void connect(ITerminalControl control) {
+	public void connect(ITerminalControl control)
+	{
 		super.connect(control);
 		this.control = control;
 
-		//Get selected project - which is required for IDF Monitor
+		// Get selected project - which is required for IDF Monitor
 		project = settings.getProject();
 
-		if (project == null) {
+		if (project == null)
+		{
 			String message = "project can't be null. Make sure you select a project before launch a serial monitor"; //$NON-NLS-1$
 			Activator.log(new Status(IStatus.ERROR, Activator.getUniqueIdentifier(), message, null));
 			return;
@@ -94,13 +103,18 @@ public class SerialConnector extends TerminalConnectorImpl {
 	}
 
 	@Override
-	protected void doDisconnect() {
+	protected void doDisconnect()
+	{
 
-		if (serialPort != null && serialPort.isOpen()) {
+		if (serialPort != null && serialPort.isOpen())
+		{
 			openPorts.remove(serialPort.getPortName());
-			try {
+			try
+			{
 				serialPort.close();
-			} catch (IOException e) {
+			}
+			catch (IOException e)
+			{
 				Activator.log(e);
 			}
 		}

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialPortHandler.java
@@ -24,8 +24,6 @@ public class SerialPortHandler
 	private boolean isOpen;
 	private boolean isPaused;
 	private Object pauseMutex = new Object();
-	private IProject project;
-
 	private static final Map<String, LinkedList<WeakReference<SerialPortHandler>>> openPorts = new HashMap<>();
 
 	private Process process;
@@ -37,14 +35,7 @@ public class SerialPortHandler
 
 	private static String adjustPortName(String portName)
 	{
-		if (System.getProperty("os.name").startsWith("Windows") && !portName.startsWith("\\\\.\\")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		{
-			return portName; // $NON-NLS-1$
-		}
-		else
-		{
-			return portName;
-		}
+		return portName;
 	}
 
 	/**
@@ -88,7 +79,6 @@ public class SerialPortHandler
 	{
 		this.portName = adjustPortName(portName);
 		this.serialConnector = serialConnector;
-		this.project = project;
 		this.serverMessageHandler = new SocketServerMessageHandler(serialConnector, project);
 	}
 
@@ -123,7 +113,7 @@ public class SerialPortHandler
 
 		// Hook IDF Monitor with the CDT serial monitor
 		SerialMonitorHandler serialMonitorHandler = new SerialMonitorHandler(serialConnector.project, portName,
-				serialConnector.filterOptions, serverPort);
+				serialConnector.filterOptions, serialConnector.encryptionOption, serverPort);
 		process = serialMonitorHandler.invokeIDFMonitor();
 		serialConnector.process = process;
 		thread = new Thread()

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
@@ -30,7 +30,7 @@ public class SerialSettings
 	private String portName;
 	private String filterText;
 	private String selectedProject;
-	private boolean extraMonitorOpts;
+	private boolean encryptionOption;
 
 	/**
 	 * Load information into the RemoteSettings object.
@@ -40,7 +40,7 @@ public class SerialSettings
 		portName = store.get(PORT_NAME_ATTR, ""); //$NON-NLS-1$
 		filterText = store.get(MONITOR_FILTER, ""); //$NON-NLS-1$
 		selectedProject = store.get(SELECTED_PROJECT_ATTR, ""); //$NON-NLS-1$
-		extraMonitorOpts = Boolean.parseBoolean(store.get(ENCRYPTION_ATTR, "false")); //$NON-NLS-1$
+		encryptionOption = Boolean.parseBoolean(store.get(ENCRYPTION_ATTR, "false")); //$NON-NLS-1$
 	}
 
 	/**
@@ -51,7 +51,7 @@ public class SerialSettings
 		store.put(PORT_NAME_ATTR, portName);
 		store.put(MONITOR_FILTER, filterText);
 		store.put(SELECTED_PROJECT_ATTR, selectedProject);
-		store.put(ENCRYPTION_ATTR, Boolean.toString(extraMonitorOpts));
+		store.put(ENCRYPTION_ATTR, Boolean.toString(encryptionOption));
 	}
 
 	public String getPortName()
@@ -69,9 +69,9 @@ public class SerialSettings
 		return selectedProject;
 	}
 
-	public boolean getExtraMonitorOptions()
+	public boolean getEncryptionOption()
 	{
-		return extraMonitorOpts;
+		return encryptionOption;
 	}
 
 	public IProject getProject()
@@ -102,9 +102,9 @@ public class SerialSettings
 		this.selectedProject = projectName;
 	}
 
-	public void setExtraOptions(boolean extraOptions)
+	public void setEncryptionOption(boolean encryptionOption)
 	{
-		this.extraMonitorOpts = extraOptions;
+		this.encryptionOption = encryptionOption;
 	}
 
 }

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
@@ -25,10 +25,12 @@ public class SerialSettings
 	public static final String PORT_NAME_ATTR = "cdtserial.portName"; //$NON-NLS-1$
 	public static final String MONITOR_FILTER = "idf.monitor.filter"; //$NON-NLS-1$
 	public static final String SELECTED_PROJECT_ATTR = "idf.monitor.project"; //$NON-NLS-1$
+	public static final String ENCRYPTION_ATTR = "idf.monitor.extraOptions"; //$NON-NLS-1$
 
 	private String portName;
 	private String filterText;
 	private String selectedProject;
+	private boolean extraMonitorOpts;
 
 	/**
 	 * Load information into the RemoteSettings object.
@@ -38,6 +40,7 @@ public class SerialSettings
 		portName = store.get(PORT_NAME_ATTR, ""); //$NON-NLS-1$
 		filterText = store.get(MONITOR_FILTER, ""); //$NON-NLS-1$
 		selectedProject = store.get(SELECTED_PROJECT_ATTR, ""); //$NON-NLS-1$
+		extraMonitorOpts = Boolean.parseBoolean(store.get(ENCRYPTION_ATTR, "false")); //$NON-NLS-1$
 	}
 
 	/**
@@ -48,6 +51,7 @@ public class SerialSettings
 		store.put(PORT_NAME_ATTR, portName);
 		store.put(MONITOR_FILTER, filterText);
 		store.put(SELECTED_PROJECT_ATTR, selectedProject);
+		store.put(ENCRYPTION_ATTR, Boolean.toString(extraMonitorOpts));
 	}
 
 	public String getPortName()
@@ -63,6 +67,11 @@ public class SerialSettings
 	public String getProjectName()
 	{
 		return selectedProject;
+	}
+
+	public boolean getExtraMonitorOptions()
+	{
+		return extraMonitorOpts;
 	}
 
 	public IProject getProject()
@@ -91,6 +100,11 @@ public class SerialSettings
 	public void setProject(String projectName)
 	{
 		this.selectedProject = projectName;
+	}
+
+	public void setExtraOptions(boolean extraOptions)
+	{
+		this.extraMonitorOpts = extraOptions;
 	}
 
 }

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
@@ -25,7 +25,7 @@ public class SerialSettings
 	public static final String PORT_NAME_ATTR = "cdtserial.portName"; //$NON-NLS-1$
 	public static final String MONITOR_FILTER = "idf.monitor.filter"; //$NON-NLS-1$
 	public static final String SELECTED_PROJECT_ATTR = "idf.monitor.project"; //$NON-NLS-1$
-	public static final String ENCRYPTION_ATTR = "idf.monitor.extraOptions"; //$NON-NLS-1$
+	public static final String ENCRYPTION_ATTR = "idf.monitor.encryption"; //$NON-NLS-1$
 
 	private String portName;
 	private String filterText;

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/connector/SerialSettings.java
@@ -19,7 +19,8 @@ import org.eclipse.tm.internal.terminal.provisional.api.ISettingsStore;
 
 import com.espressif.idf.core.util.StringUtil;
 
-public class SerialSettings {
+public class SerialSettings
+{
 
 	public static final String PORT_NAME_ATTR = "cdtserial.portName"; //$NON-NLS-1$
 	public static final String MONITOR_FILTER = "idf.monitor.filter"; //$NON-NLS-1$
@@ -32,7 +33,8 @@ public class SerialSettings {
 	/**
 	 * Load information into the RemoteSettings object.
 	 */
-	public void load(ISettingsStore store) {
+	public void load(ISettingsStore store)
+	{
 		portName = store.get(PORT_NAME_ATTR, ""); //$NON-NLS-1$
 		filterText = store.get(MONITOR_FILTER, ""); //$NON-NLS-1$
 		selectedProject = store.get(SELECTED_PROJECT_ATTR, ""); //$NON-NLS-1$
@@ -41,44 +43,53 @@ public class SerialSettings {
 	/**
 	 * Extract information from the RemoteSettings object.
 	 */
-	public void save(ISettingsStore store) {
+	public void save(ISettingsStore store)
+	{
 		store.put(PORT_NAME_ATTR, portName);
 		store.put(MONITOR_FILTER, filterText);
 		store.put(SELECTED_PROJECT_ATTR, selectedProject);
 	}
 
-	public String getPortName() {
+	public String getPortName()
+	{
 		return portName;
 	}
 
-	public String getFilterText() {
+	public String getFilterText()
+	{
 		return filterText;
 	}
 
-	public String getProjectName() {
+	public String getProjectName()
+	{
 		return selectedProject;
 	}
 
-	public IProject getProject() {
+	public IProject getProject()
+	{
 
 		return !StringUtil.isEmpty(selectedProject)
 				? ResourcesPlugin.getWorkspace().getRoot().getProject(selectedProject)
 				: null;
 	}
 
-	public void setPortName(String portName) {
+	public void setPortName(String portName)
+	{
 		this.portName = portName;
 	}
 
-	public void setFilterText(String filterText) {
+	public void setFilterText(String filterText)
+	{
 		this.filterText = filterText;
 	}
 
-	public String getSummary() {
+	public String getSummary()
+	{
 		return portName;
 	}
 
-	public void setProject(String projectName) {
+	public void setProject(String projectName)
+	{
 		this.selectedProject = projectName;
 	}
 

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
@@ -85,7 +85,8 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 
 		settings.setPortName((String) data.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) data.get(SerialSettings.MONITOR_FILTER));
-		settings.setExtraOptions((boolean) data.get(SerialSettings.ENCRYPTION_ATTR));
+		Boolean encryptionValue = (Boolean) data.get(SerialSettings.ENCRYPTION_ATTR);
+		settings.setExtraOptions(encryptionValue != null ? encryptionValue : false);
 		String encoding = (String) data.get(ITerminalsConnectorConstants.PROP_ENCODING);
 		if (encoding != null)
 		{

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
@@ -67,7 +67,7 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 		data.put(SerialSettings.PORT_NAME_ATTR, settings.getPortName());
 		data.put(SerialSettings.MONITOR_FILTER, settings.getFilterText());
 		data.put(SerialSettings.SELECTED_PROJECT_ATTR, settings.getProjectName());
-		data.put(SerialSettings.ENCRYPTION_ATTR, settings.getExtraMonitorOptions());
+		data.put(SerialSettings.ENCRYPTION_ATTR, settings.getEncryptionOption());
 
 		if (getEncoding() != null)
 		{
@@ -86,7 +86,7 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 		settings.setPortName((String) data.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) data.get(SerialSettings.MONITOR_FILTER));
 		Boolean encryptionValue = (Boolean) data.get(SerialSettings.ENCRYPTION_ATTR);
-		settings.setExtraOptions(encryptionValue != null && encryptionValue);
+		settings.setEncryptionOption(encryptionValue != null && encryptionValue);
 		String encoding = (String) data.get(ITerminalsConnectorConstants.PROP_ENCODING);
 		if (encoding != null)
 		{

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
@@ -26,17 +26,20 @@ import org.eclipse.tm.terminal.view.ui.panels.AbstractExtendedConfigurationPanel
 import com.espressif.idf.terminal.connector.serial.connector.SerialConnector;
 import com.espressif.idf.terminal.connector.serial.connector.SerialSettings;
 
-public class SerialConfigPanel extends AbstractExtendedConfigurationPanel {
+public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
+{
 
 	private SerialSettings settings;
 	private SerialSettingsPage page;
 
-	public SerialConfigPanel(IConfigurationPanelContainer container) {
+	public SerialConfigPanel(IConfigurationPanelContainer container)
+	{
 		super(container);
 	}
 
 	@Override
-	public void setupPanel(Composite parent) {
+	public void setupPanel(Composite parent)
+	{
 		Composite panel = new Composite(parent, SWT.NONE);
 		panel.setLayout(new GridLayout());
 		GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
@@ -53,8 +56,10 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel {
 	}
 
 	@Override
-	public void extractData(Map<String, Object> data) {
-		if (data == null) {
+	public void extractData(Map<String, Object> data)
+	{
+		if (data == null)
+		{
 			return;
 		}
 
@@ -63,14 +68,17 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel {
 		data.put(SerialSettings.MONITOR_FILTER, settings.getFilterText());
 		data.put(SerialSettings.SELECTED_PROJECT_ATTR, settings.getProjectName());
 
-		if (getEncoding() != null) {
+		if (getEncoding() != null)
+		{
 			data.put(ITerminalsConnectorConstants.PROP_ENCODING, getEncoding());
 		}
 	}
 
 	@Override
-	public void setupData(Map<String, Object> data) {
-		if (data == null) {
+	public void setupData(Map<String, Object> data)
+	{
+		if (data == null)
+		{
 			return;
 		}
 
@@ -78,22 +86,27 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel {
 		settings.setFilterText((String) data.get(SerialSettings.MONITOR_FILTER));
 
 		String encoding = (String) data.get(ITerminalsConnectorConstants.PROP_ENCODING);
-		if (encoding != null) {
+		if (encoding != null)
+		{
 			setEncoding(encoding);
 		}
 	}
 
 	@Override
-	protected void saveSettingsForHost(boolean add) {
+	protected void saveSettingsForHost(boolean add)
+	{
 	}
 
 	@Override
-	protected void fillSettingsForHost(String host) {
+	protected void fillSettingsForHost(String host)
+	{
 	}
 
 	@Override
-	protected String getHostFromSettings() {
-		if (page != null) {
+	protected String getHostFromSettings()
+	{
+		if (page != null)
+		{
 			page.saveSettings();
 			return settings.getPortName();
 		}

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
@@ -86,7 +86,7 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 		settings.setPortName((String) data.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) data.get(SerialSettings.MONITOR_FILTER));
 		Boolean encryptionValue = (Boolean) data.get(SerialSettings.ENCRYPTION_ATTR);
-		settings.setExtraOptions(encryptionValue != null ? encryptionValue : false);
+		settings.setExtraOptions(encryptionValue != null && encryptionValue);
 		String encoding = (String) data.get(ITerminalsConnectorConstants.PROP_ENCODING);
 		if (encoding != null)
 		{

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialConfigPanel.java
@@ -67,6 +67,7 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 		data.put(SerialSettings.PORT_NAME_ATTR, settings.getPortName());
 		data.put(SerialSettings.MONITOR_FILTER, settings.getFilterText());
 		data.put(SerialSettings.SELECTED_PROJECT_ATTR, settings.getProjectName());
+		data.put(SerialSettings.ENCRYPTION_ATTR, settings.getExtraMonitorOptions());
 
 		if (getEncoding() != null)
 		{
@@ -84,7 +85,7 @@ public class SerialConfigPanel extends AbstractExtendedConfigurationPanel
 
 		settings.setPortName((String) data.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) data.get(SerialSettings.MONITOR_FILTER));
-
+		settings.setExtraOptions((boolean) data.get(SerialSettings.ENCRYPTION_ATTR));
 		String encoding = (String) data.get(ITerminalsConnectorConstants.PROP_ENCODING);
 		if (encoding != null)
 		{

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -60,6 +61,8 @@ public class SerialSettingsPage extends AbstractSettingsPage
 	private String lastUsedSerialPort;
 	private Text filterText;
 	private String filterConfig;
+	private Button encryptionCheckbox;
+	private boolean encryptionOption;
 
 	public SerialSettingsPage(SerialSettings settings, IConfigurationPanel panel)
 	{
@@ -71,6 +74,7 @@ public class SerialSettingsPage extends AbstractSettingsPage
 				this.getClass().getSimpleName());
 		dialogSettings.get(SerialSettings.PORT_NAME_ATTR);
 		filterConfig = dialogSettings.get(SerialSettings.MONITOR_FILTER);
+		encryptionOption = Boolean.parseBoolean(dialogSettings.get(SerialSettings.ENCRYPTION_ATTR));
 
 		lastUsedSerialPort = getLastUsedSerialPort();
 
@@ -152,6 +156,10 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		filterText = new Text(comp, SWT.SINGLE | SWT.BORDER);
 		filterText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
+		encryptionCheckbox = new Button(comp, SWT.CHECK);
+		encryptionCheckbox.setText("Enable Encryption");
+		encryptionCheckbox.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
 		loadSettings();
 	}
 
@@ -192,6 +200,8 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		{
 			this.filterText.setText(filterConfig);
 		}
+
+		this.encryptionCheckbox.setSelection(encryptionOption);
 	}
 
 	@Override
@@ -200,10 +210,12 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		settings.setPortName(portCombo.getText());
 		settings.setFilterText(filterText.getText().trim());
 		settings.setProject(projectCombo.getText());
+		settings.setExtraOptions(encryptionCheckbox.getSelection());
 
 		dialogSettings.put(SerialSettings.SELECTED_PROJECT_ATTR, projectCombo.getText());
 		dialogSettings.put(SerialSettings.PORT_NAME_ATTR, portCombo.getText());
 		dialogSettings.put(SerialSettings.MONITOR_FILTER, filterText.getText().trim());
+		dialogSettings.put(SerialSettings.ENCRYPTION_ATTR, encryptionCheckbox.getSelection());
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -210,7 +210,7 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		settings.setPortName(portCombo.getText());
 		settings.setFilterText(filterText.getText().trim());
 		settings.setProject(projectCombo.getText());
-		settings.setExtraOptions(encryptionCheckbox.getSelection());
+		settings.setEncryptionOption(encryptionCheckbox.getSelection());
 
 		dialogSettings.put(SerialSettings.SELECTED_PROJECT_ATTR, projectCombo.getText());
 		dialogSettings.put(SerialSettings.PORT_NAME_ATTR, portCombo.getText());

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -157,7 +157,7 @@ public class SerialSettingsPage extends AbstractSettingsPage
 		filterText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
 		encryptionCheckbox = new Button(comp, SWT.CHECK);
-		encryptionCheckbox.setText("Enable Encryption");
+		encryptionCheckbox.setText(Messages.SerialSettingsPage_EncryptionOption);
 		encryptionCheckbox.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
 		loadSettings();

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -158,7 +158,8 @@ public class SerialSettingsPage extends AbstractSettingsPage
 
 		encryptionCheckbox = new Button(comp, SWT.CHECK);
 		encryptionCheckbox.setText(Messages.SerialSettingsPage_EncryptionOption);
-		encryptionCheckbox.setToolTipText(Messages.SerialSettingsPage_EncryptionOptionTooltip);
+		encryptionCheckbox.setToolTipText(Messages.SerialSettingsPage_EncryptionOptionTooltip1 + System.lineSeparator()
+				+ Messages.SerialSettingsPage_EncryptionOptionTooltip2);
 		encryptionCheckbox.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
 		loadSettings();

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/controls/SerialSettingsPage.java
@@ -158,6 +158,7 @@ public class SerialSettingsPage extends AbstractSettingsPage
 
 		encryptionCheckbox = new Button(comp, SWT.CHECK);
 		encryptionCheckbox.setText(Messages.SerialSettingsPage_EncryptionOption);
+		encryptionCheckbox.setToolTipText(Messages.SerialSettingsPage_EncryptionOptionTooltip);
 		encryptionCheckbox.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
 		loadSettings();

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -63,7 +63,7 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate
 		settings.setFilterText((String) properties.get(SerialSettings.MONITOR_FILTER));
 		settings.setProject((String) properties.get(SerialSettings.SELECTED_PROJECT_ATTR));
 		Boolean encryptionOption = (Boolean) properties.get(SerialSettings.ENCRYPTION_ATTR);
-		settings.setExtraOptions(encryptionOption != null ? encryptionOption : false);
+		settings.setExtraOptions(encryptionOption != null && encryptionOption);
 		// Construct the terminal settings store
 		ISettingsStore store = new SettingsStore();
 		settings.save(store);

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -30,25 +30,30 @@ import org.eclipse.tm.terminal.view.ui.launcher.AbstractLauncherDelegate;
 import com.espressif.idf.terminal.connector.serial.connector.SerialSettings;
 import com.espressif.idf.terminal.connector.serial.controls.SerialConfigPanel;
 
-public class SerialLauncherDelegate extends AbstractLauncherDelegate {
+public class SerialLauncherDelegate extends AbstractLauncherDelegate
+{
 
 	@Override
-	public boolean needsUserConfiguration() {
+	public boolean needsUserConfiguration()
+	{
 		return true;
 	}
 
 	@Override
-	public IConfigurationPanel getPanel(IConfigurationPanelContainer container) {
+	public IConfigurationPanel getPanel(IConfigurationPanelContainer container)
+	{
 		return new SerialConfigPanel(container);
 	}
 
 	@Override
-	public ITerminalConnector createTerminalConnector(Map<String, Object> properties) {
+	public ITerminalConnector createTerminalConnector(Map<String, Object> properties)
+	{
 		Assert.isNotNull(properties);
 
 		// Check for the terminal connector id
 		String connectorId = (String) properties.get(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID);
-		if (connectorId == null) {
+		if (connectorId == null)
+		{
 			connectorId = "com.espressif.idf.terminal.connector.serial.SerialConnector"; //$NON-NLS-1$
 		}
 
@@ -63,7 +68,8 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 
 		// Construct the terminal connector instance
 		ITerminalConnector connector = TerminalConnectorExtension.makeTerminalConnector(connectorId);
-		if (connector != null) {
+		if (connector != null)
+		{
 			// Apply default settings
 			connector.setDefaultSettings();
 			// And load the real settings
@@ -74,7 +80,8 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 	}
 
 	@Override
-	public void execute(Map<String, Object> properties, Done done) {
+	public void execute(Map<String, Object> properties, Done done)
+	{
 		Assert.isNotNull(properties);
 
 		// Set the terminal tab title
@@ -83,14 +90,16 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate {
 
 		// Force a new terminal tab each time it is launched, if not set otherwise from outside
 		// TODO need a command shell service routing to get this
-		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW)) {
+		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_FORCE_NEW))
+		{
 			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.TRUE);
 		}
 
 		// Get the terminal service
 		ITerminalService terminal = TerminalServiceFactory.getService();
 		// If not available, we cannot fulfill this request
-		if (terminal != null) {
+		if (terminal != null)
+		{
 			terminal.openConsole(properties, done);
 		}
 	}

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -63,7 +63,7 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate
 		settings.setFilterText((String) properties.get(SerialSettings.MONITOR_FILTER));
 		settings.setProject((String) properties.get(SerialSettings.SELECTED_PROJECT_ATTR));
 		Boolean encryptionOption = (Boolean) properties.get(SerialSettings.ENCRYPTION_ATTR);
-		settings.setExtraOptions(encryptionOption != null && encryptionOption);
+		settings.setEncryptionOption(encryptionOption != null && encryptionOption);
 		// Construct the terminal settings store
 		ISettingsStore store = new SettingsStore();
 		settings.save(store);

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -62,6 +62,7 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate
 		settings.setPortName((String) properties.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) properties.get(SerialSettings.MONITOR_FILTER));
 		settings.setProject((String) properties.get(SerialSettings.SELECTED_PROJECT_ATTR));
+		settings.setExtraOptions((boolean) properties.get(SerialSettings.ENCRYPTION_ATTR));
 		// Construct the terminal settings store
 		ISettingsStore store = new SettingsStore();
 		settings.save(store);

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/launcher/SerialLauncherDelegate.java
@@ -62,7 +62,8 @@ public class SerialLauncherDelegate extends AbstractLauncherDelegate
 		settings.setPortName((String) properties.get(SerialSettings.PORT_NAME_ATTR));
 		settings.setFilterText((String) properties.get(SerialSettings.MONITOR_FILTER));
 		settings.setProject((String) properties.get(SerialSettings.SELECTED_PROJECT_ATTR));
-		settings.setExtraOptions((boolean) properties.get(SerialSettings.ENCRYPTION_ATTR));
+		Boolean encryptionOption = (Boolean) properties.get(SerialSettings.ENCRYPTION_ATTR);
+		settings.setExtraOptions(encryptionOption != null ? encryptionOption : false);
 		// Construct the terminal settings store
 		ISettingsStore store = new SettingsStore();
 		settings.save(store);

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
@@ -34,6 +34,7 @@ public class Messages extends NLS
 
 	// **** Declare externalized string id's down here *****
 
+	public static String SerialSettingsPage_EncryptionOption;
 	public static String SerialSettingsPage_FilterOptions;
 	public static String SerialSettingsPage_ProjectName;
 	public static String SerialTerminalSettingsPage_SerialPort;

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
@@ -35,6 +35,7 @@ public class Messages extends NLS
 	// **** Declare externalized string id's down here *****
 
 	public static String SerialSettingsPage_EncryptionOption;
+	public static String SerialSettingsPage_EncryptionOptionTooltip;
 	public static String SerialSettingsPage_FilterOptions;
 	public static String SerialSettingsPage_ProjectName;
 	public static String SerialTerminalSettingsPage_SerialPort;

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.java
@@ -35,7 +35,8 @@ public class Messages extends NLS
 	// **** Declare externalized string id's down here *****
 
 	public static String SerialSettingsPage_EncryptionOption;
-	public static String SerialSettingsPage_EncryptionOptionTooltip;
+	public static String SerialSettingsPage_EncryptionOptionTooltip1;
+	public static String SerialSettingsPage_EncryptionOptionTooltip2;
 	public static String SerialSettingsPage_FilterOptions;
 	public static String SerialSettingsPage_ProjectName;
 	public static String SerialTerminalSettingsPage_SerialPort;

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
@@ -11,7 +11,8 @@
 #     QNX Software Systems - Initial API and implementation
 ###############################################################################
 
-SerialSettingsPage_EncryptionOption=Enable Encryption
+SerialSettingsPage_EncryptionOption=Enable Flash Encryption
+SerialSettingsPage_EncryptionOptionTooltip=Enable Flash Encryption. Ctrl+F and Ctrl+A will trigger the encrypted-flash and encrypted-app-flash commands. To use encrypted flash, make sure flash encryption is enabled in sdkconfig.
 SerialSettingsPage_FilterOptions=Filter Options:
 SerialSettingsPage_ProjectName=Project name:
 SerialTerminalSettingsPage_SerialPort=Serial port:

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
@@ -12,7 +12,8 @@
 ###############################################################################
 
 SerialSettingsPage_EncryptionOption=Enable Flash Encryption
-SerialSettingsPage_EncryptionOptionTooltip=Enable Flash Encryption. Ctrl+F and Ctrl+A will trigger the encrypted-flash and encrypted-app-flash commands. To use encrypted flash, make sure flash encryption is enabled in sdkconfig.
+SerialSettingsPage_EncryptionOptionTooltip1=Enable Flash Encryption. Ctrl+F and Ctrl+A will trigger the encrypted-flash and encrypted-app-flash commands. 
+SerialSettingsPage_EncryptionOptionTooltip2=To use encrypted flash, make sure flash encryption is enabled in sdkconfig.
 SerialSettingsPage_FilterOptions=Filter Options:
 SerialSettingsPage_ProjectName=Project name:
 SerialTerminalSettingsPage_SerialPort=Serial port:

--- a/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
+++ b/bundles/com.espressif.idf.terminal.connector.serial/src/com/espressif/idf/terminal/connector/serial/nls/Messages.properties
@@ -11,6 +11,7 @@
 #     QNX Software Systems - Initial API and implementation
 ###############################################################################
 
+SerialSettingsPage_EncryptionOption=Enable Encryption
 SerialSettingsPage_FilterOptions=Filter Options:
 SerialSettingsPage_ProjectName=Project name:
 SerialTerminalSettingsPage_SerialPort=Serial port:


### PR DESCRIPTION
## Description

Added an encryption option to the serial monitor page:
<img width="356" height="299" alt="image" src="https://github.com/user-attachments/assets/793f4a62-d7a8-4732-af66-883456c2b0a7" />


Fixes # ([IEP-1509](https://jira.espressif.com:8443/browse/IEP-1509))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Start the serial monitor with or without the "Enable Encryption" option → press Ctrl+T Ctrl+A to run flash from the monitor → idf.py encrypted-app-flash or idf.py app-flash will be executed.

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Serial monitor

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Enable Flash Encryption" option in serial settings; when enabled, the serial monitor runs with encryption enabled.

* **Style**
  * Consistent brace and formatting style applied across serial/monitor components.

* **Documentation**
  * New UI label and two tooltips explaining the encryption option and prerequisites; preference is persisted with serial configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->