### PR TITLE
IEP-1628: Remove conflicting System env variables for export command

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/ExportIDFTools.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -132,6 +133,8 @@ public class ExportIDFTools
 			addGitToEnvironment(environment, gitExePath);
 		}
 		
+		cleanUpSystemEnvironment(environment);
+		
 		final ProcessBuilderFactory processRunner = new ProcessBuilderFactory();
 		try
 		{
@@ -154,6 +157,26 @@ public class ExportIDFTools
 		{
 			Logger.log(IDFCorePlugin.getPlugin(), e);
 			return IDFCorePlugin.errorStatus(e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Remove the variables which can affect the idf_tools.py export command
+	 * These variables can come from system environment
+	 * @param environment
+	 */
+	private void cleanUpSystemEnvironment(Map<String, String> environment)
+	{
+		List<String> keysToRenmove = new LinkedList<>();
+		keysToRenmove.add(IDFEnvironmentVariables.IDF_PYTHON_ENV_PATH);
+		keysToRenmove.add(IDFEnvironmentVariables.IDF_PATH);
+		
+		for (String key : keysToRenmove)
+		{
+			if (environment.containsKey(key))
+			{
+				environment.remove(key);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Original bug report: https://github.com/espressif/idf-eclipse-plugin/issues/1303

Some conflicting variables from the system environment can cause issues with the export script so we need to remove those.

Fixes # ([IEP-1628](https://jira.espressif.com:8443/browse/IEP-1628))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Try to add IDF_PYTHON_ENV_PATH in your system env variables and run the IDE and try installing tools they should install without any problems


**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): Windows (POSIX based systems usually dont get this as long as they are not run from CLI adding the environment to the executable being run)

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Verified on Windows 
