### PR TITLE
IEP-1699: Use CDT build environment for idf_tools.py list command

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/update/AbstractToolsHandler.java
@@ -5,7 +5,6 @@
 package com.espressif.idf.ui.update;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -141,7 +140,7 @@ public abstract class AbstractToolsHandler extends AbstractHandler
 			console.println(cmdMsg);
 			Logger.log(cmdMsg);
 
-			Map<String, String> environment = new HashMap<>(System.getenv());
+			Map<String, String> environment = new IDFEnvironmentVariables().getSystemEnvMap();
 			Logger.log(environment.toString());
 			environment.put("PYTHONUNBUFFERED", "1"); //$NON-NLS-1$ //$NON-NLS-2$
 			


### PR DESCRIPTION
## Description

The AbstractToolsHandler.runCommand() was using System.getenv() which only
includes OS system environment variables, but not the CDT build environment
variables set by the IDE (like IDF_TOOLS_PATH).

Fixes # ([IEP-1699](https://jira.espressif.com:8443/browse/IEP-1699))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal environment setup process to use a unified method for system environment retrieval. No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->