### PR TITLE
docs: Provide CN translation for four docs

### DIFF
--- a/docs/en/additionalfeatures/cmakeeditor.rst
+++ b/docs/en/additionalfeatures/cmakeeditor.rst
@@ -1,12 +1,14 @@
 CMake Editor
 ============
 
-The CMake Editor Plug-in is integrated with the IDF Plugin for editing CMake files, such as ``CMakeLists.txt``. It provides syntax coloring, CMake command content assistance, and code templates.
+:link_to_translation:`zh_CN:[中文]`
+
+The CMake Editor Plugin is integrated with the IDF Plugin for editing CMake files, such as ``CMakeLists.txt``. It provides syntax coloring, CMake command auto-completion, and code templates.
 
 .. image:: ../../../media/cmake_editor_ca.png
    :alt: CMake Editor with content assist
 
-CMake editor preferences can be controlled using **Eclipse > Preferences > CMakeEd**.
+CMake editor preferences can be controlled using ``Eclipse`` > ``Preferences`` > ``CMakeEd``.
 
 .. image:: ../../../media/cmake_editor_preferences.png
    :alt: CMake editor preferences

--- a/docs/en/additionalfeatures/configuretoolchain.rst
+++ b/docs/en/additionalfeatures/configuretoolchain.rst
@@ -1,57 +1,71 @@
-How to Add a Preview or Custom ESP-IDF Target in the IDE (Manual Configuration)
-===============================================================================
+Add a Preview or Custom ESP-IDF Target in the IDE 
+=================================================
 
-To add support for any preview or custom ESP-IDF target (such as ESP32-C5 or others not listed by default in the IDE), follow these steps:
+:link_to_translation:`zh_CN:[中文]`
+
+To add support for any preview or custom ESP-IDF target (such as ESP32-C5 or other targets not listed by default in the IDE), follow these steps:
 
 Step 1: Configure Toolchain
 ---------------------------
-1. Go to Preferences → C/C++ → Core Build Toolchain.
-2. Under User Defined Toolchain, click on Add….
-3. Select GCC and configure as follows:
-   - **Compiler:** (Path to the toolchain compiler for your target, e.g. `/Users/testuser/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin/riscv32-esp-elf-gcc`)
-   - **Operating System:** (e.g. `esp32c5` for ESP32-C5)
-   - **CPU Arch:** (e.g. `riscv32` for ESP32-C5)
-4. Click Finish.
 
-.. image:: ../../../media/toolchain/toolchain_1.png
+1.  Go to ``Preferences`` > ``C/C++`` > ``Core Build Toolchain``.
+2.  Under ``User Defined Toolchains``, click ``Add``.
+3.  Select ``GCC`` and configure as follows:
+
+    - **Compiler**: Path to the toolchain compiler for your target, e.g., ``/Users/testuser/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin/riscv32-esp-elf-gcc``
+    - **Operating System**: e.g., ``esp32c5`` for ESP32-C5
+    - **CPU Arch**: e.g., ``riscv32`` for ESP32-C5
+
+4.  Click ``Finish``.
+
+.. figure:: ../../../media/toolchain/toolchain_1.png
+   :align: center
    :alt: Core Build Toolchains Preferences (Add Custom Target)
 
-*Core Build Toolchains Preferences: Adding a custom/preview target toolchain (example: ESP32-C5)*
+   Core Build Toolchains Preferences: Adding a custom/preview target toolchain (example: ESP32-C5)
 
 Step 2: Configure CMake Toolchain
 ---------------------------------
-1. Navigate to Preferences → C/C++ → CMake.
-2. Click on Add….
-3. Browse and select the CMake toolchain file for your target (e.g. `toolchain-esp32c5.cmake`).
-4. Choose the corresponding toolchain entry created in Step 1.
-5. Click Finish.
 
-.. image:: ../../../media/toolchain/toolchain_2.png
+1. Navigate to ``Preferences`` > ``C/C++`` > ``CMake``.
+2. Click ``Add``.
+3. Browse and select the CMake toolchain file for your target (e.g., ``toolchain-esp32c5.cmake``).
+4. Choose the corresponding toolchain entry created in Step 1.
+5. Click ``Finish``.
+
+.. figure:: ../../../media/toolchain/toolchain_2.png
+   :align: center
    :alt: CMake Toolchain Preferences (Add Custom Target)
 
