### PR TITLE
IEP-1691 Terminal throws error after IDE restarted

### DIFF
--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleMementoHandler.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFConsoleMementoHandler.java
@@ -23,17 +23,23 @@ import org.eclipse.ui.IMemento;
  */
 public class IDFConsoleMementoHandler implements IMementoHandler {
 
+	private static final String TERMINALS_VIEW_ID = "org.eclipse.terminal.view.ui.TerminalsView"; //$NON-NLS-1$
+	private static final String PROPERTY_ID = "id"; //$NON-NLS-1$
+
 	@Override
 	public void saveState(IMemento memento, Map<String, Object> properties) {
 		Assert.isNotNull(memento);
 		Assert.isNotNull(properties);
 	}
 
+
 	@Override
 	public void restoreState(IMemento memento, Map<String, Object> properties) {
 		Assert.isNotNull(memento);
 		Assert.isNotNull(properties);
-		Assert.isTrue("org.eclipse.tm.terminal.view.ui.TerminalsView".equals(memento.getID()), //$NON-NLS-1$
-				Messages.IDFConsoleMementoHandler_TerminalNameOutdatedMsg);
+
+		Object terminalId = properties.get(PROPERTY_ID);
+
+		Assert.isTrue(TERMINALS_VIEW_ID.equals(terminalId), Messages.IDFConsoleMementoHandler_TerminalNameOutdatedMsg);
 	}
 }


### PR DESCRIPTION
## Description

I left some code that was written for testing purposes. I’ve fixed it and made the assertion correct in this PR.

We expect to receive an outdated property_id when restoring the terminal right after upgrading from 4.0 to 4.1, so we show a meaningful message asking the user to close and reopen the terminal. After that, the terminal will restore its state correctly after each restart.

Fixes # ([IEP-1691](https://jira.espressif.com:8443/browse/IEP-1691))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Open the terminal in the 4.0 release → update the plugin to version 4.1 → restart the IDE → expect a meaningful error → close and reopen the terminal → restart the IDE → expect no error and a restored terminal.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

Terminal

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved terminal connector ID validation logic to use a property-based approach for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->