### PR TITLE
Runners: set FullScreen to runners main test shell

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
@@ -2,7 +2,6 @@ package com.espressif.idf.ui.test.operations;
 
 import static org.eclipse.swtbot.eclipse.finder.matchers.WidgetMatcherFactory.withPartName;
 
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
@@ -28,12 +27,16 @@ public class EnvSetupOperations
 			return;
 
 		Display.getDefault().syncExec(() -> {
-		    Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-		    // Maximize (Windows/Linux/macOS windowed)
-		    shell.setMaximized(true);
-		    try {
-		        shell.setFullScreen(true);
-		    } catch (Throwable ignore) {}
+			Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+			// Maximize (Windows/Linux/macOS windowed)
+			shell.setMaximized(true);
+			try
+			{
+				shell.setFullScreen(true);
+			}
+			catch (Throwable ignore)
+			{
+			}
 		});
 
 		for (SWTBotView view : bot.views(withPartName("Welcome")))

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
@@ -28,13 +28,13 @@ public class EnvSetupOperations
 			return;
 
 		Display.getDefault().syncExec(() -> {
-		      Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-		      // Maximize (Windows/Linux/macOS windowed)
-		      shell.setMaximized(true);
-		      if (Platform.OS_WIN32.equals(Platform.getOS()) || Platform.OS_LINUX.equals(Platform.getOS()) || Platform.OS_MACOSX.equals(Platform.getOS())) {
-		        try { shell.setFullScreen(true); } catch (Throwable ignore) {}
-		      }
-		    });
+		    Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		    // Maximize (Windows/Linux/macOS windowed)
+		    shell.setMaximized(true);
+		    try {
+		        shell.setFullScreen(true);
+		    } catch (Throwable ignore) {}
+		});
 
 		for (SWTBotView view : bot.views(withPartName("Welcome")))
 		{

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
@@ -2,9 +2,13 @@ package com.espressif.idf.ui.test.operations;
 
 import static org.eclipse.swtbot.eclipse.finder.matchers.WidgetMatcherFactory.withPartName;
 
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.eclipse.ui.PlatformUI;
 
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
@@ -22,6 +26,15 @@ public class EnvSetupOperations
 	{
 		if (SETUP)
 			return;
+
+		Display.getDefault().syncExec(() -> {
+		      Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		      // Maximize (Windows/Linux/macOS windowed)
+		      shell.setMaximized(true);
+		      if (Platform.OS_WIN32.equals(Platform.getOS()) || Platform.OS_LINUX.equals(Platform.getOS()) || Platform.OS_MACOSX.equals(Platform.getOS())) {
+		        try { shell.setFullScreen(true); } catch (Throwable ignore) {}
+		      }
+		    });
 
 		for (SWTBotView view : bot.views(withPartName("Welcome")))
 		{


### PR DESCRIPTION
## Description

Some SWT tests were constantly failing due to incorrect main shell size. 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## Checklist
- [X] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - UI automation now initializes the app window in a maximized/fullscreen state before running UI steps.
  - This initialization runs across Windows, macOS, and Linux to improve stability and consistency of UI tests.
  - Fullscreen attempts are non-blocking and failures are handled gracefully so tests continue.
  - Change is limited to test setup and has no impact on application behavior for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->