### PR TITLE
IEP-1695 Remove the JRE from the category.xml

### DIFF
--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -30,9 +30,6 @@
    <feature id="org.eclipse.tm4e.language_pack.feature">
       <category name="com.espressif.idf"/>
    </feature>
-   <feature id="org.eclipse.justj.openjdk.hotspot.jre.full">
-      <category name="com.espressif.idf.dependencies"/>
-   </feature>
    <feature id="org.eclipse.terminal.feature">
       <category name="com.espressif.idf.dependencies"/>
    </feature>


### PR DESCRIPTION
## Description

We started providing the JRE in the update site two years ago to simplify the process of upgrading Espressif-IDE/Eclipse from older to newer versions. However, the downside of this approach is a significant increase in the size of the update site.

Since Eclipse has officially required Java 21 for quite some time, we can assume that most users have already updated from older versions, and we can safely remove it.

Fixes # ([IEP-1695](https://jira.espressif.com:8443/browse/IEP-1695))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Java Development Kit feature from the update site dependencies configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->