### PR TITLE
docs: Provide CN translation for three docs

### DIFF
--- a/docs/en/additionalfeatures/configureenvvariables.rst
+++ b/docs/en/additionalfeatures/configureenvvariables.rst
@@ -1,7 +1,9 @@
 Configuring Environment Variables
 ==================================
 
-All the required environment variables are automatically configured by the IDE during the ESP-IDF and Tools installation process (``Espressif > ESP-IDF Manager > Add ESP-IDF``). You can verify these variables in the Preferences page under ``C/C++ > Build > Environment``.
+:link_to_translation:`zh_CN:[中文]`
+
+Once you install ESP-IDF through `EIM <https://docs.espressif.com/projects/idf-im-ui/en/latest/>`_, all required environment variables are automatically configured by the IDE when you activate the ESP-IDF in ``Espressif`` > ``ESP-IDF Manager``. You can verify these variables on the ``Preferences`` page under ``C/C++`` > ``Build`` > ``Environment``.
 
 .. image:: ../../../media/2_environment_pref.png
    :alt: Environment Preferences

--- a/docs/en/additionalfeatures/lspeditor.rst
+++ b/docs/en/additionalfeatures/lspeditor.rst
@@ -1,7 +1,9 @@
 LSP C/C++ Editor
-=================
+================
 
-Starting with Espressif IDE 3.0.0, the LSP Editor is the default code editor, which differs in several ways from the previous default editor. Below are the most notable differences:
+:link_to_translation:`zh_CN:[中文]`
+
+Starting with Espressif IDE 3.0.0, the LSP Editor becomes the default code editor and behaves differently from the previous default editor. The most notable differences are listed below.
 
 Formatting
 ----------
@@ -25,18 +27,18 @@ You can also disable formatting for specific folders by using the ``DisableForma
 
     project
      ├── managed_components
-     │       └── .clang-format  
+     │       └── .clang-format
      ├── main
      └── .clang-format
 
 Add the ``DisableFormat: true`` option to the ``.clang-format`` file in the ``managed_components`` folder. This flag tells ClangFormat to completely ignore this specific ``.clang-format`` file and its formatting rules within the ``managed_components`` directory.
 
-For more information about available style options, refer to `the Clang-Format Style Options guide <https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options>`_.
+For more information about available style options, refer to `Configurable Format Style Options <https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options>`_.
 
 Search
 ------
 
-The search text option in the right-click menu is currently unavailable in the LSP-based C/C++ Editor. However, you can use the toolbar menu ``Search`` > ``Text`` > ``Workspace`` as a workaround.
+The ``Search Text`` option in the right-click menu is currently unavailable in the LSP-based C/C++ Editor. However, as a workaround, you can use ``Search`` > ``Text`` > ``Workspace`` from the toolbar menu.
 
 Inlay Hints
 -----------
@@ -59,28 +61,29 @@ Searching ESP-IDF Components
 
 To browse ESP-IDF components, follow these steps:
 
-- Create a new project.
-- Add the ESP-IDF components folder as a virtual folder to the newly created project.
-- Press **Ctrl + Shift + T** or **Ctrl + Shift + R**.
-- You should now be able to browse the ESP-IDF component files.
-- To search for a specific function or keyword, use the Search menu in the toolbar.
+1. Create a new project.
+2. Add the ESP-IDF components folder as a virtual folder to the newly created project.
+3. Press **Ctrl + Shift + T** or **Ctrl + Shift + R**.
+4. You should now be able to browse the ESP-IDF component files.
+5. To search for a specific function or keyword, use the ``Search`` menu in the toolbar.
 
 Creating a Virtual Folder
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Navigate to ``New`` > ``Folder``.
-- Click on ``Advanced``.
-- Select ``Link to alternate Location (Linked Folder)``.
-- Click ``Browse`` and select the ``ESP-IDF components`` folder.
+1. Navigate to ``New`` > ``Folder``.
+2. Click on ``Advanced``.
+3. Select ``Link to alternate Location (Linked Folder)``.
+4. Click ``Browse`` and select the ``ESP-IDF components`` folder.
 
-It is recommended to always create a new project instead of modifying your current one to avoid unnecessary Git files and error markers created by the indexer for the components folder. Since both projects will be in the same workspace, you should be able to search anywhere within your workspace.
+It is recommended to always create a new project instead of modifying your current one to avoid unnecessary Git files and error markers created by the indexer for the ``components`` folder. Since both projects reside in the same workspace, you will still be able to search across your entire workspace.
 
 If you have any issues with the Clangd Configuration with the LSP Editor, please refer to the :ref:`Clangd Configuration <clangd_cdt_support>` guide.
 
 References
 ----------