-*CMake Toolchain Preferences: Adding a custom/preview target toolchain file (example: ESP32-C5)*
+   CMake Toolchain Preferences: Adding a custom/preview target toolchain file (example: ESP32-C5)
 
 Step 3: Add Launch Target
 -------------------------
-1. From the IDE's top toolbar target list, click on New Launch Target.
-2. Select ESP Target.
-3. Provide the following details:
-   - **Name:** (e.g. `esp32c5`)
-   - **IDF Target:** (e.g. `esp32c5`)
-4. Click Finish.
 
-.. image:: ../../../media/toolchain/toolchain_3.png
+1. From the IDE's top toolbar target list, click ``New Launch Target``.
+2. Select ``ESP Target``.
+3. Provide the following details:
+
+   - ``Name``: e.g., esp32c5
+   - ``IDF Target``: e.g., esp32c5
+
+4. Click ``Finish``.
+
+.. figure:: ../../../media/toolchain/toolchain_3.png
+   :align: center
    :alt: New ESP Target Dialog (Custom Target Example)
 
-*New ESP Target Dialog: Creating a launch target for a custom/preview target (example: ESP32-C5)*
+   New ESP Target Dialog: Creating a launch target for a custom/preview target (example: ESP32-C5)
 
 Step 4: Build a Project
 -----------------------
+
 - Create or open a project.
 - Select your custom/preview target from the target list.
 - Build the project.
 
-.. image:: ../../../media/toolchain/toolchain_4.png
+.. figure:: ../../../media/toolchain/toolchain_4.png
+   :align: center
    :alt: Build Output for Custom Target Project
 
-*Build Output: Successfully building a project for a custom/preview target (example: ESP32-C5)*
+   Build Output: Successfully building a project for a custom/preview target (example: ESP32-C5)

--- a/docs/en/additionalfeatures/partitiontableeditor.rst
+++ b/docs/en/additionalfeatures/partitiontableeditor.rst
@@ -1,28 +1,31 @@
-Partition Table Editor UI for ESP-IDF
-=====================================
+Partition Table Editor
+======================
 
-The Partition Table Editor command allows you to edit your `partition table <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html>`_ in a more convenient way, where you can see the supported types and subtypes and monitor the correctness of the entered data.
+:link_to_translation:`zh_CN:[中文]`
+
+The Partition Table Editor command allows you to edit your `partition table <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html>`_ in a more convenient way. It provides a view of the supported types and subtypes and helps you verify the correctness of the entered data.
 
 Steps
 -----
 
-1. Go to *Project Explorer* and open any IDF Project where you want to create a customized partition table.
-2. In *Project Explorer*, right-click on the project and select *ESP-IDF > Partition Table Editor*:
+1.  Go to ``Project Explorer`` and open any IDF Project where you want to create a customized partition table.
+2.  In ``Project Explorer``, right-click on the project and select ``ESP-IDF: Partition Table Editor``:
 
-   .. image:: https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png
-      :alt: Partition Table Editor menu option
+    .. image:: https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png
+       :alt: Partition Table Editor menu option
 
-   When you open the partition table editor for the selected project, you will see the standard editable content. Errors, if any, will be highlighted. You can hover your mouse over them to get hints about the issues:
+    When you open the partition table editor for the selected project, you will see the standard editable content. Any errors will be highlighted, and you can hover the mouse over them to see hints about the issues.
 
-   .. image:: https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559-0599f072219f.png
-      :alt: Error hints in Partition Table Editor
+    .. image:: https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559-0599f072219f.png
+       :alt: Error hints in Partition Table Editor
 
-3. Click *Save* or *Save and Quit* to save your changes.
+3.  Click ``Save`` or ``Save and Quit`` to save your changes.
+
 
 To Use a Customized Partition Table
 -----------------------------------
 
