### PR TITLE
Docs/translate marketplaceupdate.rst and buildproject.rst

### DIFF
--- a/docs/en/buildproject.rst
+++ b/docs/en/buildproject.rst
@@ -1,23 +1,23 @@
-Build the Project
-===============================
+Build Your Project
+==================
+
+:link_to_translation:`zh_CN:[中文]`
 
 .. |build_icon| image:: ../../media/icons/build.png
    :height: 16px
    :align: middle
 
+Once you have created a project and configured the ESP target and serial port, you can build the project by clicking on |build_icon| in the toolbar.
 
-Once you have created a project and configured the esp target and serial port, you can build the project by clicking on |build_icon| in the toolbar.
-
-However, below steps will guide you through the process of building the project if you are new to the IDE:
+However, the following steps will guide you through the process of building the project if you are new to the IDE:
 
 1. Select a project from the ``Project Explorer``.
-2. Select ``Run`` from the first dropdown, which is called `Launch Mode`.
-3. Select your application from the second dropdown, which is called `Launch Configuration` (Auto-detected).
-4. Select a target from the third dropdown, for example, ``esp32``, which is called `Launch Target`.
+2. Select ``Run`` from the first dropdown, which is called **Launch Mode**.
+3. Select your application from the second dropdown, which is called **Launch Configuration** (Auto-detected).
+4. Select a target from the third dropdown, which is called **Launch Target**. For example, ``esp32``.
 5. Now click on the ``Build`` button |build_icon| to start the build process.
 
-
- .. image:: ../../media/9_cmake_build.png
+.. image:: ../../media/9_cmake_build.png
 
 Custom Build Directory
 ----------------------
@@ -30,16 +30,17 @@ The IDE allows configuring a custom build directory for the project:
 4. Click on ``Ok`` and build the project.
 
 .. note::
-   This configuration changes where all the project build artifacts will be generated.
+
+    This configuration specifies the location where all the project build artifacts will be generated.  
 
 .. image:: ../../media/custombuilddir.png
    :alt: Custom Build Directory Configuration
 
 References
 ----------
+
 .. toctree::
     :maxdepth: 1
 
     Configure CDT Build Environment Variables <additionalfeatures/configureenvvariables>
     Add a Preview or Custom ESP-IDF Target <additionalfeatures/configuretoolchain>
-      

--- a/docs/en/marketplaceupdate.rst
+++ b/docs/en/marketplaceupdate.rst
@@ -1,37 +1,40 @@
 .. _marketplaceupdate:
 
 Update Site Installation Guide
-======================================
+==============================
 
-The Espressif-IDE Eclipse Plugin can be installed using the update site URL, Eclipse Marketplace, or a local archive. This guide provides instructions for each method.
+:link_to_translation:`zh_CN:[中文]`
+
+The Espressif-IDE Eclipse Plugin can be installed using the following three methods:
 
 - :ref:`installUpdateSiteURL`
 - :ref:`install_idf_eclipse_plugin_marketplace`
 - :ref:`install_idf_eclipse_plugin_local_archive`
-- :ref:`upgradePlugins`
-- :ref:`upgradeEspressifIdeDependencies`
-- :ref:`troubleshooting_missing_items`
 
 .. _installUpdateSiteURL:
 
-Installing IDF Plugin using update site URL
---------------------------------------------
+Installing IDF Plugin Using the Update Site URL
+-----------------------------------------------
+
 You can install the IDF Eclipse plugin into an existing Eclipse CDT/Espressif-IDE using the update site URL. First, add the release repository URL as follows:
 
-1. Go to ``Help`` > ``Install New Software``.
-2. Click `Add…`, and in the pop-up window:
-    * Enter `Name` as `Espressif IDF Plugin for Eclipse`.
-    * Enter `Location` of the repository
-        * For the stable release: `<https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_.
-    * Click `Add`.
-3. Select all from the list and proceed with the installation.
+1.  Go to ``Help`` > ``Install New Software``.
+2.  Click ``Add``, and in the pop-up window:
+
+    * Enter ``Espressif IDF Plugin for Eclipse`` as the ``Name``.
+    * Enter ``Location`` of the repository. (`Stable release <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_)
+    * Click ``Add``.
+
+3.  Select all items from the list and proceed with the installation.
 
 For adding beta and nightly builds, you can use the following update site URLs:
-   * For Beta version: `<https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/>`_.
-   * For Nightly build: `<https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/>`_.
+
+* `Beta version <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/>`_
+* `Nightly build <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/>`_
 
 .. note::
-    While the screenshots are captured on macOS, the installation instructions are applicable to Windows, Linux, and macOS.
+
+    Although the following screenshots are captured on macOS, the installation steps are the same for Windows and Linux.
 
 .. image:: ../../media/idf_update_site_install.png
 