+
 .. toctree::
     :maxdepth: 1
 
     Clangd CDT Support and Configuration <clangd_cdt_support>
-    Configuring Clang Toolchain<clangtoolchain>
+    Clang Toolchain Configuration <clangtoolchain>

--- a/docs/en/additionalfeatures/writebinarytoflash.rst
+++ b/docs/en/additionalfeatures/writebinarytoflash.rst
@@ -1,14 +1,16 @@
 Write Binary to Flash
 ======================
 
-Binary data can be written to the ESP’s flash chip via the *ESP-IDF > Write Binary Data to Flash* command. To access this command, right-click on the project in the Project Explorer:
+:link_to_translation:`zh_CN:[中文]`
+
+Binary data can be written to the ESP's flash chip via the ``ESP-IDF: Write Binary Data to Flash`` command. To access this command, right-click on the project in the Project Explorer:
 
 .. image:: https://github.com/espressif/idf-eclipse-plugin/assets/24419842/186c8498-d779-4771-af53-e5bf09e29502
    :alt: Write Binary Data to Flash command
 
-After clicking this command, the *Write Binary Data to Flash* dialog box will open. Editable default values are provided for the binary path and offset. You can check the correct offset by viewing the partition table via *ESP-IDF > Partition Table Editor* or by manually opening the `partitions.csv` file.
+After clicking this command, the ``Write Binary Data to Flash`` dialog box will open. Editable default values are provided for the binary path and offset. You can check the correct offset by viewing the partition table via ``ESP-IDF: Partition Table Editor`` or by manually opening the ``partitions.csv`` file.
 
 .. image:: https://github.com/espressif/idf-eclipse-plugin/assets/24419842/46e24e89-a1ed-4169-8c92-1ba0b0089ea7
    :alt: Write Binary Data to Flash dialog
 
-Clicking the *Flash* button will execute the flash command, and the result will be displayed within this dialog.
+Clicking the ``Flash`` button will execute the flash command, and the result will be displayed within this dialog.

--- a/docs/zh_CN/additionalfeatures/configureenvvariables.rst
+++ b/docs/zh_CN/additionalfeatures/configureenvvariables.rst
@@ -1,1 +1,9 @@
-.. include:: ../../en/additionalfeatures/configureenvvariables.rst
+配置环境变量
+============
+
+:link_to_translation:`en:[English]`
+
+通过 `EIM <https://docs.espressif.com/projects/idf-im-ui/en/latest/>`_ 安装 ESP-IDF 后，在 ``Espressif`` > ``ESP-IDF Manager`` 中激活 ESP-IDF 时，IDE 会自动配置所有必需的环境变量。你可以在 ``Preferences`` 页面前往 ``C/C++`` > ``Build`` > ``Environment``，查看这些变量。
+
+.. image:: ../../../media/2_environment_pref.png
+   :alt: 环境首选项