-1. Go to *sdkconfig* and set *Custom partition table CSV* as shown below:
+Go to ``SDK Configuration`` and set ``Custom partition table CSV`` as shown below:
 
-   .. image:: https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png
-      :alt: Setting custom partition table in sdkconfig
+.. image:: https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png
+   :alt: Setting custom partition table in sdkconfig

--- a/docs/en/additionalfeatures/switchlanguage.rst
+++ b/docs/en/additionalfeatures/switchlanguage.rst
@@ -1,5 +1,8 @@
-Switch Between Languages in Espressif IDE
-==========================================
+Switch Between Languages in the IDE
+===================================
+
+:link_to_translation:`zh_CN:[中文]`
+
 Espressif IDE supports English and Chinese languages. You can switch between these languages using the following steps:
 
 1. Click on the ``Espressif`` menu from the menu bar.

--- a/docs/zh_CN/additionalfeatures/cmakeeditor.rst
+++ b/docs/zh_CN/additionalfeatures/cmakeeditor.rst
@@ -1,1 +1,14 @@
-.. include:: ../../en/additionalfeatures/cmakeeditor.rst
+CMake 编辑器
+============
+
+:link_to_translation:`zh_CN:[中文]`
+
+CMake 编辑器插件与 IDF 插件集成，可用于编辑 CMake 文件（例如 ``CMakeLists.txt``）。该插件提供语法高亮、CMake 命令自动补全和代码模板等功能。
+
+.. image:: ../../../media/cmake_editor_ca.png
+   :alt: 带内容提示的 CMake 编辑器
+
+CMake 编辑器的首选项可通过 ``Eclipse`` > ``Preferences`` > ``CMakeEd`` 进行设置。
+
+.. image:: ../../../media/cmake_editor_preferences.png
+   :alt: CMake 编辑器首选项

--- a/docs/zh_CN/additionalfeatures/configuretoolchain.rst
+++ b/docs/zh_CN/additionalfeatures/configuretoolchain.rst
@@ -1,1 +1,71 @@
-.. include:: ../../en/additionalfeatures/configuretoolchain.rst
+在 IDE 中添加预览版或自定义 ESP-IDF 目标
+========================================
+
+:link_to_translation:`zh_CN:[中文]`
+
+若想添加预览版或自定义的 ESP-IDF 目标（例如 ESP32-C5 或 IDE 中未默认列出的目标），请按以下步骤操作：
+
+步骤 1：配置工具链
+------------------
+
+1.  前往 ``Preferences`` > ``C/C++`` > ``Core Build Toolchain``。
+2.  在 ``User Defined Toolchains`` 部分，点击 ``Add``。
+3.  选择 ``GCC``，并按如下配置：
+
+    - **编译器**：目标所用工具链编译器的路径，例如 ``/Users/testuser/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin/riscv32-esp-elf-gcc``
+    - **操作系统**：例如 ``esp32c5``，用于 ESP32-C5
+    - **CPU 架构**：例如 ``riscv32``，用于 ESP32-C5
+
+4.  点击 ``Finish``。
+
+.. figure:: ../../../media/toolchain/toolchain_1.png
+   :align: center
+   :alt: 核心构建工具链首选项（添加自定义目标）
+
+   核心构建工具链：添加自定义或预览版目标工具链（示例：ESP32-C5）
+
+步骤 2：配置 CMake 工具链
+-------------------------
+
+1. 前往 ``Preferences`` > ``C/C++`` > ``CMake``。
+2. 点击 ``Add``。
+3. 浏览并选择目标的 CMake 工具链文件（例如 ``toolchain-esp32c5.cmake``）。
+4. 选择步骤 1 中创建的相应工具链条目。
+5. 点击 ``Finish``。
+
+.. figure:: ../../../media/toolchain/toolchain_2.png
+   :align: center
+   :alt: CMake 工具链首选项（添加自定义目标）
+
+   CMake 工具链首选项：添加自定义或预览版目标工具链文件（示例：ESP32-C5）
+
+步骤 3：添加启动目标
+--------------------
+
+1. 在 IDE 顶部工具栏的目标列表中，点击 ``New Launch Target``。
+2. 选择 ``ESP Target``。
+3. 填写如下信息：
+
+   - ``Name``：例如， esp32c5
+   - ``IDF Target``：例如， esp32c5
+
+4. 点击 ``Finish``。
+
+.. figure:: ../../../media/toolchain/toolchain_3.png
+   :align: center
+   :alt: 新建乐鑫目标对话框（自定义目标示例）
+
+   新建乐鑫目标对话框：为自定义或预览版目标创建启动目标（示例：ESP32-C5）
+
+步骤 4：构建项目
+----------------
+
+- 新建或打开项目。
+- 在目标列表中选择自定义或预览版目标。
+- 构建项目。
+
+.. figure:: ../../../media/toolchain/toolchain_4.png
+   :align: center
+   :alt: 自定义目标项目的构建输出
+
+   构建输出：成功为自定义或预览版目标构建项目（示例：ESP32-C5）

