### PR TITLE
Feat/add codespell checks for local development and CI/CD

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = _build
+ignore-words-list = laf,OT,hart,EHEN,targetIn,dout,DOUT,oen,OEN,EMAC,emac,doubleClick,AfterAll
+write-changes = true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,22 @@ jobs:
     - name: Install pre-commit
       run: pip install pre-commit
 
+    - name: Install codespell
+      run: pip install codespell
+    
+    - name: Run pre-commit checks
+      run: |
+        BASE_SHA=${{ github.event.pull_request.base.sha }}
+        HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA | grep -E '\.(py|c|h|md|rst|yml)$' || true)
+        echo "Changed files:"
+        echo "$CHANGED_FILES" | tr ' ' '\n'
+        if [ -n "$CHANGED_FILES" ]; then
+          pre-commit run --files $CHANGED_FILES -v
+        else
+          echo "No matching files changed."
+        fi
+
     - name: Validate commit messages
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,11 @@
         hooks:
           - id: conventional-precommit-linter
             stages: [commit-msg]
+
+      - repo: https://github.com/codespell-project/codespell
+        rev: v2.4.1
+        hooks:
+          - id: codespell
+            stages: [pre-commit]
+            args: [--config=.codespellrc]
+            files: ^.*\.(py|c|h|md|rst|yml)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ Fix: Window -> Preferences -> Plug-in Development -> API Baselines -> Missing AP
 
 ![image](https://github.com/espressif/idf-eclipse-plugin/assets/69584713/0a879d4f-99e2-4d5a-98ca-a745a6683752)
 
-Fix: in "Project Explorer" -> com.espressif.idf.tests -> com.espressif.idf.ui.test -> META-INF -> doubleclick MANIFEST.MF -> Dependencies -> Add... -> Type "slf4j.api" -> Add&Save. 
+Fix: in "Project Explorer" -> com.espressif.idf.tests -> com.espressif.idf.ui.test -> META-INF -> double-click MANIFEST.MF -> Dependencies -> Add... -> Type "slf4j.api" -> Add&Save. 
 
-* After importing project Eclipse might prompt a wizard to install `Maven Plugin Connectors` to resolve the idf-eclipse-plugins maven errors, make sure you install all of them. But, depending on the version(Eclipse / Extentions), an error may occur:
+* After importing project Eclipse might prompt a wizard to install `Maven Plugin Connectors` to resolve the idf-eclipse-plugins maven errors, make sure you install all of them. But, depending on the version(Eclipse / Extensions), an error may occur:
 
 ![image](https://github.com/espressif/idf-eclipse-plugin/assets/69584713/048196c9-8ac6-4f10-8095-596ab2ef05f2)
 
-Fix: check the error and delete one of the extention (usually Tycho) - Help -> Install New Software -> Already Installed -> select "Tycho" -> Uninstall. 
+Fix: check the error and delete one of the extension (usually Tycho) - Help -> Install New Software -> Already Installed -> select "Tycho" -> Uninstall. 
 
 * Run as -> SWTBot Test -> may lead to error: 
 
@@ -50,7 +50,7 @@ Fix: Uninstall SWTBot -> Install latest snapshot(04.04.2023): http://download.ec
 * Make changes locally on a specific local branch
 * Test with Maven Tycho using `$ mvn clean verify -Djarsigner.skip=true`
 * Submit a Pull Request(PR)
-* It is also recommended that you add or update a Functional Test if you are adding or updating a functionality in plugin. More details about adding SWTBot Funtional test can be found in the README.md in test folder in the repo.
+* It is also recommended that you add or update a Functional Test if you are adding or updating a functionality in plugin. More details about adding SWTBot Functional test can be found in the README.md in test folder in the repo.
 
 ## Coding Standards and guidelines
 * Code formatter https://github.com/espressif/idf-eclipse-plugin/blob/master/resources/espressif_eclipse_formatter.xml

--- a/docs/en/openocddebugging.rst
+++ b/docs/en/openocddebugging.rst
@@ -57,7 +57,7 @@ Points 4 - 6 are shown below.
 .. image:: ../../media/OpenOCDDebug_6.png
 
 .. note::  
-    Update the OpenOCD Config options based on the esp board you've choosen. Please check this `here <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#id1>`_.
+    Update the OpenOCD Config options based on the esp board you've chosen. Please check this `here <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#id1>`_.
 
 Startup Tab
 -----------

--- a/docs_readme/Espressif-IDE-Windows-Installer.md
+++ b/docs_readme/Espressif-IDE-Windows-Installer.md
@@ -13,7 +13,7 @@ The installer deploys the following components:
 - Espressif-IDE
 - Amazon Corretto OpenJDK
 
-As Installer bundles, all the required components and tools including stable esp-idf so people behind corporate firewalls can use the whole solution out-of-box. This also configures all the required build environment variables and tool paths as you launch the IDE. All you could do is to get started with your project direclty without manually configuring anything. This will give you a big boost to your productivity!
+As Installer bundles, all the required components and tools including stable esp-idf so people behind corporate firewalls can use the whole solution out-of-box. This also configures all the required build environment variables and tool paths as you launch the IDE. All you could do is to get started with your project directly without manually configuring anything. This will give you a big boost to your productivity!
 
 More details about the standard setup of toolchain for Windows can be found in the [windows-setup](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html).
 

--- a/docs_readme/JTAG Flashing.md
+++ b/docs_readme/JTAG Flashing.md
@@ -28,4 +28,4 @@ After doing this, update the `OPENOCD_SCRIPT` environment variable in the eclips
 
 * Go to `Eclipse > Preferences > C/C++ > Build > Environment`
 * Edit `OPENOCD_SCRIPTS` variable by providing the right path to the `openocd/scripts` folder
-* As a result, the path to the OpenOCD scipts may look like this: `.../.espressif/tools/openocd-esp32/v0.10.0-esp32-20201202/openocd-esp32/share/openocd/scripts`
+* As a result, the path to the OpenOCD scripts may look like this: `.../.espressif/tools/openocd-esp32/v0.10.0-esp32-20201202/openocd-esp32/share/openocd/scripts`

--- a/docs_readme/MissingToolsManualPathUpdateGuide.md
+++ b/docs_readme/MissingToolsManualPathUpdateGuide.md
@@ -3,7 +3,7 @@
 Some tools are required as mandatory for the IDF and must be installed manually or must be selected when you are using the tools installation wizard on Linux and MAC and only selected recommended tools for windows these tools installation are mandatory and are selected with recommended tools.
 
 If you have these tools already present on your system you can skip the first step and continue from the second step.
-1. In case you want to manually install these tools to the system first please vist [this](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html) link to install them respective to your platform.
+1. In case you want to manually install these tools to the system first please visit [this](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html) link to install them respective to your platform.
 
 *Once you have installed the required tools you can move to the next step.
 The `PATH` in the IDE is independent of the system's `PATH` variable so we need to configure it.<br/>* 

--- a/docs_readme/OpenOCD Debugging.md
+++ b/docs_readme/OpenOCD Debugging.md
@@ -43,7 +43,7 @@ Let's take a look at some other options, that you need to check if they auto con
 Points 4 - 6 are shown below.
 ![](images/OpenOCDDebug_6.png)
 
-> **NOTE:**  Update the OpenOCD Config options based on the esp board you've choosen. Please check this here https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#id1
+> **NOTE:**  Update the OpenOCD Config options based on the esp board you've chosen. Please check this here https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#id1
 
 ## Startup Tab
 

--- a/tests/com.espressif.idf.ui.test/README.md
+++ b/tests/com.espressif.idf.ui.test/README.md
@@ -24,7 +24,7 @@ These files were added so they can be compared with the file being created by a 
 The configs directory contains the default-configs required for the tests they contain some configuration like build delay and some other UI awaiting delays can be added here as well, the idea is to keep only the default baseline configs here and if a functionality is taking some extensive UI operations that are not part of default operations, we can introduce another property file to contain those configurations. Currently this contains a setting for the build delay required and some absolute paths that are not relative to the repository or a central location we will try to update this once the CI for the automation is complete and the updated version of this document will contain isntructions on them. For now if your test needs to contain a property use this file and use the `**DefaultPropertyFetcher.java**` for fetching that property, for paths you can use the path on your own local env for the moment, also make sure to update these paths when you are trying to run the test.
 
 ### Test Classes
-Test cases themselves are to be placed in the `**com.espressif.idf.tests.exectuables.cases**` package. They can be further subdivided into their own packages in this package based upon the functionality they are testing for example at the time of writing this following packages are present that contain different test executable classes.
+Test cases themselves are to be placed in the `**com.espressif.idf.tests.executables.cases**` package. They can be further subdivided into their own packages in this package based upon the functionality they are testing for example at the time of writing this following packages are present that contain different test executable classes.
 ![](doc/images/test_executable_packages.png)
 
 
@@ -66,7 +66,7 @@ Make sure to click on `Validate Plug-ins` button to see if there are any issues 
 If there is no issue with your eclipse or SWTBot installation you should be able to run your test using the configuration.
 
 ### Using JUnit Runner Launch Config
-At times we need to debug the tests and for some issues in the SWTBot API you will get the exception of `WidgetNotFound` during debug which is because the SWTBot is dependent on UI focus a lot and during a test run if you are using the machine and the test instance of eclipse looses focus it gives that exception during debug we have to make sure that breakpoints are properly placed so that during UI interaction the test instance stays in focus. The SWTBot Runner config in eclipse for me prior to eclipse 2021-06 alway gave issues during debug so I had to use the JUnit Runner Launch Config.
+At times we need to debug the tests and for some issues in the SWTBot API you will get the exception of `WidgetNotFound` during debug which is because the SWTBot is dependent on UI focus a lot and during a test run if you are using the machine and the test instance of eclipse loses focus it gives that exception during debug we have to make sure that breakpoints are properly placed so that during UI interaction the test instance stays in focus. The SWTBot Runner config in eclipse for me prior to eclipse 2021-06 always gave issues during debug so I had to use the JUnit Runner Launch Config.
 
 You can generate this launch config simply by right clicking on your test class and from context menu select `Run As` in the sub menu select the option `JUnit Plug-in Test`.
 
@@ -77,5 +77,5 @@ This will start execution of your test but just like SWTBot there are a few thin
 Now from launch configurations in the Eclipse CDT Launchbar click on edit button next to the launch configuration name which is just added.
 ![](doc/images/launch_config_edit_junit.png)
 
-From the opened screen you can see some settings. First thing to make sure is that you use **JUnit4** from the `Test runner:` drop down. Alos make sure that `Run in UI thread` is unchecked.
+From the opened screen you can see some settings. First thing to make sure is that you use **JUnit4** from the `Test runner:` drop-down. Also make sure that `Run in UI thread` is unchecked.
 Now headover to the `Plug-ins` tab and follow the same configuration steps as you did for SWTBot Launch Config


### PR DESCRIPTION
This PR introduces the following changes:

- Adds codespell support to the idf-eclipse-plugin repo.
- Runs codespell across the entire repo and fixes existing typos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated spell-checking with codespell and integrated it into pre-commit checks to run on relevant files.

* **Documentation**
  * Corrected typos and clarified wording across contributing guides, installation and debugging docs, and test README; fixed a test README package path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->