### PR TITLE
IEP-1615 Update windows runner's JDK to 21 version

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Maven
-      run: mvn clean verify -Djava.home="%JAVA_HOME%" "-Djarsigner.skip=true" "-DskipTests=false" "-DtestWorkspace=C:/actions-runner/_work/workspace"
+      run: mvn clean verify "-Djarsigner.skip=true" "-DskipTests=false" "-DtestWorkspace=C:/actions-runner/_work/workspace"
 
     - name: Publish Test Reports
       if: ${{ always() }}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -37,10 +37,10 @@ jobs:
       with:
         maven-version: 3.9.6
    
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Build with Maven

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Maven
-      run: mvn clean verify "-Djarsigner.skip=true" "-DskipTests=false" "-DtestWorkspace=C:/actions-runner/_work/workspace"
+      run: mvn clean verify -Djava.home="%JAVA_HOME%" "-Djarsigner.skip=true" "-DskipTests=false" "-DtestWorkspace=C:/actions-runner/_work/workspace"
 
     - name: Publish Test Reports
       if: ${{ always() }}


### PR DESCRIPTION
## Description

Updated windows runner's JDK to 21 version

Fixes # ([IEP-1615](https://jira.espressif.com:8443/browse/IEP-1615))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Windows CI Java runtime from 17 to 21 and updated the CI setup action.
  * Maven build configuration and invocation remain unchanged.
  * No changes to public APIs or user-facing behavior; build tooling updated only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->