### PR TITLE
IEP-1644 Release 3.7.0 regression testing: Terminal does not work

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -900,13 +900,9 @@ public class IDFUtil
 		env.put(IDFCorePreferenceConstants.IDF_TOOLS_PATH, idfToolsPath);
 
 		// Merge Homebrew bin paths into PATH
-		String keyPath = "PATH"; //$NON-NLS-1$
+		// Windows may use "Path" while Unix uses "PATH"
+		String keyPath = env.containsKey("PATH") ? "PATH" : "Path"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		String existingPath = env.getOrDefault(keyPath, ""); //$NON-NLS-1$
-		if (existingPath.isEmpty())
-		{
-			keyPath = "Path"; //$NON-NLS-1$
-			existingPath = env.getOrDefault(keyPath, ""); //$NON-NLS-1$
-		}
 		StringBuilder newPath = new StringBuilder();
 
 		String[] brewPaths = { "/usr/local/bin", "/opt/homebrew/bin" }; //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
## Description

The issue was caused by retrieving the PATH key, which doesn’t exist on Windows, leading to a new conflicting variable. Fixed by fetching the existing key (PATH or Path) based on the platform.

Fixes # ([IEP-1644](https://jira.espressif.com:8443/browse/IEP-1644))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Install tools -> open terminal -> run idf.py commands

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PATH handling now respects system-specific casing (e.g., "PATH" vs "Path"), avoiding missed tool lookups.
  * Homebrew-related directories are more reliably merged into the environment PATH on macOS, improving command discovery.
  * Provides more consistent environment setup across platforms, reducing failures when launching or locating external tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->