### PR TITLE
fix: Dynamic discovery of of signtool.exe

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -182,13 +182,21 @@ jobs:
         run: |
           $exe = Get-ChildItem -Recurse extracted\Espressif-IDE\espressif-ide.exe | Select-Object -First 1
           $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits" -Recurse -Name "signtool.exe" | Select-Object -First 1
-          & "C:\Program Files (x86)\Windows Kits\$signtool" sign /f cert.pfx /p $env:PFX_PASS /tr http://timestamp.digicert.com /td sha256 /fd sha256 $exe.FullName
+          & "C:\Program Files (x86)\Windows Kits\$signtool" sign `
+            /f cert.pfx `
+            /p $env:PFX_PASS `
+            /tr http://timestamp.digicert.com `
+            /td sha256 `
+            /fd sha256 `
+            $exe.FullName
 
       - name: Verify Signature
         run: |
          $exe = Get-ChildItem -Recurse extracted\Espressif-IDE\espressif-ide.exe | Select-Object -First 1
          $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits" -Recurse -Name "signtool.exe" | Select-Object -First 1
-         & "C:\Program Files (x86)\Windows Kits\$signtool" verify /pa $exe.FullName
+         & "C:\Program Files (x86)\Windows Kits\$signtool" verify `
+         /pa `
+         $exe.FullName
 
       - name: Removing original ZIP from extracted folder
         run: |


### PR DESCRIPTION
## Description

Dynamic discovery of of signtool.exe

Fixes # ([IEP-1647](https://jira.espressif.com:8443/browse/IEP-1647))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows release signing by dynamically locating the signing tool during builds, enhancing reliability across different environments. No changes to application functionality or installer contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->