### PR TITLE
docs: Provide CN translation for kconfigeditor.rst

### DIFF
--- a/docs/en/additionalfeatures/kconfigeditor.rst
+++ b/docs/en/additionalfeatures/kconfigeditor.rst
@@ -1,6 +1,8 @@
 KConfig Editor
 ==============
 
+:link_to_translation:`zh_CN:[中文]`
+
 The KConfig Editor provides enhanced editing capabilities for ESP-IDF configuration files, including syntax highlighting, content assist, and intelligent editing features. It supports all KConfig file types used in ESP-IDF projects.
 
 Supported File Types
@@ -8,8 +10,8 @@ Supported File Types
 
 The KConfig Editor automatically recognizes and provides enhanced editing for the following file types:
 
-- ``Kconfig`` - Main configuration files
-- ``Kconfig.projbuild`` - Project-specific configuration files  
+- ``Kconfig`` – Main configuration files
+- ``Kconfig.projbuild`` – Project-specific configuration files
 
 Features
 --------
@@ -19,11 +21,11 @@ Syntax Highlighting
 
 The editor provides comprehensive syntax highlighting for all KConfig language constructs:
 
-- **Keywords**: ``config``, ``menuconfig``, ``choice``, ``menu``, ``endmenu``, ``endchoice``
-- **Types**: ``bool``, ``tristate``, ``string``, ``hex``, ``int``
-- **Properties**: ``default``, ``depends``, ``select``, ``help``, ``prompt``
-- **Values**: ``y``, ``n``, ``m``, string literals, hexadecimal and integer values
-- **Comments**: Line comments starting with ``#``
+- **Keywords**: ``config``, ``menuconfig``, ``choice``, ``menu``, ``endmenu``, ``endchoice``.
+- **Types**: ``bool``, ``tristate``, ``string``, ``hex``, ``int``.
+- **Properties**: ``default``, ``depends``, ``select``, ``help``, ``prompt``.
+- **Values**: ``y``, ``n``, ``m``, string literals, hexadecimal and integer values.
+- **Comments**: Line comments starting with ``#``.
 
 Content Assist
 ~~~~~~~~~~~~~~
@@ -31,18 +33,18 @@ Content Assist
 Intelligent content proposals are available when editing KConfig files:
 
 - **Main Keywords**: Proposals for ``config``, ``menuconfig``, ``choice``, ``menu``, etc.
-- **Types**: Suggestions for ``bool``, ``tristate``, ``string``, ``hex``, ``int``
-- **Properties**: Auto-completion for ``default``, ``depends``, ``select``, ``help``, ``prompt``
-- **Values**: Context-aware suggestions for ``y``, ``n``, ``m``, and string values
+- **Types**: Suggestions for ``bool``, ``tristate``, ``string``, ``hex``, ``int``.
+- **Properties**: Auto-completion for ``default``, ``depends``, ``select``, ``help``, ``prompt``.
+- **Values**: Context-aware suggestions for ``y``, ``n``, ``m``, and string values.
 
-Auto-closing Pairs
+Auto-Closing Pairs
 ~~~~~~~~~~~~~~~~~~
 
 The editor automatically handles bracket and quote pairing:
 
-- **Parentheses**: Automatically closes ``(`` with ``)``
-- **Quotes**: Automatically closes ``"`` with ``"``
-- **Smart Cursor Positioning**: Cursor stays in the optimal position for continued typing
+- **Parentheses**: Automatically closes ``(`` with ``)``.
+- **Quotes**: Automatically closes ``"`` with ``"``.
+- **Smart Cursor Positioning**: Cursor stays in the optimal position for continued typing.
 
 Example of auto-closing pairs:
 
@@ -62,28 +64,28 @@ Smart Indentation
 
 The editor provides intelligent indentation rules for KConfig structure:
 
-- **Increase Indent**: After ``menu``, ``config``, ``menuconfig``, ``choice``, ``help``, ``comment``
-- **Decrease Indent**: After ``endmenu``, ``endchoice``, ``endif``
-- **Consistent Formatting**: Maintains proper KConfig file structure
+- **Increase Indent**: After ``menu``, ``config``, ``menuconfig``, ``choice``, ``help``, ``comment``.
+- **Decrease Indent**: After ``endmenu``, ``endchoice``, ``endif``.
+- **Consistent Formatting**: Maintains proper KConfig file structure.
 
 Bracket Matching
 ~~~~~~~~~~~~~~~~
 
 Visual highlighting of matching bracket pairs:
 
-- **Menu Blocks**: ``menu`` and ``endmenu`` pairs
-- **Choice Blocks**: ``choice`` and ``endchoice`` pairs
-- **Parentheses**: ``(`` and ``)`` pairs
-- **Quotes**: ``"`` and ``"`` pairs
+- **Menu Blocks**: ``menu`` and ``endmenu`` pairs.
+- **Choice Blocks**: ``choice`` and ``endchoice`` pairs.
+- **Parentheses**: ``(`` and ``)`` pairs.
+- **Quotes**: ``"`` and ``"`` pairs.
 
 Code Folding
 ~~~~~~~~~~~~
 
 Support for folding KConfig blocks:
 
