### PR TITLE
docs: Provide CN translation for two docs

### DIFF
--- a/docs/en/additionalfeatures/coredumpdebugging.rst
+++ b/docs/en/additionalfeatures/coredumpdebugging.rst
@@ -1,20 +1,21 @@
 .. _coredumpdebugging:
 
 Core Dump Debugging
-====================
+===================
 
-The IDF-Eclipse plugin allows you to debug the core dump if any crash occurs on the chip and the configurations are set. Currently, only the UART core dump capture and debugging is supported.
+:link_to_translation:`zh_CN:[中文]`
+
+The IDF-Eclipse plugin allows you to debug the core dump if any crash occurs on the chip, provided that the required configurations are set. Currently, only UART core dump capture and debugging are supported.
 
 To enable core dump debugging for a project:
 
-1. You need to enable it first in `sdkconfig`. Launch the `sdkconfig` in the project root by double-clicking on it which will open the configuration editor.
-
-2. Click on the `Core Dump` from the settings on the left and select `Data Destination` as `UART`.
+1. You need to enable it first in ``sdkconfig``. Launch the ``sdkconfig`` in the project root by double-clicking on it which will open the configuration editor.
+2. Click on the ``Core Dump`` from the settings on the left and select ``Data Destination`` as ``UART``.
 
 .. image:: ../../../media/CoreDumpDebugging/sdkconfig_editor.png
 
-This will enable the core dump debugging, and whenever you connect a serial monitor for that project, if any crash occurs, it will load the dump and open a debug perspective in Eclipse to let you diagnose the dump where you can view all the information in the core dump.
+This enables core dump debugging. When you connect a serial monitor for the project and a crash occurs, Eclipse automatically loads the core dump and opens the debug perspective, allowing you to inspect all the information contained in the dump.
 
-You can view the registers stack trace and even view the value of variables in the stack frame.
+You can view the registers and stack trace, and even check the value of variables in the stack frame.
 
-To exit the debug session: simply press the `stop` button.
+To exit the debug session: simply press the ``stop`` button.

--- a/docs/en/additionalfeatures/install-esp-components.rst
+++ b/docs/en/additionalfeatures/install-esp-components.rst
@@ -1,12 +1,15 @@
 Install ESP-IDF Components
-===============================
+==========================
+
+:link_to_translation:`zh_CN:[中文]`
+
 You can install the ESP-IDF Components directly into your project from the available components from the `ESP-IDF Component Registry <https://components.espressif.com/>`_. Follow the steps below:
 
-- Right-click on the project in ``Project Explorer`` where you want to add the component, and select ``ESP-IDF > Install ESP-IDF Components``.
-- A new window will open, displaying all available components to be installed.
-- In the window, you can click on the ``Install`` button to add the selected component to the project. To access the README file for a component, click ``More Info``, which opens the README in your browser.
+1. Right-click on the project in ``Project Explorer`` where you want to add the component, and select ``ESP-IDF: Install ESP-IDF Components``.
+2. A new window will open, displaying all available components to be installed.
+3. In the window, you can click on the ``Install`` button to add the selected component to the project. To access the README file for a component, click ``More Info``, which opens the README in your browser.
 
-  .. image:: ../../../media/ESP-IDF_Components/components_window.png
-     :alt: ESP-IDF Components Window
+.. image:: ../../../media/ESP-IDF_Components/components_window.png
+   :alt: ESP-IDF Components Window
 
 Already added components are also shown, but the ``Install`` button text changes to ``Already Added`` and is disabled.

--- a/docs/zh_CN/additionalfeatures/coredumpdebugging.rst
+++ b/docs/zh_CN/additionalfeatures/coredumpdebugging.rst
@@ -1,1 +1,21 @@
-.. include:: ../../en/additionalfeatures/coredumpdebugging.rst
+.. _coredumpdebugging:
+
+核心转储调试
+============
+
+:link_to_translation:`en:[English]`
+
+IDF-Eclipse 插件允许在芯片发生崩溃且已完成相关配置时调试核心转储。目前，仅支持通过 UART 捕获和调试核心转储。
+
+可参照以下步骤为项目启用核心转储调试：
+
+1. 先在 ``sdkconfig`` 中启用该功能。在项目根目录中双击 ``sdkconfig``，打开配置编辑器。
+2. 在左侧设置中点击 ``Core Dump``，并将 ``Data Destination`` 设置为 ``UART``。
+
+.. image:: ../../../media/CoreDumpDebugging/sdkconfig_editor.png
+
+上述步骤将启用核心转储调试。为项目连接串口监视器时，如发生崩溃，则将加载转储并在 Eclipse 中打开调试透视图，以便查看核心转储包含的所有信息。
+
+你可以查看寄存器、栈回溯，甚至查看栈帧中的变量值。
+
+若想退出调试会话，只需点击 ``stop`` 按钮。

--- a/docs/zh_CN/additionalfeatures/install-esp-components.rst
+++ b/docs/zh_CN/additionalfeatures/install-esp-components.rst
@@ -1,1 +1,15 @@
-.. include:: ../../en/additionalfeatures/install-esp-components.rst
+安装 ESP-IDF 组件
+=================
+
+:link_to_translation:`en:[English]`
+
+可以从 `ESP-IDF 组件注册表 <https://components.espressif.com/>`_ 提供的可用组件中，选择 ESP-IDF 组件安装至你的项目。请按照以下步骤操作：
+
+1. 在 ``Project Explorer`` 中，右键点击要添加组件的项目，然后选择 ``ESP-IDF: Install ESP-IDF Components``。
+2. 界面中出现一个新窗口，显示所有可安装的组件。
+3. 在该窗口中，可点击 ``Install`` 按钮将所选组件添加到项目。要查看组件的 README 文件，点击 ``More Info``，浏览器会打开该 README。
+
+.. image:: ../../../media/ESP-IDF_Components/components_window.png
+   :alt: ESP-IDF 组件窗口
+
+已添加的组件也会在此显示，但 ``Install`` 按钮的文字会变为 ``Already Added`` 并被禁用。


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions for ``coredumpdebugging.rst`` and ``install-esp-components.rst`` in the docs/en/additionalfeatures folder based on [Espressif Style Guide](https://docs-internal.espressif.cn/projects/esp-mos/en/latest/index.html).
- Provides CN translation for above two docs.
- TODO: Closes [DOC-12876](https://jira.espressif.com:8443/browse/DOC-12876) once merged