### PR TITLE
IEP-1668 idf.py command not recognized in the Linux terminal 4.0.0

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleLauncherDelegate.java
@@ -16,6 +16,7 @@ package com.espressif.idf.terminal.connector.launcher;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -336,6 +337,13 @@ public class IDFConsoleLauncherDelegate extends AbstractLauncherDelegate {
 		//Removing path, since we are using PATH
 		if (envMap.containsKey("PATH") && envMap.containsKey("Path")) { //$NON-NLS-1$ //$NON-NLS-2$
 			envMap.remove("Path"); //$NON-NLS-1$
+		}
+		// Adding esp-idf/tools in the path if it's missing (IEP-1668)
+		String idfToolsPath = Paths.get(IDFUtil.getIDFPath(), "tools").toAbsolutePath().toString(); //$NON-NLS-1$
+		String currentPath = envMap.get("PATH"); //$NON-NLS-1$
+
+		if (currentPath != null && !currentPath.contains(idfToolsPath)) {
+			envMap.put("PATH", currentPath + File.pathSeparator + idfToolsPath); //$NON-NLS-1$
 		}
 
 		for (String envKey : keySet) {


### PR DESCRIPTION
## Description

Check if esp-idf/tools is in PATH and adding it if it's missing. Temporary workaround 

Fixes # ([IEP-1668](https://jira.espressif.com:8443/browse/IEP-1668))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling to ensure ESP-IDF tools directory is properly accessible in the system PATH when launching the terminal connector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->