### PR TITLE
IEP-1612 LSP: Use automatic driver detection for clangd

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -58,20 +58,6 @@ public class LspService
 				additionalOptions);
 	}
 
-	public void updateLspQueryDrivers()
-	{
-		String toolchainPath = IDFUtil.getToolchainExePathForActiveTarget();
-		String qualifier = configuration.qualifier();
-		if (toolchainPath == null)
-		{
-			Logger.log("Toolchain path not found. Skipping update of --query-driver for LSP"); //$NON-NLS-1$
-			return;
-		}
-		// By passing --query-driver argument to clangd helps to resolve the
-		// cross-compiler toolchain headers.
-		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.queryDriver.identifer(), toolchainPath);
-	}
-
 	public void updateClangdPath()
 	{
 		String clangdPath = IDFUtil.findCommandFromBuildEnvPath(ILSPConstants.CLANGD_EXECUTABLE);

--- a/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
+++ b/bundles/com.espressif.idf.lsp/src/com/espressif/idf/lsp/preferences/IDFClangdMetadataDefaults.java
@@ -1,6 +1,5 @@
 package com.espressif.idf.lsp.preferences;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +11,6 @@ import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 import org.osgi.service.component.annotations.Component;
 
 import com.espressif.idf.core.ILSPConstants;
-import com.espressif.idf.core.toolchain.ESPToolChainManager;
 import com.espressif.idf.core.util.IDFUtil;
 
 @Component(property = { "service.ranking:Integer=0" })
@@ -33,9 +31,8 @@ public class IDFClangdMetadataDefaults extends ConfigurationMetadataBase impleme
 
 		var clangdMetadataWithDefault = wrapWithCustomDefaultValue(clangdPath, ClangdMetadata.Predefined.clangdPath);
 
-		ESPToolChainManager toolChainManager = new ESPToolChainManager();
-		String defaultIdfQueryDriver = Optional.ofNullable(toolChainManager.findCompiler("esp32")) //$NON-NLS-1$
-				.map(File::getAbsolutePath).orElse(""); //$NON-NLS-1$
+		// Allow clangd to use the driver specified in compile_commands.json
+		String defaultIdfQueryDriver = "**"; //$NON-NLS-1$
 
 		var queryDriverMetadataWithDefault = wrapWithCustomDefaultValue(defaultIdfQueryDriver,
 				ClangdMetadata.Predefined.queryDriver);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -19,8 +19,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchMode;
@@ -38,7 +36,6 @@ import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LaunchUtil;
-import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.SDKConfigJsonReader;
 import com.espressif.idf.core.util.StringUtil;
 
@@ -96,9 +93,6 @@ public class LaunchBarListener implements ILaunchBarListener
 				if (!StringUtil.isEmpty(targetName) && (!targetChangeIgnored))
 				{
 					update(targetName);
-					LspService lspService = new LspService();
-					lspService.updateLspQueryDrivers();
-					lspService.restartLspServers();
 				}
 			}
 		});


### PR DESCRIPTION
## Description

Using --query-driver=** instead of changing query drivers dynamically for each target.
<img width="789" height="310" alt="image" src="https://github.com/user-attachments/assets/8ff91b40-7d76-4edd-a41a-8091ddc4b51b" />

Fixes # ([IEP-1612](https://jira.espressif.com:8443/browse/IEP-1612))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

- Build project, change targets - indexer not fails

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - The C/C++ language server no longer auto-configures its compiler driver from the toolchain; it now relies on compile_commands.json by default.
  - Automatic language server restarts on launch target changes were removed to reduce interruptions.

- Chores
  - Simplified preference defaults related to the language server.
  - Removed unused dependencies to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->