-- **Menu Sections**: Fold/unfold menu blocks
-- **Choice Sections**: Fold/unfold choice blocks
-- **Comment Regions**: Fold/unfold comment sections
+- **Menu Sections**: Fold/unfold menu blocks.
+- **Choice Sections**: Fold/unfold choice blocks.
+- **Comment Regions**: Fold/unfold comment sections.
 
 Usage
 -----
@@ -93,9 +95,9 @@ Opening KConfig Files
 
 KConfig files are automatically opened with the enhanced editor when:
 
-1. Double-clicking on any ``Kconfig`` or ``Kconfig.projbuild`` file in the Project Explorer
-2. Right-clicking and selecting "Open With > KConfig Editor"
-3. Opening files from the File menu
+1. Double-clicking on any ``Kconfig`` or ``Kconfig.projbuild`` file in the Project Explorer.
+2. Right-clicking and selecting ``Open With`` > ``KConfig Editor``.
+3. Opening files from the ``File`` menu.
 
 The editor will automatically detect the file type and apply the appropriate syntax highlighting and features.
 
@@ -104,10 +106,10 @@ Editing KConfig Files
 
 When editing KConfig files, you can take advantage of:
 
-- **Content Assist**: Press ``Ctrl+Space`` to trigger content proposals
-- **Auto-completion**: Type partial keywords and press ``Tab`` to complete
-- **Bracket Navigation**: Use ``Ctrl+Shift+P`` to jump between matching brackets
-- **Code Folding**: Click the fold icons in the editor gutter to collapse/expand sections
+- **Content Assist**: Press ``Ctrl+Space`` to trigger content proposals.
+- **Auto-completion**: Type partial keywords and press ``Tab`` to complete.
+- **Bracket Navigation**: Use ``Ctrl+Shift+P`` to jump between matching brackets.
+- **Code Folding**: Click the fold icons in the editor gutter to collapse/expand sections.
 
 Example KConfig Entry
 ~~~~~~~~~~~~~~~~~~~~~
@@ -141,4 +143,3 @@ References
 - `ESP-IDF KConfig Language Reference <https://docs.espressif.com/projects/esp-idf-kconfig/en/latest/kconfiglib/language.html>`_
 - `KConfig Language Documentation <https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_
 - `Eclipse TM4E Documentation <https://github.com/eclipse/tm4e>`_
-

--- a/docs/zh_CN/additionalfeatures.rst
+++ b/docs/zh_CN/additionalfeatures.rst
@@ -8,6 +8,7 @@
 
     LSP C/C++ 编辑器 <additionalfeatures/lspeditor>
     CMake 编辑器 <additionalfeatures/cmakeeditor>
+    KConfig 编辑器 <additionalfeatures/kconfigeditor>
     ESP-IDF 应用程序大小分析 <additionalfeatures/application-size-analysis>
     ESP-IDF 终端 <additionalfeatures/esp-terminal>
     安装 ESP-IDF 组件 <additionalfeatures/install-esp-components>

