### PR TITLE
IEP-1608 Update test runtime environment to Java 21

### DIFF
--- a/tests/com.espressif.idf.core.test/.classpath
+++ b/tests/com.espressif.idf.core.test/.classpath
@@ -4,9 +4,10 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/tests/com.espressif.idf.core.test/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/com.espressif.idf.core.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=21

--- a/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.core.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: com.espressif.idf.core.test
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: Espressif Systems
 Automatic-Module-Name: com.espressif.idf.core.test
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: com.espressif.idf.core;bundle-version="1.0.1",
  junit-jupiter-api,
  org.eclipse.launchbar.core,

--- a/tests/com.espressif.idf.ui.test/.classpath
+++ b/tests/com.espressif.idf.ui.test/.classpath
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="resources"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="configs"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="src" path="resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="configs">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/com.espressif.idf.ui.test/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/com.espressif.idf.ui.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=21

--- a/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
+++ b/tests/com.espressif.idf.ui.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: com.espressif.idf.ui.test;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.tests
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,


### PR DESCRIPTION
## Description

Our project dependencies already require Java 21. To align with this, we need to update the test runtime environment accordingly.

Fixes # ([IEP-1608](https://jira.espressif.com:8443/browse/IEP-1608))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java runtime environment for test projects to Java SE 21.
  * Adjusted compiler settings to target Java version 21.
  * Marked relevant source folders as test sources in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->