### PR TITLE
IEP-1667 support esp-idf-size 2.0 and use idf.py size command

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeChartsComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeChartsComposite.java
@@ -149,6 +149,25 @@ public class IDFSizeChartsComposite
 		for (var child : chartComp.getChildren())
 			child.dispose();
 
+		// Defensive check: Handle unexpected empty data gracefully to prevent UI crash.
+		if (overviewJson == null || overviewJson.isEmpty() || !overviewJson.containsKey(IDFSizeConstants.LAYOUT))
+		{
+			Label errorLabel = new Label(chartComp, SWT.WRAP | SWT.CENTER);
+			errorLabel.setText(
+					Messages.IDFSizeChartsComposite_NoMemoryDataAvailableLblMsg);
+			errorLabel.setForeground(chartComp.getDisplay().getSystemColor(SWT.COLOR_RED));
+
+			// Center the error message across the 2-column grid
+			GridData gd = new GridData(SWT.CENTER, SWT.CENTER, true, true);
+			gd.horizontalSpan = 2;
+			errorLabel.setLayoutData(gd);
+
+			// Refresh layout and return to avoid crash
+			chartComp.layout(true, true);
+			scrollable.setMinSize(chartComp.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+			return;
+		}
+
 		JSONArray layoutArray = (JSONArray) overviewJson.get(IDFSizeConstants.LAYOUT);
 		for (Object obj : layoutArray)
 		{
@@ -206,7 +225,7 @@ public class IDFSizeChartsComposite
 		for (int i = 0; i < dataset.getRowCount(); i++)
 		{
 			String rowKey = dataset.getRowKey(i).toString();
-			if (rowKey.startsWith("Free"))
+			if (rowKey.startsWith("Free")) //$NON-NLS-1$
 			{
 				labelColorMap.putIfAbsent(rowKey, Color.GREEN);
 			}
@@ -245,7 +264,7 @@ public class IDFSizeChartsComposite
 
 		for (String key : dataset.getKeys())
 		{
-			if (key.startsWith("Free"))
+			if (key.startsWith("Free")) //$NON-NLS-1$
 			{
 				labelColorMap.putIfAbsent(key, Color.GREEN);
 			}
@@ -302,7 +321,7 @@ public class IDFSizeChartsComposite
 	{
 		try
 		{
-			return new IDFSizeDataManager().getIDFSizeOverview(file, targetName);
+			return new IDFSizeDataManager().getIDFSizeOverview(file);
 		}
 		catch (Exception e)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
@@ -99,7 +99,7 @@ public class IDFSizeOverviewComposite
 		table.setLinesVisible(true);
 		table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
 
-		String[] columns = { "Region", "Used", "Free", "Total", "Usage" };
+		String[] columns = { "Region", "Used", "Free", "Total", "Usage" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 		for (String colName : columns)
 		{
 			TableColumn col = new TableColumn(table, SWT.NONE);
@@ -119,7 +119,17 @@ public class IDFSizeOverviewComposite
 	{
 		table.removeAll();
 
-		JSONArray layout = (JSONArray) overviewJson.get("layout");
+		// Defensive check: Handle unexpected empty data gracefully to prevent UI crash.
+		if (overviewJson == null || overviewJson.isEmpty() || !overviewJson.containsKey("layout")) //$NON-NLS-1$
+		{
+			TableItem errorItem = new TableItem(table, SWT.NONE);
+			errorItem.setText(0,
+					Messages.IDFSizeOverviewComposite_NoExpectedOutputMsg);
+			errorItem.setForeground(0, table.getDisplay().getSystemColor(SWT.COLOR_RED));
+			return;
+		}
+
+		JSONArray layout = (JSONArray) overviewJson.get("layout"); //$NON-NLS-1$
 		long grandUsed = 0;
 		long grandFree = 0;
 
@@ -127,16 +137,16 @@ public class IDFSizeOverviewComposite
 		for (Object obj : layout)
 		{
 			JSONObject section = (JSONObject) obj;
-			String name = (String) section.get("name");
-			long used = (long) section.get("used");
-			long free = (long) section.get("free");
-			long total = (long) section.get("total");
+			String name = (String) section.get("name"); //$NON-NLS-1$
+			long used = (long) section.get("used"); //$NON-NLS-1$
+			long free = (long) section.get("free"); //$NON-NLS-1$
+			long total = (long) section.get("total"); //$NON-NLS-1$
 
 			grandUsed += used;
 			grandFree += free;
 
 			TableItem item = new TableItem(table, SWT.NONE);
-			item.setText(new String[] { name, formatMemory(used), formatMemory(free), formatMemory(total), "" // progress
+			item.setText(new String[] { name, formatMemory(used), formatMemory(free), formatMemory(total), "" // progress //$NON-NLS-1$
 																												// bar
 																												// will
 																												// go
@@ -150,8 +160,8 @@ public class IDFSizeOverviewComposite
 
 		// Total row
 		TableItem totalRow = new TableItem(table, SWT.NONE);
-		totalRow.setText(new String[] { "Total:", formatMemory(grandUsed), formatMemory(grandFree),
-				formatMemory(grandUsed + grandFree), "" });
+		totalRow.setText(new String[] { "Total:", formatMemory(grandUsed), formatMemory(grandFree), //$NON-NLS-1$
+				formatMemory(grandUsed + grandFree), "" }); //$NON-NLS-1$
 		for (int i = 0; i < 5; i++)
 		{
 			applyBoldToColumn(totalRow, i);
@@ -206,7 +216,7 @@ public class IDFSizeOverviewComposite
 	private String getUsagePercent(long used, long total)
 	{
 		if (total == 0)
-			return "-";
+			return "-"; //$NON-NLS-1$
 		double percent = (double) used / total * 100;
 		return String.format("%.1f%%", percent); //$NON-NLS-1$
 	}
@@ -228,7 +238,7 @@ public class IDFSizeOverviewComposite
 	{
 		try
 		{
-			return new IDFSizeDataManager().getIDFSizeOverview(file, targetName);
+			return new IDFSizeDataManager().getIDFSizeOverview(file);
 		}
 		catch (Exception e)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/Messages.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/Messages.java
@@ -26,11 +26,13 @@ public class Messages extends NLS
 	public static String IDFSizeOverviewComposite_SwitchToPie;
 	public static String IDFSizeOverviewComposite_SwitchToBar;
 	public static String IDFSizeOverviewComposite_MemoryUsagePrefix;
+	public static String IDFSizeOverviewComposite_NoExpectedOutputMsg;
 	public static String IDFSizeEditorOverview;
 	public static String IDFSizeEditorDetails;
 	public static String IDFSizeEditorCharts;
 	public static String IDFSizeChartsComposite_SizeUnit;
 	public static String IDFSizeChartsComposite_MemoryParts;
+	public static String IDFSizeChartsComposite_NoMemoryDataAvailableLblMsg;
 	public static String IDFSizeChartsComposite_SizeTag;
 	public static String IDFSizeEditorVersionError;
 	public static String IDFSizeEditorVersionErrorDescription;

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/messages.properties
@@ -19,6 +19,7 @@ IDFSizeOverviewComposite_ChartView=Chart View:
 IDFSizeOverviewComposite_SwitchToPie=Switch to Pie
 IDFSizeOverviewComposite_SwitchToBar=Switch to Bar
 IDFSizeOverviewComposite_MemoryUsagePrefix=Memory Usage - 
+IDFSizeOverviewComposite_NoExpectedOutputMsg=No memory data available.'idf.py size' output not as expected
 
 IDFSizeEditorOverview=Overview
 IDFSizeEditorDetails=Details
@@ -27,6 +28,7 @@ IDFSizeEditorCharts=Charts
 
 IDFSizeChartsComposite_SizeUnit=Size Unit:
 IDFSizeChartsComposite_MemoryParts=Memory Parts
+IDFSizeChartsComposite_NoMemoryDataAvailableLblMsg=No memory data available.\nPlease ensure the project is built successfully and 'idf.py size' works.
 IDFSizeChartsComposite_SizeTag=Size {0}
 
 IDFSizeEditorVersionError=Memory Usage Analysis Unavailable


### PR DESCRIPTION
## Description

Added pip show check for esp-idf-size package

Fixes # ([IEP-1667](https://jira.espressif.com:8443/browse/IEP-1667))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Install the the latest esp-idf 6.0, and make sure it includes the esp-idf-size package with at least version 2.0. Check it from the esp-idf venv Python.
Then check the application size analysis.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archive and file-specific size/symbol queries and richer memory breakdowns shown in the size viewer.

* **Bug Fixes**
  * Improved handling of missing/invalid size output to show a clear error message instead of failing; NaN values are now treated as zero.

* **Documentation**
  * Added user-facing messages/localization for no-data and error states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->