### PR TITLE
WIP: SWTBot test case: Flash Process verification

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectFlashProcessTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectFlashProcessTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright 2021 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui.test.executable.cases.project;
+
+import java.io.IOException;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
+import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+import com.espressif.idf.ui.test.operations.EnvSetupOperations;
+import com.espressif.idf.ui.test.operations.ProjectTestOperations;
+
+/**
+ * Test class to test the Flash process
+ * 
+ * @author Andrii Filippov
+ *
+ */
+@SuppressWarnings("restriction")
+@RunWith(SWTBotJunit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+
+public class NewEspressifIDFProjectFlashProcessTest {
+	@BeforeClass
+	public static void beforeTestClass() throws Exception
+	{
+		Fixture.loadEnv();
+	}
+
+	@After
+	public void afterEachTest()
+	{
+		try
+		{
+			Fixture.cleanTestEnv(); // Make sure test environment is always cleaned up
+		}
+		catch (Exception e)
+		{
+			System.err.println("Error during cleanup: " + e.getMessage());
+		}
+	}
+
+
+	@Test
+	public void givenNewProjectCreatedBuiltWhenSelectSerialPortWhenFlashThenCheckFlashedSuccessfully()
+			throws Exception
+	{
+		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
+		Fixture.givenProjectNameIs("NewProjectFlashTest");
+		Fixture.whenNewProjectIsSelected();
+		Fixture.whenProjectIsBuiltUsingContextMenu();
+	}
+
+	private static class Fixture
+	{
+		private static SWTWorkbenchBot bot;
+		private static String category;
+		private static String subCategory;
+		private static String projectName;
+
+		private static void loadEnv() throws Exception
+		{
+			bot = WorkBenchSWTBot.getBot();
+			EnvSetupOperations.setupEspressifEnv(bot);
+			bot.sleep(1000);
+		}
+
+		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)
+		{
+			Fixture.category = category;
+			Fixture.subCategory = subCategory;
+		}
+
+		private static void givenProjectNameIs(String projectName)
+		{
+			Fixture.projectName = projectName;
+		}
+
+		private static void whenNewProjectIsSelected() throws Exception
+		{
+			ProjectTestOperations.setupProject(projectName, category, subCategory, bot);
+		}
+
+		private static void whenProjectIsBuiltUsingContextMenu() throws IOException
+		{
+			ProjectTestOperations.buildProjectUsingContextMenu(projectName, bot);
+			ProjectTestOperations.waitForProjectBuild(bot);
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+		}
+
+		private static void cleanTestEnv()
+		{
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+			ProjectTestOperations.closeAllProjects(bot);
+			ProjectTestOperations.deleteAllProjects(bot);
+		}
+	}
+}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -53,6 +53,8 @@ public class ProjectTestOperations
 
 	private static final String DEFAULT_PROJECT_BUILD_WAIT_PROPERTY = "default.project.build.wait";
 
+	private static final String DEFAULT_FLASH_WAIT_PROPERTY = "default.project.flash.wait";
+
 	private static final Logger logger = LoggerFactory.getLogger(ProjectTestOperations.class);
 
 	private static final int DELETE_PROJECT_TIMEOUT = 240000;
@@ -88,6 +90,14 @@ public class ProjectTestOperations
 		consoleView.setFocus();
 		TestWidgetWaitUtility.waitUntilViewContains(bot, "Build complete", consoleView,
 				DefaultPropertyFetcher.getLongPropertyValue(DEFAULT_PROJECT_BUILD_WAIT_PROPERTY, 300000));
+	}
+
+	public static void waitForProjectFlash(SWTWorkbenchBot bot) throws IOException
+	{
+		SWTBotView view = bot.viewByPartName("Console");
+		view.setFocus();
+		TestWidgetWaitUtility.waitUntilViewContains(bot, "Hard resetting via RTS pin...", view,
+				DefaultPropertyFetcher.getLongPropertyValue(DEFAULT_FLASH_WAIT_PROPERTY, 120000));
 	}
 
 	public static void waitForProjectNewComponentInstalled(SWTWorkbenchBot bot) throws IOException

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/selectors/LaunchBarTargetSelector.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/selectors/LaunchBarTargetSelector.java
@@ -68,10 +68,9 @@ public class LaunchBarTargetSelector extends AbstractSWTBotControl<CSelector>
 		notify(SWT.MouseUp, createMouseEvent(x, y, 1, SWT.BUTTON1, 1));
 	}
 
-	public void clickEdit()
+    public void clickEdit()
 	{
-		click();
-		bot().buttonWithId(LaunchBarWidgetIds.EDIT).click(); // $NON-NLS-1$
+		bot().canvasWithId(LaunchBarWidgetIds.EDIT).click(); // $NON-NLS-1$
 	}
 
 	private void clickOnInternalWidget(int x, int y, Widget internalWidget)


### PR DESCRIPTION
## Description

Flash process verification tests

Fixes # ([IEP-1626](https://jira.espressif.com:8443/browse/IEP-1626))

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added an end-to-end UI test validating the flash process for newly created Espressif IDF projects, including environment setup, build, serial port selection, and flashing verification.
  - Enhanced test utilities to wait for flash completion via console output with a configurable timeout for more reliable results.
  - Improved Launch Bar interaction in tests for greater stability by streamlining the edit action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->