@@ -43,100 +46,91 @@ Installing IDF Eclipse Plugin from Eclipse Marketplace
 
 To install the ESP-IDF Eclipse Plugin from the Eclipse Marketplace, follow these steps:
 
-1. Open Eclipse and go to `Help` > `Eclipse Marketplace...`.
-
+1. Open Eclipse and go to ``Help`` > ``Eclipse Marketplace...``.
 2. In the search box, enter **ESP-IDF Eclipse Plugin** to locate the plugin.
-
-3. Click **Install** and follow the on-screen instructions to complete the installation.
-
+3. Click ``Install`` and follow the on-screen instructions to complete the installation.
 4. After installation, restart Eclipse to activate the plugin.
 
 
 .. _install_idf_eclipse_plugin_local_archive:
 
 Installing IDF Eclipse Plugin from Local Archive
-------------------------------------------------------
+------------------------------------------------
 
 To install the ESP-IDF Eclipse Plugin from a local archive, follow these steps:
 
-1. Download the latest update site archive for the IDF Eclipse Plugin from [here](https://github.com/espressif/idf-eclipse-plugin/releases).
-
-2. In Eclipse, go to `Help` > `Install New Software`.
-
-3. Click the `Add…` button.
-
-4. In the **Add Repository** dialog, select **Archive** and choose the file `com.espressif.idf.update-vxxxxxxx.zip`.
-
-5. Click **Add**.
-
-6. Select **Espressif IDF** from the list and proceed with the installation.
-
-7. Restart Eclipse after the installation is complete.
-
+1. Download the latest update site archive for the IDF Eclipse Plugin from `here <https://github.com/espressif/idf-eclipse-plugin/releases>`_.
+2. In Eclipse, go to ``Help`` > ``Install New Software``.
+3. Click the ``Add`` button.
+4. In the ``Add Repository`` dialog, select ``Archive`` and choose the file ``com.espressif.idf.update-vxxxxxxx.zip``.
+5. Click ``Add``.
+6. Select ``Espressif IDF`` from the list and continue with the installation.
+7. After the installation is complete, restart Eclipse.
 
 .. _upgradePlugins:
 
-How do I upgrade my existing IDF Eclipse Plugin?
-------------------------------------------------------
+How to Upgrade Existing IDF Eclipse Plugin
+------------------------------------------
+
 If you are installing the IDF Eclipse Plugin for the first time, follow these steps to add the repository for the new release:
 
-1. Go to `Window` > `Preferences` > `Install/Update` > `Available Software Sites`.
-2. Click `Add`.
-3. Enter the URL of the new repository: `https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/`.
-4. Click `Ok`.
+1. Go to ``Window`` > ``Preferences`` > ``Install/Update`` > ``Available Software Sites``.
+2. Click ``Add``.
+3. Enter the `URL <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_ of the new repository: .
+4. Click ``Ok``.
 
 If you have already installed the IDF Eclipse Plugin using the update site URL, you can upgrade to the latest version with the following steps:
 
-1. Go to `Help` > `Check for Updates`.
-2. If updates are found, select `Espressif IDF Plugins for Eclipse` and deselect all other items.
-3. Click `Next` to proceed with the installation.
+1. Go to ``Help`` > ``Check for Updates``.
+2. If updates are found, select ``Espressif IDF Plugins for Eclipse`` and deselect all other items.
+3. Click ``Next`` to proceed with the installation.
 
 .. image:: ../../media/Update_plugins.png
-	
+
 
 .. _upgradeEspressifIdeDependencies:
-	
+
 Upgrading from Espressif-IDE 3.3.0 to 3.4.0
-------------------------------------------------------
+-------------------------------------------
+
 If the next version of the plugin requires updated dependencies (e.g., the minimum CDT version has changed from 11.6 to 12), make sure these dependencies are updated during installation from the update site.
 
 .. image:: ../../media/Update_dependencies.png
-	
+
 If the required dependencies are not updated, the installer will display the following error:
-`The installation cannot be completed as requested.`
+
+``The installation cannot be completed as requested.``
 
 To resolve this:
 
-1. Click **Show original error and build my own solution**.
-2. Then select both:
+1.  Click ``Show original error and build my own solution``.
+2.  Then select both:
 
-- **Update items already installed**
-- **Remove items already installed**
+    - ``Update items already installed``
+    - ``Remove items already installed``
 
 .. image:: ../../media/Resolve_update_error.png
 
-This will allow the installer to update or replace any conflicting components and continue the installation successfully.
-
-
+This ensures that the installer can update or replace any conflicting components, allowing the installation to complete successfully.
 
 .. _troubleshooting_missing_items:
 
-Troubleshooting: "Cannot complete the install because one or more required items could not be found"
------------------------------------------------------------------------------------------------------
+Troubleshooting
+---------------
 
+If you encounter the error ``Cannot complete the install because one or more required items could not be found.`` during installation, it usually means that the Eclipse Platform update site is not enabled.
 
-This usually happens when the Eclipse Platform update site is not enabled.  
 To resolve this issue:
 
-1. Go to ``Help`` > ``Install New Software``.  
-2. Click **Manage**.  
-3. Make sure the option for the **Eclipse Platform - Latest Release Update Site** is enabled.  
+1.  Go to ``Help`` > ``Install New Software``.  
+2.  Click ``Manage``.  
+3.  Make sure the option for the ``Eclipse Platform - Latest Release Update Site`` is enabled.  
 
-.. image:: ../../media/Resolve_update_error_2.png
+    .. image:: ../../media/Resolve_update_error_2.png
 
-4. Apply the changes and close the dialog.  
-5. Then go to ``Help`` > ``Check for Updates`` and proceed with updating the IDE and its dependencies.  
+4.  Apply the changes and close the dialog.  
+5.  Then go to ``Help`` > ``Check for Updates`` and proceed with updating the IDE and its dependencies.  
 
 .. note::
-    Enabling the Eclipse Platform update site ensures that all required dependencies can be resolved during installation or upgrade.
 
+    Enabling the Eclipse Platform update site ensures that all required dependencies are properly resolved during installation or upgrade.

--- a/docs/zh_CN/buildproject.rst
+++ b/docs/zh_CN/buildproject.rst
@@ -1,1 +1,46 @@
-.. include:: ../en/buildproject.rst
+构建项目
+========
+
+:link_to_translation:`en:[English]`
+
+.. |build_icon| image:: ../../media/icons/build.png
+   :height: 16px
+   :align: middle
+
+创建项目并配置好乐鑫目标设备及串口后，可在工具栏中点击 |build_icon| 图标来构建项目。
+
+如果你是初次使用 IDE，请参照下列步骤，完成项目的构建流程：
+
+1. 在 ``Project Explorer`` 中选择一个项目。
+2. 在第一个下拉菜单 **启动模式** 中选择 ``Run``。。
+3. 在第二个下拉菜单 **启动配置** 中选择你的应用程序（该程序会被自动检测）。
+4. 在第三个下拉菜单 **启动目标** 中选择目标芯片，如 ``esp32``。
+5. 点击 ``Build`` 按钮 |build_icon|，开始构建流程。
+
+.. image:: ../../media/9_cmake_build.png
+
+自定义构建目录
+--------------
+
+IDE 允许为项目配置自定义构建目录：
+
+1. 选择一个项目，在顶部工具栏中点击启动配置的 ``Edit`` 按钮，打开 ``Edit Configuration`` 窗口。
+2. 前往 ``Build Settings`` 选项卡。
+3. 在 ``Build folder location`` 部分填写自定义的构建目录。该自定义目录路径可以位于项目内，也可以位于文件系统中的任意位置。
+4. 点击 ``Ok`` 并构建项目。
+
+.. note::
+
+    此配置指定了项目生成的所有构建产物的存放位置。
+
+.. image:: ../../media/custombuilddir.png
+   :alt: 自定义构建目录配置
+
+参考文档
+--------
+
+.. toctree::
+    :maxdepth: 1
+
+    配置 CDT 构建环境变量 <additionalfeatures/configureenvvariables>
+    添加预览或自定义 ESP-IDF 目标 <additionalfeatures/configuretoolchain>

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -1,1 +1,136 @@
-.. include:: ../en/marketplaceupdate.rst
+.. _marketplaceupdate:
+
+更新站点安装指南
+================
+
+:link_to_translation:`en:[English]`
+
+可通过以下三种方式安装 Espressif-IDE Eclipse 插件：
+
+- :ref:`installUpdateSiteURL`
+- :ref:`install_idf_eclipse_plugin_marketplace`
+- :ref:`install_idf_eclipse_plugin_local_archive`
+
+.. _installUpdateSiteURL:
+
+使用更新站点 URL 安装 IDF 插件
+------------------------------
+
+可以使用更新站点 URL 将 IDF Eclipse 插件安装到现有的 Eclipse CDT 或 Espressif-IDE 中。首先，按如下方式添加发布仓库的 URL：
+
+1.  进入 ``Help`` > ``Install New Software``。
+2.  点击 ``Add``，在弹出窗口中：
+
+    * 在 ``Name`` 一栏填写 ``Espressif IDF Plugin for Eclipse``。
+    * 在 ``Location`` 一栏，填写插件更新站点的 URL.（`稳定版 <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_）
+    * 点击 ``Add``。
+
+3.  全选列表中的组件并继续安装。
+
+若要添加测试版和每日构建版插件，可以使用以下的更新站点 URL：
+
+* `测试版本 <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/beta/>`_
+* `每日构建版本 (Nightly Build) <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/>`_
+
+.. note::
+
+    尽管本文中的截图来自 macOS 系统中的操作，但安装说明同样适用于 Windows 和 Linux。
+
+.. image:: ../../media/idf_update_site_install.png
+
+
+.. _install_idf_eclipse_plugin_marketplace:
+
+通过 Eclipse 市场安装 IDF Eclipse 插件
+--------------------------------------
+
+要通过 Eclipse 市场安装 ESP-IDF Eclipse 插件，请按以下步骤操作：
+
+1. 打开 Eclipse，前往 ``Help`` > ``Eclipse Marketplace...``。
+2. 在搜索框中输入 **ESP‑IDF Eclipse Plugin** 找到该插件。
+3. 点击 ``Install``，按照屏幕上的提示完成安装。
+4. 安装完成后，重启 Eclipse 以启用插件。
+
+
+.. _install_idf_eclipse_plugin_local_archive:
+
+通过本地压缩包安装 IDF Eclipse 插件
+-----------------------------------
+
+要通过本地压缩包安装 ESP-IDF Eclipse 插件，请按以下步骤操作：
+
+1. 点击 `此处 <https://github.com/espressif/idf-eclipse-plugin/releases>`_ 下载 IDF Eclipse 插件的最新更新站点压缩包。
+2. 在 Eclipse 中，进入 ``Help`` > ``Install New Software``。
+3. 点击 ``Add`` 按钮。
+4. 在 ``Add Repository`` 对话框中，选择 ``Archive`` 并选择文件 ``com.espressif.idf.update-vxxxxxxx.zip``。
+5. 点击 ``Add``。
+6. 在列表中选择 ``Espressif IDF``，然后继续安装。
+7. 完成安装后重启 Eclipse。
+
+.. _upgradePlugins:
+
+如何升级现有的 IDF Eclipse 插件
+-------------------------------
+
+如果你是首次安装 IDF Eclipse 插件，请按以下步骤添加新版本的仓库：
+
+1. 前往 ``Window`` > ``Preferences`` > ``Install/Update`` > ``Available Software Sites``。
+2. 点击 ``Add``。
+3. 输入新仓库的 `URL <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_。
+4. 点击 ``Ok``。
+
+如果已经通过更新站点 URL 安装了 IDF Eclipse 插件，可按以下步骤升级到最新版本：
+
+1. 进入 ``Help`` > ``Check for Updates``。
+2. 如果发现有可用更新版本，选择 ``Espressif IDF Plugins for Eclipse``，并取消选择所有其他项目。
+3. 点击 ``Next`` 继续安装。
+
+.. image:: ../../media/Update_plugins.png
+
+
+.. _upgradeEspressifIdeDependencies:
+
+从 Espressif-IDE 3.3.0 升级到 3.4.0
+-----------------------------------
+
+如果插件的新版本需要更新依赖项（例如最低 CDT 版本从 11.6 更新到 12），请在通过更新站点安装插件时一并更新这些依赖项。
+
+.. image:: ../../media/Update_dependencies.png
+
+如果所需依赖项未更新，安装程序会显示如下错误：
+
+``The installation cannot be completed as requested.``
+
+解决方法：
+
+1.  点击 ``Show original error and build my own solution``。
+2.  然后勾选以下两项：
+
+    - ``Update items already installed``
+    - ``Remove items already installed``
+
+.. image:: ../../media/Resolve_update_error.png
+
+这样可以确保安装程序更新或替换任何存在冲突的组件，从而顺利完成安装。
+
+.. _troubleshooting_missing_items:
+
+故障排查
+--------
+
+如果在安装过程中遇到错误提示 ``Cannot complete the install because one or more required items could not be found.``，通常是因为未启用 Eclipse 更新站点。
+
+解决方法：
+
+1.  进入 ``Help`` > ``Install New Software``。  
+2.  点击 ``Manage``。  
+3.  确保已启用 ``Eclipse Platform - Latest Release Update Site`` 选项。
+
+    .. image:: ../../media/Resolve_update_error_2.png
+
+4.  应用更改并关闭对话框。
+5.  前往 ``Help`` > ``Check for Updates``，继续更新 IDE 及其依赖项。  
+
+.. note::
+
+    启用 Eclipse Platform 更新站点可确保在安装或升级过程中解析所有必要的依赖项。


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions for marketplaceupdate.rst and buildproject.rst in the docs/en folder based on [Espressif Style Guide](https://docs-internal.espressif.cn/projects/esp-mos/en/latest/index.html).
- Provides CN translation for above two docs.
- TODO: Closes [DOC-12873](https://jira.espressif.com:8443/browse/DOC-12873) once merged