### PR TITLE
IEP-1657 Clangd Preferences Not Applied Automatically After Tools Initialization in 4.0 Beta

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/SetupToolsInIde.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/SetupToolsInIde.java
@@ -43,6 +43,7 @@ import com.espressif.idf.core.tools.util.ToolsUtility;
 import com.espressif.idf.core.tools.vo.EimJson;
 import com.espressif.idf.core.tools.vo.IdfInstalled;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.LspService;
 import com.espressif.idf.core.util.StringUtil;
 
 /**
@@ -150,6 +151,11 @@ public class SetupToolsInIde extends Job
 			copyOpenOcdRules();
 			monitor.worked(1);
 			
+			monitor.setTaskName("Applying Clangd Preferences"); //$NON-NLS-1$
+			log("Applying Clangd Preferences", IStatus.INFO); //$NON-NLS-1$
+			var lspService = new LspService();
+			lspService.updateClangdPath();
+			lspService.updateQueryDriver();
 			log("Tools Setup complete", IStatus.INFO); //$NON-NLS-1$
 			
 			return Status.OK_STATUS;


### PR DESCRIPTION
## Description

The code responsible for setting the query drivers and the clangd path was missing in the 4.0.0 branch.

Fixes # ([IEP-1657](https://jira.espressif.com:8443/browse/IEP-1657))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