--- a/docs/zh_CN/additionalfeatures/partitiontableeditor.rst
+++ b/docs/zh_CN/additionalfeatures/partitiontableeditor.rst
@@ -1,1 +1,31 @@
-.. include:: ../../en/additionalfeatures/partitiontableeditor.rst
+分区表编辑器
+============
+
+:link_to_translation:`zh_CN:[中文]`
+
+可以使用分区表编辑器命令更快捷地编辑 `分区表 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/partition-tables.html>`_。你可以在编辑器中查看受支持的类型和子类型，并检查输入数据的正确性。
+
+步骤
+----
+
+1.  进入 ``Project Explorer``，打开任意希望创建自定义分区表的 IDF 工程。
+2.  在 ``Project Explorer`` 中，右键单击该项目并选择 ``ESP-IDF: Partition Table Editor``：
+
+    .. image:: https://user-images.githubusercontent.com/24419842/216105408-ca2e73ce-5df3-4bdd-ac61-b7265deb9b44.png
+       :alt: 分区表编辑器菜单选项
+
+    为所选项目打开分区表编辑器时，能看到标准可编辑的内容。若存在错误，则会高亮显示。你可以将鼠标悬停在错误之上以查看相关提示：
+
+    .. image:: https://user-images.githubusercontent.com/24419842/216106804-703b2eb4-b141-48de-8559f072219f.png
+       :alt: 分区表编辑器中的错误提示
+
+3. 单击 ``Save`` 或 ``Save and Quit`` 以保存更改。
+
+
+使用自定义分区表
+----------------
+
+进入 ``SDK Configuration``，并按下图所示设置 ``Custom partition table CSV``：
+
+.. image:: https://user-images.githubusercontent.com/24419842/216104107-2844068b-8412-468b-931f-b4778af4417c.png
+   :alt: 在 sdkconfig 中设置自定义分区表

--- a/docs/zh_CN/additionalfeatures/switchlanguage.rst
+++ b/docs/zh_CN/additionalfeatures/switchlanguage.rst
@@ -1,1 +1,14 @@
-.. include:: ../../en/additionalfeatures/switchlanguage.rst
+在 IDE 中切换语言
+=================
+
+:link_to_translation:`zh_CN:[中文]`
+
+乐鑫 IDE 支持英文和中文。可参照以下步骤在两种语言之间进行切换：
+
+1. 在菜单栏中点击 ``Espressif``。
+2. 从下拉菜单中选择 ``Change Language``。
+3. 在子菜单中选择需要的语言。
+4. IDE 将重新启动并切换至所选语言界面。
+
+.. image:: ../../../media/change_language.png
+   :alt: 切换语言菜单


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions for ``configuretoolchain.rst``, ``cmakeeditor.rst``, ``switchlanguage.rst``, ``partitiontableeditor.rst`` in the docs/en/additionalfeatures folder based on [Espressif Style Guide](https://docs-internal.espressif.cn/projects/esp-mos/en/latest/index.html).
- Provides CN translation for above four docs.
- TODO: Closes [DOC-12875](https://jira.espressif.com:8443/browse/DOC-12875) once merged