### PR TITLE
IEP-1639: Update query drivers after installing tools

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LspService.java
@@ -70,6 +70,12 @@ public class LspService
 		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.clangdPath.identifer(), clangdPath);
 	}
 
+	public void updateQueryDriver()
+	{
+		String qualifier = configuration.qualifier();
+		InstanceScope.INSTANCE.getNode(qualifier).put(ClangdMetadata.Predefined.queryDriver.identifer(), "**"); //$NON-NLS-1$
+	}
+
 	public void updateCompileCommandsDir(String buildDir)
 	{
 		String qualifier = configuration.qualifier();

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/ToolsActivationJob.java
@@ -96,7 +96,10 @@ public class ToolsActivationJob extends ToolsJob
 
 		toolSetConfigurationManager.export(idfToolSet);
 		console.println("Tools Activated");
-		new LspService().updateClangdPath();
+		LspService lspService = new LspService();
+		lspService.updateClangdPath();
+		lspService.updateQueryDriver();
+		console.println(Messages.ClangdPreferences_UpdatedMsg);
 		Preferences scopedPreferenceStore = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 		scopedPreferenceStore.putBoolean(INSTALL_TOOLS_FLAG, true);
 		try
@@ -173,7 +176,7 @@ public class ToolsActivationJob extends ToolsJob
 
 	private void setUpToolChainsAndTargets()
 	{
-		//Get current active idf
+		// Get current active idf
 		String idfPath = IDFUtil.getIDFPath();
 		List<String> targets = IDFTargetsReader.readTargetsFromEspIdf(idfPath).getAllTargetNames();
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/Messages.java
@@ -73,9 +73,10 @@ public class Messages extends NLS
 	public static String SbomCommandDialog_StatusCantBeNullErrorMsg;
 
 	public static String ToolsInstallationJobCompletedMessage;
-	
+
 	public static String BugReportHandler_CompletedBugReportMsg;
-	
+	public static String ClangdPreferences_UpdatedMsg;
+
 	static
 	{
 		// initialize resource bundle

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/messages.properties
@@ -68,3 +68,4 @@ ToolsInstallationJobCompletedMessage=Tool installation has been successfully com
 
 
 BugReportHandler_CompletedBugReportMsg=\n\n================================\nBug report completed. You can find the report at: %s \n=================================\n
+ClangdPreferences_UpdatedMsg=Clangd preferences updated: clangd path and query driver path have been set.


### PR DESCRIPTION
## Description

Updating the query driver's path after installing the tools

Fixes # ([IEP-1639](https://jira.espressif.com:8443/browse/IEP-1639))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

modify query driver's path -> update tools -> verify that query driver's path is default

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