--- a/docs/zh_CN/additionalfeatures/lspeditor.rst
+++ b/docs/zh_CN/additionalfeatures/lspeditor.rst
@@ -1,1 +1,89 @@
-.. include:: ../../en/additionalfeatures/lspeditor.rst
+LSP C/C++ 编辑器
+================
+
+:link_to_translation:`en:[English]`
+
+从 Espressif IDE 3.0.0 开始，LSP 编辑器成为默认的代码编辑器，其行为与之前的默认编辑器存在显著差异，主要区别如下所示。
+
+格式化
+------
+
+如需自定义格式化，请打开项目中的 ``.clang-format`` 文件。默认情况下，文件包含以下内容：
+
+.. code-block:: none
+
+    BasedOnStyle: LLVM
+    UseTab: Always
+    IndentWidth: 4
+    TabWidth: 4
+    PackConstructorInitializers: NextLineOnly
+    BreakConstructorInitializers: AfterColon
+    IndentAccessModifiers: false
+    AccessModifierOffset: -4
+
+也可以使用 ``DisableFormat: true`` 选项对特定文件夹禁用格式化。例如，如果希望在如下结构的项目中为 ``managed_components`` 文件夹禁用格式化：
+
+.. code-block:: none
+
+    project
+     ├── managed_components
+     │       └── .clang-format
+     ├── main
+     └── .clang-format
+
+在 ``managed_components`` 文件夹中的 ``.clang-format`` 文件中添加 ``DisableFormat: true`` 选项。该选项会指示 ClangFormat 完全忽略此 ``.clang-format`` 文件及其在 ``managed_components`` 目录下定义的所有格式化规则。
+
+有关可用风格选项的更多信息，请参阅 `可配置的格式化风格选项 <https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options>`_。
+
+搜索
+----
+
+在基于 LSP 的 C/C++ 编辑器中，右键菜单里的 ``Search Text`` 选项目前不可用。不过，你可以暂时通过工具栏菜单中的 ``Search`` > ``Text`` > ``Workspace`` 来实现相同的功能。
+
+内联提示
+--------
+
+LSP 编辑器默认启用内联提示。如果你不想使用此功能，可通过编辑 ``.clangd`` 文件将其禁用：
+
+.. code-block:: none
+
+    CompileFlags:
+      CompilationDatabase: build
+      Remove: 
+        - -m*
+        - -f*
+
+    InlayHints:
+      Enabled: No
+
+搜索 ESP-IDF 组件
+-----------------
+
+如需浏览 ESP-IDF 组件，请执行以下步骤：
+
+1. 创建一个新项目。
+2. 将 ESP-IDF 组件文件夹作为虚拟文件夹添加到新建项目中。
+3. 使用快捷键 **Ctrl + Shift + T** 或 **Ctrl + Shift + R**。
+4. 现在可以浏览 ESP-IDF 组件文件。
+5. 若要搜索特定函数或关键字，请使用工具栏中的 ``Search`` 菜单。
+
+创建虚拟文件夹
+~~~~~~~~~~~~~~
+
+1. 前往 ``New`` > ``Folder``。
+2. 点击 ``Advanced``。
+3. 选择 ``Link to alternate Location (Linked Folder)``。
+4. 点击 ``Browse`` 并选择 ``ESP-IDF components`` 文件夹。
+
+建议始终创建一个新项目，而不是修改现有项目，从而避免索引器在 ``components`` 文件夹中生成不必要的 Git 文件和错误标记。由于两个项目都位于同一个工作区中，你仍然可以在整个工作区范围内进行搜索。
+
+如果在 LSP 编辑器中使用 Clangd 配置时遇到任何问题，请参阅 :ref:`Clangd 配置 <clangd_cdt_support>` 指南。
+
+参考文档
+--------
+
+.. toctree::
+    :maxdepth: 1
+
+    Clangd CDT 支持与配置 <clangd_cdt_support>
+    配置 Clang 工具链 <clangtoolchain>

--- a/docs/zh_CN/additionalfeatures/writebinarytoflash.rst
+++ b/docs/zh_CN/additionalfeatures/writebinarytoflash.rst
@@ -1,1 +1,16 @@
-.. include:: ../../en/additionalfeatures/writebinarytoflash.rst
+将二进制数据写入 flash
+======================
+
+:link_to_translation:`en:[English]`
+
+可以通过 ``ESP-IDF: Write Binary Data to Flash`` 命令将二进制数据写入乐鑫的 flash 芯片。要访问此命令，请在项目资源管理器中右键单击该项目：
+
+.. image:: https://github.com/espressif/idf-eclipse-plugin/assets/24419842/186c8498-d779-4771-af53-e5bf09e29502
+   :alt: 将二进制数据写入 flash 的命令
+
+点击此命令后，将打开 ``Write Binary Data to Flash`` 对话框，为二进制路径和偏移地址提供了可编辑的默认值。可以使用 ``ESP-IDF: Partition Table Editor`` 命令或手动打开 ``partitions.csv`` 文件查看分区表，确认正确的偏移地址。
+
+.. image:: https://github.com/espressif/idf-eclipse-plugin/assets/24419842/46e24e89-a1ed-4169-8c92-1ba0b0089ea7
+   :alt: 将二进制数据写入 flash 的对话框
+
+点击 ``Flash`` 按钮将执行烧录命令，并在此对话框中显示结果。


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions for  ``lspeditor.rst``, ``writebinarytoflash.rst``, ``configureenvvariables.rst`` in the docs/en/additionalfeatures folder based on [Espressif Style Guide](https://docs-internal.espressif.cn/projects/esp-mos/en/latest/index.html).
- Provides CN translation for above three docs.
- TODO: Closes [DOC-12874](https://jira.espressif.com:8443/browse/DOC-12874) once merged