### PR TITLE
IEP-1660 Update LSP4E to the 0.29.3

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -81,15 +81,6 @@
 			<unit id="org.eclipse.embedcdt.packs.feature.group" version="6.4.0.202307251916"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.29.0/"/>
-			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tm4e/releases/0.15.1/"/>
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
@@ -110,6 +101,15 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/swtchart/releases/1.0.0/repository/"/>
 			<unit id="org.eclipse.swtchart.feature.feature.group" version="1.0.0.202412021530"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.29.3/"/>
+			<unit id="org.eclipse.lsp4e" version="0.19.3.202512021035"/>
+			<unit id="org.eclipse.lsp4e.debug" version="0.16.1.202511182243"/>
+			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
## Description

We recently updated lsp4e to version 0.29.0; however, the latest version is now 0.29.3 and includes some important fixes.

Fixes # ([IEP-1660](https://jira.espressif.com:8443/browse/IEP-1660))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Verified that the lsp4e plugins are updated in Espressif-IDE/plugins.
Additionally, you can confirm that features from any release between 0.29.0 and 0.29.3 are working as expected:
https://github.com/eclipse-lsp4e/lsp4e/releases

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
