### PR TITLE
IEP-1677 Low App Partition Size notification does not display link correctly

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -17,7 +17,7 @@ CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource.
 IDFBuildConfiguration_CMakeBuildConfiguration_NoToolchainFile=No toolchain file found
 IDFBuildConfiguration_ParseCommand=Parse Compile Commands File
 IncreasePartitionSizeTitle=Low Application Partition Size
-IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href={2}>here</a> to check more details.
+IncreasePartitionSizeMessage=Less than 30% of application partition size is free({0} of {1} bytes), would you like to increase it? Please click <a href="{2}">here</a> to check more details.
 ToolsInitializationDifferentPathMessageBoxTitle=Different IDF path found in the config file
 ToolsInitializationEimMissingMsgBoxTitle=ESP-IDF Installation Required
 ToolsInitializationEimMissingMsgBoxMessage=ESP-IDF is not currently installed on your system.\n\nThe IDE can automatically download and launch the EIM - GUI Installer to help you install it.\n\nWould you like to proceed with the installation?\n\nOnce complete, ESP-IDF will be detected automatically. You can also manage installations later from the ESP-IDF Manager (Espressif > ESP-IDF Manager). 


### PR DESCRIPTION
## Description

fixed this issue:
<img width="1422" height="640" alt="image" src="https://github.com/user-attachments/assets/7f95f3b4-1f80-4a46-bacf-bec3aa840333" />


Fixes # ([IEP-1677](https://jira.espressif.com:8443/browse/IEP-1677))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed href attribute formatting in partition size messages for proper link rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->