### PR TITLE
WIP: SWTBot test case: Serial Monitor verification

### DIFF
--- a/tests/com.espressif.idf.ui.test/configs/default-test-linux.properties
+++ b/tests/com.espressif.idf.ui.test/configs/default-test-linux.properties
@@ -1,5 +1,6 @@
 # Default build wait before the timeout exception is thrown by the test
 default.project.build.wait=90800000
+default.project.flash.wait=60000
 
 # Default project copy delay before the timeout exception is thrown
 default.project.copy.wait=7000

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/common/utility/TestWidgetWaitUtility.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/common/utility/TestWidgetWaitUtility.java
@@ -6,7 +6,6 @@ package com.espressif.idf.ui.test.common.utility;
 
 import java.util.Arrays;
 import java.util.Optional;
-
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
@@ -130,6 +129,7 @@ public class TestWidgetWaitUtility
 				view.show();
 				view.setFocus();
 				String textString = view.bot().styledText().getText();
+				
 				return textString.toLowerCase().contains(text.toLowerCase());
 			}
 
@@ -140,6 +140,25 @@ public class TestWidgetWaitUtility
 			}
 		}, timeOut, 3000);
 	}
+	
+	public static void waitUntilTextContains(SWTWorkbenchBot bot, String text, SWTBotView terminalView, long timeOut) {
+	    terminalView.bot().waitUntil(new DefaultCondition() {
+	        @Override
+	        public boolean test() throws Exception {
+	            
+	            String terminalText = terminalView.bot().canvas().getText();
+	            
+	            return terminalText.toLowerCase().contains(text.toLowerCase());
+	        }
+
+	        @Override
+	        public String getFailureMessage() {
+	            return "Text not found in terminal!";
+	        }
+	    }, timeOut, 3000);  // Wait for up to 'timeOut' milliseconds
+	}
+
+
 
 	/**
 	 * Waits until the tree contains an item which contains the name in its text

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSerialMonitorTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSerialMonitorTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright 2025 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui.test.executable.cases.project;
+import java.io.IOException;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
+import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+import com.espressif.idf.ui.test.operations.EnvSetupOperations;
+import com.espressif.idf.ui.test.operations.ProjectTestOperations;
+
+/**
+ * Test class to test the Serial Monitor feature
+ * 
+ * @author Andrii Filippov
+ *
+ */
+@SuppressWarnings("restriction")
+@RunWith(SWTBotJunit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NewEspressifIDFProjectSerialMonitorTest
+{
+	@BeforeClass
+	public static void beforeTestClass() throws Exception
+	{
+		Fixture.loadEnv();
+	}
+
+	@After
+	public void afterEachTest()
+	{
+		try
+		{
+			Fixture.cleanTestEnv(); // Make sure test environment is always cleaned up
+		}
+		catch (Exception e)
+		{
+			System.err.println("Error during cleanup: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void givenNewProjectCreatedBuiltWhenFlashProjectThenCheckSerialMonitorOutput()
+			throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectSerialMonitorTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+		Fixture.whenFlashProject();
+		Fixture.whenSelectSerialPort();
+		Fixture.whenFlashProject();
+		Fixture.openSerialMonitorandVerify();
+	}
+
+	private static class Fixture
+	{
+		private static SWTWorkbenchBot bot;
+		private static String category;
+		private static String subCategory;
+		private static String projectName;
+
+		private static void loadEnv() throws Exception
+		{
+			bot = WorkBenchSWTBot.getBot();
+			EnvSetupOperations.setupEspressifEnv(bot);
+			bot.sleep(1000);
+		}
+
+		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)
+		{
+			Fixture.category = category;
+			Fixture.subCategory = subCategory;
+		}
+
+		private static void givenProjectNameIs(String projectName)
+		{
+			Fixture.projectName = projectName;
+		}
+
+		private static void whenNewProjectIsSelected() throws Exception
+		{
+			ProjectTestOperations.setupProject(projectName, category, subCategory, bot);
+		}
+
+		private static void whenProjectIsBuiltUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
+			ProjectTestOperations.waitForProjectBuild(bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+		}
+		
+		private static void whenFlashProject() throws IOException
+		{
+			ProjectTestOperations.launchCommandUsingContextMenu(projectName, bot, "Run Configurations...");
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Run Configurations", 10000);
+			SWTBotShell prefrencesShell = bot.shell("Run Configurations");
+			prefrencesShell.bot().tree().getTreeItem("ESP-IDF Application").select();
+			prefrencesShell.bot().tree().getTreeItem("ESP-IDF Application").expand();
+			prefrencesShell.bot().tree().getTreeItem("ESP-IDF Application").getNode("NewProjectSerialMonitorTest").select();
+			bot.sleep(1000);
+			bot.button("Run").click();
+		}
+		
+		private static void whenSelectSerialPort() throws IOException
+		{
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Serial port not found", 30000);
+			bot.button("OK").click();
+			TestWidgetWaitUtility.waitForDialogToAppear(bot, "New ESP Target", 20000);
+			bot.comboBoxWithLabel("Serial Port:").setSelection("COM5 USB Serial Port (COM5)");
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+			bot.button("Finish").click();
+		}
+		
+		private static void openSerialMonitorandVerify() throws IOException {
+			ProjectTestOperations.waitProjectFlash(bot);
+			ProjectTestOperations.waitForProjectMonitorAndDisconnect(bot);
+			ProjectTestOperations.findTextInSerialMonitorOutput(bot);
+		}
+
+		private static void cleanTestEnv()
+		{
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+			ProjectTestOperations.closeAllProjects(bot);
+			ProjectTestOperations.deleteAllProjects(bot);
+		}
+	}
+}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -52,6 +52,8 @@ public class ProjectTestOperations
 {
 
 	private static final String DEFAULT_PROJECT_BUILD_WAIT_PROPERTY = "default.project.build.wait";
+	
+	private static final String DEFAULT_FLASH_WAIT_PROPERTY = "default.project.build.wait";
 
 	private static final Logger logger = LoggerFactory.getLogger(ProjectTestOperations.class);
 
@@ -99,6 +101,25 @@ public class ProjectTestOperations
 				DefaultPropertyFetcher.getLongPropertyValue("Install New Component", 10000));
 	}
 
+	public static void waitForProjectMonitorAndDisconnect(SWTWorkbenchBot bot) throws IOException
+	{
+		bot.sleep(5000);
+		SWTBotView terminalView = viewTerminal("COM5", bot, 30000);
+		terminalView.toolbarPushButton("Disconnect Terminal Connection").click();
+		terminalView.show();
+		terminalView.setFocus();
+	}
+	
+	public static void findTextInSerialMonitorOutput(SWTWorkbenchBot bot) throws IOException
+	{
+		bot.sleep(5000);
+		SWTBotView terminalView = viewTerminal("<Closed> COM5", bot, 30000);
+		terminalView.show();
+		terminalView.setFocus();
+		TestWidgetWaitUtility.waitUntilTextContains(bot, "Hello", terminalView,
+				DefaultPropertyFetcher.getLongPropertyValue(DEFAULT_FLASH_WAIT_PROPERTY, 20000));
+	}
+
 	public static SWTBotView viewConsole(String consoleType, SWTWorkbenchBot bot)
 	{
 		SWTBotView view = bot.viewByPartName("Console");
@@ -109,6 +130,22 @@ public class ProjectTestOperations
 		b.menuItem(withRegex).click();
 		view.setFocus();
 		return view;
+	}
+	
+	public static SWTBotView viewTerminal(String terminalType, SWTWorkbenchBot bot, long timeOut)
+	{
+		SWTBotView view = bot.viewByPartName("Terminal");
+		view.show();
+		view.setFocus();
+		return view;
+	}
+
+	public static void waitProjectFlash(SWTWorkbenchBot bot) throws IOException
+	{
+		SWTBotView view = bot.viewByPartName("Console");
+		view.setFocus();
+		TestWidgetWaitUtility.waitUntilViewContains(bot, "Hard resetting via RTS pin...", view,
+				DefaultPropertyFetcher.getLongPropertyValue(DEFAULT_FLASH_WAIT_PROPERTY, 40000));
 	}
 
 	public static void createDebugConfiguration(String projectName, SWTWorkbenchBot bot)


### PR DESCRIPTION
## Description

SWTBot Serial Monitor test cases

Fixes # ([IEP-1624](https://jira.espressif.com:8443/browse/IEP-1624))

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS): 

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added end-to-end UI test for the Serial Monitor workflow on newly created projects (create, build, flash, verify output).
  - Enhanced test utilities to improve terminal/console handling, flash completion detection, and text-wait conditions.
  - Introduced a dedicated flash wait timeout in Linux test configurations to improve stability and timing.
  - Improved synchronization and reliability across UI-driven test flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->