### PR TITLE
added the version list for docs on master

### DIFF
--- a/docs/_static/docs_version.js
+++ b/docs/_static/docs_version.js
@@ -1,0 +1,9 @@
+var DOCUMENTATION_VERSIONS = {
+    DEFAULTS: { has_targets: false,
+                supported_targets: [ "esp32" ]
+              },
+    VERSIONS: [
+        { name: "latest" },
+        { name: "release-v4.0.0", pre_release: true }
+    ]
+};


### PR DESCRIPTION
Versions file for master added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced versioned documentation configuration to support a version selector.
  * Available versions: “latest” and “release-v4.0.0” (marked as pre-release).
  * Default hardware target set to ESP32; no multi-target content enabled yet.
  * Improves clarity on supported targets and upcoming release availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->