### PR TITLE
fix: sign only idf repo plugins and simplifying the P2 metadata

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -72,28 +72,41 @@ jobs:
             echo "Using certificate chain file"
           fi
           
-          # Find and sign JAR files using jarsigner with Jsign's JCA provider
-          find releng/com.espressif.idf.update/target/repository -type f -name "*.jar" | while read -r file; do
-            echo "Signing JAR: $file"
-            
-            jarsigner \
-              -J-cp -Jjsign-7.4.jar \
-              -J--add-modules -Jjava.sql \
-              -providerClass net.jsign.jca.JsignJcaProvider \
-              -providerArg "${{ secrets.AZURE_KEYVAULT_URI }}" \
-              -keystore NONE \
-              -storetype AZUREKEYVAULT \
-              -storepass "$AZURE_TOKEN" \
-              -tsa http://timestamp.digicert.com \
-              $CERTCHAIN_ARG \
-              "$file" \
-              "${{ secrets.AZURE_KEYVAULT_CERT_NAME }}"
-            
-            if [ $? -eq 0 ]; then
-              echo "Successfully signed: $file"
+          REPO_DIR="releng/com.espressif.idf.update/target/repository"
+          SIGFILE="ECLIPSE"
+          
+          echo "Signing IDF plugin JARs in $REPO_DIR..."
+          echo "Only signing JARs matching com.espressif.* pattern..."
+          
+          find "$REPO_DIR" -type f -name "*.jar" | while read -r file; do
+            if [[ "$file" =~ (plugins|features)/com\.espressif\. ]]; then
+              echo "Signing IDF plugin/feature JAR: $file"
+              
+              jarsigner \
+                -J-cp -Jjsign-7.4.jar \
+                -J--add-modules -Jjava.sql \
+                -providerClass net.jsign.jca.JsignJcaProvider \
+                -providerArg "${{ secrets.AZURE_KEYVAULT_URI }}" \
+                -keystore NONE \
+                -storetype AZUREKEYVAULT \
+                -storepass "$AZURE_TOKEN" \
+                -sigfile "$SIGFILE" \
+                -digestalg SHA-256 \
+                -tsa http://timestamp.digicert.com \
+                $CERTCHAIN_ARG \
+                -certs \
+                -verbose \
+                "$file" \
+                "${{ secrets.AZURE_KEYVAULT_CERT_NAME }}"
+              
+              if [ $? -eq 0 ]; then
+                echo "Successfully signed: $file"
+              else
+                echo "Failed to sign: $file"
+                exit 1
+              fi
             else
-              echo "Failed to sign: $file"
-              exit 1
+              echo "Skipping non-IDF JAR: $file"
             fi
           done
           
@@ -112,9 +125,6 @@ jobs:
         env:
           MAVEN_OPTS: "-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.maxParameterEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0"
         run: |
-          # Regenerate P2 metadata to update hashes for signed JARs
-          # This ensures the SHA-512 hashes in metadata match the signed JAR files
-          # Use Tycho's fix-artifacts-metadata goal to update metadata without rebuilding artifacts
           REPO_DIR="releng/com.espressif.idf.update/target/repository"
           
           echo "Updating P2 metadata for signed JARs in $REPO_DIR..."
@@ -122,7 +132,6 @@ jobs:
             org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
             -DrepositoryPath="$REPO_DIR" \
             -DskipTests=true || \
-          # Fallback: try without explicit path (auto-detect)
           mvn -f releng/com.espressif.idf.update/pom.xml \
             org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
             -DskipTests=true


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD release process with refined JAR signing targeting for IDF plugins and features.
  * Strengthened error handling to detect and report signing failures in the release pipeline.
  * Enhanced logging and messaging for better release process visibility and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->