--- a/docs/zh_CN/additionalfeatures/kconfigeditor.rst
+++ b/docs/zh_CN/additionalfeatures/kconfigeditor.rst
@@ -1,0 +1,145 @@
+KConfig 编辑器
+==============
+
+:link_to_translation:`en:[English]`
+
+KConfig 编辑器为 ESP-IDF 配置文件提供增强的编辑功能，包括语法高亮、内容辅助和智能编辑。该编辑器支持 ESP-IDF 项目中使用的所有 KConfig 文件类型。
+
+支持的文件类型
+--------------
+
+KConfig 编辑器会自动识别并为下列文件类型提供增强编辑：
+
+- ``Kconfig`` – 主配置文件
+- ``Kconfig.projbuild`` – 项目特定的配置文件
+
+功能
+----
+
+语法高亮
+~~~~~~~~
+
+该编辑器为所有 KConfig 语言结构提供全面的语法高亮：
+
+- **关键字**：``config``、``menuconfig``、``choice``、``menu``、``endmenu``、``endchoice``。
+- **类型**：``bool``、``tristate``、``string``、``hex``、``int``。
+- **属性**：``default``、``depends``、``select``、``help``、``prompt``。
+- **取值**：``y``、``n``、``m``、字符串字面量、十六进制与整数值。
+- **注释**：以 ``#`` 开头的行注释。
+
+内容辅助
+~~~~~~~~
+
+编辑 KConfig 文件时提供智能建议：
+
+- **主要关键字**：对 ``config``、``menuconfig``、``choice``、``menu`` 等的建议。
+- **类型**：对 ``bool``、``tristate``、``string``、``hex``、``int`` 的建议。
+- **属性**：对 ``default``、``depends``、``select``、``help``、``prompt`` 的自动补全。
+- **取值**：针对 ``y``、``n``、``m`` 与字符串值的上下文感知建议。
+
+自动补全成对符号
+~~~~~~~~~~~~~~~~
+
+编辑器会自动处理括号和引号的成对输入：
+
+- **圆括号**：输入 ``(`` 时自动补全 ``)``。
+- **引号**：输入 ``"`` 时自动补全 ``"``。
+- **智能光标定位**：光标保持在继续输入的最佳位置。
+
+自动补全成对符号示例：
+
+.. code-block:: kconfig
+
+    config ESP32_WIFI_ENABLED
+        bool "Enable WiFi"
+        default y
+        depends on (IDF_TARGET="esp32" || IDF_TARGET="esp32s2")
+        help
+            "Enable WiFi support for ESP32"
+
+当输入 ``depends on (`` 时，编辑器会自动补上 ``)``，并将光标置于二者之间。
+
+智能缩进
+~~~~~~~~
+
+编辑器为 KConfig 结构提供智能缩进规则：
+
+- **增加缩进**：在 ``menu``、``config``、``menuconfig``、``choice``、``help``、``comment`` 之后。
+- **减少缩进**：在 ``endmenu``、``endchoice``、``endif`` 之后。
+- **格式一致性**：保持正确的 KConfig 文件结构。
+
+括号匹配
+~~~~~~~~
+
+支持高亮匹配成对符号：
+
+- **菜单块**：``menu`` 与 ``endmenu`` 成对。
+- **选择块**：``choice`` 与 ``endchoice`` 成对。
+- **圆括号**：``(`` 与 ``)`` 成对。
+- **引号**：``"`` 与 ``"`` 成对。
+
+代码折叠
+~~~~~~~~
+
+支持折叠 KConfig 代码块：
+
+- **菜单区域**：折叠或展开菜单块。
+- **选择区域**：折叠或展开选择块。
+- **注释区域**：折叠或展开注释段。
+
+用法
+----
+
+打开 KConfig 文件
+~~~~~~~~~~~~~~~~~
+
+在以下情况下，KConfig 文件会自动使用增强型编辑器打开：
+
+1. 在项目资源管理器中双击任意 ``Kconfig`` 或 ``Kconfig.projbuild`` 文件。
+2. 右键点击并选择 ``Open With`` > ``KConfig Editor``。
+3. 从 ``File`` 菜单打开文件。
+
+编辑器会自动检测文件类型并应用相应的语法高亮与其他编辑功能。
+
+编辑 KConfig 文件
+~~~~~~~~~~~~~~~~~
+
+编辑 KConfig 文件时，可以使用：
+
+- **内容辅助**：按 ``Ctrl+Space`` 触发内容建议。
+- **自动补全**：输入部分关键字后按 ``Tab`` 补全内容。
+- **括号导航**：使用 ``Ctrl+Shift+P`` 在匹配的括号之间跳转。
+- **代码折叠**：点击编辑器边栏中的折叠图标以折叠或展开内容。
+
+KConfig 条目示例
+~~~~~~~~~~~~~~~~
+
+下面是一个带有语法高亮的完整 KConfig 条目示例：
+
+.. code-block:: kconfig
+
+    config ESP32_WIFI_ENABLED
+        bool "Enable WiFi Support"
+        default y
+        depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2
+        select ESP32_WIFI
+        help
+            Enable WiFi support for ESP32 and ESP32-S2 chips.
+            
+            This option enables the WiFi driver and related functionality.
+            It requires the ESP32 or ESP32-S2 target to be selected.
+
+    config ESP32_WIFI_MAX_CONN_NUM
+        int "Maximum number of WiFi connections"
+        range 1 10
+        default 4
+        depends on ESP32_WIFI_ENABLED
+        help
+            Maximum number of concurrent WiFi connections supported.
+
+参考资料
+--------
+
+- `ESP-IDF KConfig 语言参考 <https://docs.espressif.com/projects/esp-idf-kconfig/en/latest/kconfiglib/language.html>`_
+- `KConfig 语言文档 <https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_
+- `Eclipse TM4E 文档 <https://github.com/eclipse/tm4e>`_


### PR DESCRIPTION
This PR:

- Provides CN translation for `kconfigeditor.rst`
- Related to https://github.com/espressif/idf-eclipse-plugin/pull/1327
- Closes [DOC-13245](https://jira.espressif.com:8443/browse/DOC-13245) once merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved KConfig Editor docs with consistent punctuation, typography, and clearer formatting for examples, usage, and feature descriptions.
  * Added comprehensive Chinese documentation and updated the Chinese toctree entry for the KConfig Editor.
  * Chinese and English docs now clearly describe syntax highlighting, content assist, auto-pairing, smart indentation, bracket matching, and code folding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->