### PR TITLE
Automate Update Site verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         path:
           tests/*/*/*/TEST-*.xml
         reporter: java-junit
-  
+
   build_macos:
     runs-on: macos-latest
 

--- a/.github/workflows/update-site-test.yml
+++ b/.github/workflows/update-site-test.yml
@@ -1,0 +1,81 @@
+name: ESP Eclipse Plug-in Update Site Test
+
+on:
+  push:
+    paths:
+      - 'releng/update-site-tests/**'
+      - '.github/workflows/update-site-tests.yml'
+  pull_request:
+    paths:
+      - 'releng/update-site-tests/**'
+      - '.github/workflows/update-site-tests.yml'
+  schedule:
+    # Runs every day at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-site-tests:
+    runs-on: [self-hosted, eclipse, BrnoUBU0004]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: |
+          chmod +x releng/update-site-tests/*.sh
+
+      - name: Run update-site test cases
+        run: |
+          cd releng/update-site-tests
+          ./run-all-cases.sh
+
+      - name: Publish workflow summary
+        if: always()
+        shell: bash
+        run: |
+          echo "# ESP Eclipse Plug-in Update Site Tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Test case | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+          for case_dir in releng/update-site-tests/out/*; do
+            [ -d "$case_dir" ] || continue
+            case_name="$(basename "$case_dir")"
+            runlog="$case_dir/logs/run.log"
+
+            if [ ! -f "$runlog" ]; then
+              echo "| $case_name | ⚠️ No log found |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            if grep -q "STATUS: PASSED" "$runlog"; then
+              status="✅ Passed"
+            elif grep -q "STATUS: FAILED" "$runlog"; then
+              status="❌ Failed"
+            elif grep -q "STATUS: SKIPPED" "$runlog"; then
+              reason="$(grep -m1 'SKIP_REASON:' "$runlog" | sed 's/SKIP_REASON: //')"
+
+              if [ -n "$reason" ]; then
+                status="⏭️ Skipped ($reason)"
+              else
+                status="⏭️ Skipped"
+              fi
+
+              else
+                status="⚠️ Unknown"
+              fi
+
+            echo "| $case_name | $status |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Full logs are available in workflow artifacts." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Update Site Test Results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: eclipse-update-site-test-results
+          path: releng/update-site-tests/out

--- a/releng/update-site-tests/detect-latest-eclipse-steams.sh
+++ b/releng/update-site-tests/detect-latest-eclipse-steams.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/variables.sh"
+
+echo "Fetching Eclipse release list from $RELEASE_XML"
+XML="$(curl -fsSL "$RELEASE_XML")"
+
+has_r_dir() {
+  local stream="$1"
+  local dir_url="$EPP_BASE/$stream/"
+
+  curl -fsSL "$dir_url" | grep -qE 'href="R/"|>R/'
+}
+
+select_stable_r_stream() {
+  local stream="$1"
+  local url="$EPP_BASE/$stream/R/eclipse-cpp-$stream-R-linux-gtk-x86_64.tar.gz"
+  local p2="https://download.eclipse.org/releases/$stream"
+
+  echo "Checking stream directory for official R/: $stream"
+  if ! has_r_dir "$stream"; then
+    echo "⚠️ No official R/ directory found for $stream"
+    return 1
+  fi
+
+  echo "Checking stable archive URL: $url"
+  if ! curl -fsI "$url" >/dev/null; then
+    echo "⚠️ R/ exists but archive is not reachable for $stream"
+    return 1
+  fi
+
+  ECLIPSE_R_RELEASE="$stream"
+  ECLIPSE_R_URL="$url"
+  ECLIPSE_R_P2="$p2"
+  return 0
+}
+
+mapfile -t ECLIPSE_R_RELEASES < <(
+  printf '%s\n' "$XML" \
+    | grep -oE '[0-9]{4}-[0-9]{2}/R([^A-Za-z0-9]|$)' \
+    | sed -E 's|/R([^A-Za-z0-9].*)?$||' \
+    | sort -r \
+    | uniq \
+    | head -n 2
+)
+
+# Latest milestone - optional
+ECLIPSE_M_RELEASE="$(
+  printf '%s\n' "$XML" \
+    | grep -oE '[0-9]{4}-[0-9]{2}/M[0-9]+' \
+    | sort -r \
+    | head -n1 || true
+)"
+
+# Latest RC - optional
+ECLIPSE_RC_RELEASE="$(
+  printf '%s\n' "$XML" \
+    | grep -oE '[0-9]{4}-[0-9]{2}/RC[0-9]+' \
+    | sort -r \
+    | head -n1 || true
+)"
+
+ECLIPSE_CASE3_STREAM="${ECLIPSE_M_RELEASE:-}"
+if [[ -n "${ECLIPSE_RC_RELEASE:-}" ]]; then
+  ECLIPSE_CASE3_STREAM="$ECLIPSE_RC_RELEASE"
+fi
+
+ECLIPSE_CASE3_URL=""
+ECLIPSE_CASE3_P2=""
+
+if [[ -n "${ECLIPSE_CASE3_STREAM:-}" ]]; then
+  CASE3_STREAM="${ECLIPSE_CASE3_STREAM%/*}"   # YYYY-MM
+  CASE3_TAG="${ECLIPSE_CASE3_STREAM#*/}"      # M* or RC*
+  ECLIPSE_CASE3_URL="$EPP_BASE/$CASE3_STREAM/$CASE3_TAG/eclipse-cpp-$CASE3_STREAM-$CASE3_TAG-linux-gtk-x86_64.tar.gz"
+  ECLIPSE_CASE3_P2="https://download.eclipse.org/releases/$CASE3_STREAM"
+else
+  echo "⚠️ No milestone or RC detected. Case 3 will be skipped."
+fi
+
+if [[ "${#ECLIPSE_R_RELEASES[@]}" -eq 0 ]]; then
+  echo "❌ Could not detect any /R release"
+  exit 1
+fi
+
+LATEST_R="${ECLIPSE_R_RELEASES[0]}"
+PREVIOUS_R="${ECLIPSE_R_RELEASES[1]:-}"
+
+if [[ -z "${ECLIPSE_M_RELEASE:-}" ]]; then
+  echo "⚠️ No latest milestone detected (/M*)."
+fi
+
+if [[ -z "${ECLIPSE_RC_RELEASE:-}" ]]; then
+  echo "⚠️ No latest RC detected (/RC*)."
+fi
+
+ECLIPSE_R_RELEASE=""
+ECLIPSE_R_URL=""
+ECLIPSE_R_P2=""
+
+echo "Trying latest stable R stream: $LATEST_R"
+if ! select_stable_r_stream "$LATEST_R"; then
+  if [[ -n "${PREVIOUS_R:-}" ]]; then
+    echo "Trying previous stable R stream: $PREVIOUS_R"
+    if ! select_stable_r_stream "$PREVIOUS_R"; then
+      echo "❌ Neither latest R nor previous R has a usable official archive"
+      exit 1
+    fi
+  else
+    echo "❌ No previous R stream found to fall back to"
+    exit 1
+  fi
+fi
+
+ECLIPSE_M_URL=""
+ECLIPSE_M_P2=""
+
+if [[ -n "${ECLIPSE_M_RELEASE:-}" ]]; then
+  STREAM="${ECLIPSE_M_RELEASE%/*}"     # 2026-03
+  M_TAG="${ECLIPSE_M_RELEASE#*/}"      # M2
+  ECLIPSE_M_URL="$EPP_BASE/$STREAM/$M_TAG/eclipse-cpp-$STREAM-$M_TAG-linux-gtk-x86_64.tar.gz"
+  ECLIPSE_M_P2="https://download.eclipse.org/releases/$STREAM"
+fi
+
+# Verify Case 3 URL exists - if unreachable, skip Case 3
+if [[ -n "${ECLIPSE_CASE3_URL:-}" ]]; then
+  if ! curl -fsI "$ECLIPSE_CASE3_URL" >/dev/null; then
+    echo "⚠️ Case 3 pre-release archive not reachable. Case 3 will be skipped."
+    ECLIPSE_CASE3_STREAM=""
+    ECLIPSE_CASE3_URL=""
+    ECLIPSE_CASE3_P2=""
+  fi
+fi
+
+# -------- Espressif-IDE stable version (tags) --------
+echo "Detecting latest *stable* Espressif-IDE tag..."
+TAGS_JSON="$(curl -fsSL "$IEP_TAGS_API")"
+
+ESP_IDE_TAG="$(
+  printf '%s\n' "$TAGS_JSON" \
+    | grep -oE '"name":[[:space:]]*"v?[0-9]+\.[0-9]+\.[0-9]+"' \
+    | sed -E 's/.*"name":[[:space:]]*"([^"]+)".*/\1/' \
+    | head -n1
+)"
+
+if [[ -z "${ESP_IDE_TAG:-}" ]]; then
+  echo "❌ Could not detect stable Espressif-IDE tag (vX.Y.Z)"
+  exit 1
+fi
+
+ESP_IDE_VERSION="${ESP_IDE_TAG#v}"
+ESPRESSIF_IDE_URL="$ESP_IDE_BASE/Espressif-IDE-${ESP_IDE_VERSION}-linux.gtk.x86_64.tar.gz"
+
+echo "Verifying Espressif-IDE archive exists..."
+if ! curl -sfI "$ESPRESSIF_IDE_URL" >/dev/null; then
+  echo "⚠️ Could not verify Espressif-IDE archive URL. Continuing anyway."
+fi
+
+export ECLIPSE_R_RELEASE ECLIPSE_R_URL ECLIPSE_R_P2
+export ECLIPSE_M_RELEASE ECLIPSE_RC_RELEASE
+export ECLIPSE_CASE3_STREAM ECLIPSE_CASE3_URL ECLIPSE_CASE3_P2
+export ESP_IDE_VERSION ESPRESSIF_IDE_URL
+
+echo "✅ Latest stable Eclipse: $ECLIPSE_R_RELEASE"
+echo "✅ Stable URL: $ECLIPSE_R_URL"
+echo "✅ Stable P2:  $ECLIPSE_R_P2"
+echo "✅ Latest milestone Eclipse: ${ECLIPSE_M_RELEASE:-<none>}"
+echo "✅ Latest RC Eclipse:        ${ECLIPSE_RC_RELEASE:-<none>}"
+echo "✅ Case 3 pre-release pick:  ${ECLIPSE_CASE3_STREAM:-<none>}"
+if [[ -n "${ECLIPSE_CASE3_STREAM:-}" ]]; then
+  echo "✅ Case 3 URL: $ECLIPSE_CASE3_URL"
+  echo "✅ Case 3 P2:  $ECLIPSE_CASE3_P2"
+fi
+echo "✅ Espressif-IDE version: $ESP_IDE_VERSION"
+echo "✅ Espressif-IDE URL: $ESPRESSIF_IDE_URL"

--- a/releng/update-site-tests/run-all-cases.sh
+++ b/releng/update-site-tests/run-all-cases.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTROOT="$ROOT_DIR/out"
+WORKROOT="$ROOT_DIR/workdir"
+
+rm -rf "$OUTROOT" "$WORKROOT"
+mkdir -p "$OUTROOT" "$WORKROOT"
+
+# Populate:
+# ECLIPSE_R_URL, ECLIPSE_R_P2, and optionally ECLIPSE_M_RELEASE/ECLIPSE_M_URL/ECLIPSE_M_P2
+# shellcheck source=/dev/null
+source "$ROOT_DIR/detect-latest-eclipse-steams.sh"
+source "$ROOT_DIR/variables.sh"
+
+export IEP_STABLE_REPO
+export IEP_DEV_REPO
+
+FAIL=0
+
+echo "=== Case 1: Plain Eclipse (latest R) + stable IEP install ==="
+
+if CASE_ID="case1-Eclipse-R-install-stable" \
+   BASE_PRODUCT="eclipse-cdt" \
+   ECLIPSE_URL="$ECLIPSE_R_URL" \
+   ECLIPSE_P2_REPO="$ECLIPSE_R_P2" \
+   DO_DEV_UPDATE=0 \
+   WORKROOT="$WORKROOT" OUTROOT="$OUTROOT" \
+   bash "$ROOT_DIR/run-single-case.sh"; then
+
+  echo "✅ Test Case 1 completed successfully"
+
+else
+  echo "❌ Test Case 1 FAILED"
+  FAIL=1
+fi
+
+echo "=== Case 2: Plain Eclipse (latest R) stable -> dev update ==="
+
+if CASE_ID="case2-Eclipse-R-stable-to-nightly" \
+   BASE_PRODUCT="eclipse-cdt" \
+   ECLIPSE_URL="$ECLIPSE_R_URL" \
+   ECLIPSE_P2_REPO="$ECLIPSE_R_P2" \
+   DO_DEV_UPDATE=1 \
+   WORKROOT="$WORKROOT" OUTROOT="$OUTROOT" \
+   bash "$ROOT_DIR/run-single-case.sh"; then
+
+  echo "✅ Test Case 2 completed successfully"
+
+else
+  echo "❌ Test Case 2 FAILED"
+  FAIL=1
+fi
+
+echo "=== Case 3: Eclipse (latest pre-release) stable -> dev update ==="
+
+CASE3_ID="case3-Eclipse-RC-Milestone-to-nightly"
+CASE3_DIR="$OUTROOT/$CASE3_ID"
+CASE3_LOGDIR="$CASE3_DIR/logs"
+CASE3_RUNLOG="$CASE3_LOGDIR/run.log"
+
+if [[ -n "${ECLIPSE_CASE3_STREAM:-}" && -n "${ECLIPSE_CASE3_URL:-}" && -n "${ECLIPSE_CASE3_P2:-}" ]]; then
+
+  if CASE_ID="$CASE3_ID" \
+     BASE_PRODUCT="eclipse-cdt" \
+     ECLIPSE_URL="$ECLIPSE_CASE3_URL" \
+     ECLIPSE_P2_REPO="$ECLIPSE_CASE3_P2" \
+     DO_DEV_UPDATE=1 \
+     WORKROOT="$WORKROOT" OUTROOT="$OUTROOT" \
+     bash "$ROOT_DIR/run-single-case.sh"; then
+
+      echo "✅ Test Case 3 completed successfully"
+
+  else
+      echo "❌ Test Case 3 FAILED"
+      FAIL=1
+  fi
+
+else
+  mkdir -p "$CASE3_LOGDIR"
+
+  {
+    echo "=== [$CASE3_ID] Starting case ==="
+    echo "Base product: eclipse-cdt"
+    echo ""
+    echo "SKIP_REASON: No Eclipse RC or Milestone found"
+    echo "Case 3 requires a pre-release Eclipse stream (M* or RC*)."
+    echo "Therefore this test case was skipped."
+    echo ""
+    echo "STATUS: SKIPPED"
+  } > "$CASE3_RUNLOG"
+
+  echo "⚠️ Skipping Case 3 (no milestone/RC detected)."
+fi
+
+echo "=== Preparing Espressif-IDE (latest stable) for Case 4 ==="
+: "${ESP_IDE_VERSION:?ESP_IDE_VERSION not set by detection script}"
+: "${ESPRESSIF_IDE_URL:?ESPRESSIF_IDE_URL not set by detection script}"
+
+ESP_IDE_WORK="$WORKROOT/espressif-ide-${ESP_IDE_VERSION}"
+rm -rf "$ESP_IDE_WORK"
+mkdir -p "$ESP_IDE_WORK"
+
+echo "Downloading Espressif-IDE from: $ESPRESSIF_IDE_URL"
+curl -fsSL "$ESPRESSIF_IDE_URL" -o "$ESP_IDE_WORK/espressif-ide.tar.gz"
+
+echo "Extracting Espressif-IDE..."
+tar -xzf "$ESP_IDE_WORK/espressif-ide.tar.gz" -C "$ESP_IDE_WORK" \
+  2> >(grep -v "LIBARCHIVE.creationtime" >&2)
+
+# Figure out where the eclipse executable is after extraction
+# Usually archive contains a top-level "eclipse/" directory
+if [[ -x "$ESP_IDE_WORK/Espressif-IDE/espressif-ide" ]]; then
+  export ESPRESSIF_IDE_SOURCE="$ESP_IDE_WORK/Espressif-IDE"
+else
+  # fallback: search for an eclipse executable
+  FOUND_IDE="$(find "$ESP_IDE_WORK" -maxdepth 4 -type f -name espressif-ide -perm -111 | head -n1 || true)"
+  if [[ -z "$FOUND_IDE" ]]; then
+    echo "❌ Could not locate 'espressif-ide' launcher inside extracted Espressif-IDE."
+    echo "Top-level contents:"
+    ls -la "$ESP_IDE_WORK"
+    exit 1
+  fi
+  export ESPRESSIF_IDE_SOURCE="$(dirname "$FOUND_IDE")"
+fi
+
+echo "ESPRESSIF_IDE_SOURCE resolved to: $ESPRESSIF_IDE_SOURCE"
+test -x "$ESPRESSIF_IDE_SOURCE/espressif-ide" || { echo "❌ Invalid ESPRESSIF_IDE_SOURCE: $ESPRESSIF_IDE_SOURCE"; exit 1; }
+
+echo "=== Case 4: Espressif-IDE stable -> dev update ==="
+: "${ESPRESSIF_IDE_SOURCE:?Provide ESPRESSIF_IDE_SOURCE for Case 4 (path to extracted IDE root)}"
+
+if CASE_ID="case4-Espressif-IDE-stable-to-nightly" \
+   BASE_PRODUCT="espressif-ide" \
+   DO_DEV_UPDATE=1 \
+   SKIP_STABLE_INSTALL=1 \
+   ESPRESSIF_IDE_SOURCE="$ESPRESSIF_IDE_SOURCE" \
+   WORKROOT="$WORKROOT" OUTROOT="$OUTROOT" \
+   bash "$ROOT_DIR/run-single-case.sh"; then
+
+  echo "✅ Test Case 4 completed successfully"
+
+else
+  echo "❌ Test Case 4 FAILED"
+  FAIL=1
+fi
+
+echo ""
+echo "All cases finished. Artifacts in: $OUTROOT"
+exit "$FAIL"

--- a/releng/update-site-tests/run-single-case.sh
+++ b/releng/update-site-tests/run-single-case.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+set -euo pipefail
+
+CASE_ID="${CASE_ID:?CASE_ID not set}"
+BASE_PRODUCT="${BASE_PRODUCT:?BASE_PRODUCT not set}"
+ECLIPSE_URL="${ECLIPSE_URL:-}"
+ECLIPSE_P2_REPO="${ECLIPSE_P2_REPO:-}"
+
+IEP_STABLE_REPO="${IEP_STABLE_REPO:?IEP_STABLE_REPO not set}"
+IEP_DEV_REPO="${IEP_DEV_REPO:?IEP_DEV_REPO not set}"
+FEATURE_ID="${FEATURE_ID:-com.espressif.idf.feature.feature.group}"
+
+ROOT_DIR="$(pwd)/releng/update-site-tests"
+WORKROOT="${WORKROOT:-$ROOT_DIR/workdir}"
+OUTROOT="${OUTROOT:-$ROOT_DIR/out}"
+
+CASE_DIR="$OUTROOT/$CASE_ID"
+LOGDIR="$CASE_DIR/logs"
+WORKDIR="$WORKROOT/$CASE_ID"
+
+mkdir -p "$LOGDIR" "$WORKDIR"
+
+RUNLOG="$LOGDIR/run.log"
+exec > >(tee -a "$RUNLOG") 2>&1
+
+echo "=== [$CASE_ID] Starting case ==="
+echo "Base product: $BASE_PRODUCT"
+
+# Build the base installation into "$WORKDIR/eclipse"
+ECLIPSE_HOME="$WORKDIR/eclipse"
+
+if [[ "$BASE_PRODUCT" == "eclipse-cdt" ]]; then
+  : "${ECLIPSE_URL:?ECLIPSE_URL required for eclipse-cdt}"
+  echo "Downloading Eclipse from: $ECLIPSE_URL"
+  curl -fsSL "$ECLIPSE_URL" -o "$WORKDIR/eclipse.tar.gz"
+  tar -xzf "$WORKDIR/eclipse.tar.gz" -C "$WORKDIR"
+
+  if [[ -x "$WORKDIR/eclipse/eclipse" ]]; then
+    ECLIPSE_HOME="$WORKDIR/eclipse"
+  else
+    ECLIPSE_EXE="$(find "$WORKDIR" -maxdepth 3 -type f -name eclipse -perm -111 | head -n1 || true)"
+    [[ -n "$ECLIPSE_EXE" ]] || { echo "❌ Eclipse executable not found after extraction"; exit 1; }
+    ECLIPSE_HOME="$(dirname "$ECLIPSE_EXE")"
+  fi
+
+elif [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+  : "${ESPRESSIF_IDE_SOURCE:?ESPRESSIF_IDE_SOURCE not set (path to preinstalled IDE or extracted IDE root)}"
+  echo "Copying Espressif-IDE from: $ESPRESSIF_IDE_SOURCE"
+  mkdir -p "$ECLIPSE_HOME"
+  cp -a "$ESPRESSIF_IDE_SOURCE"/. "$ECLIPSE_HOME"/
+else
+  echo "Unknown BASE_PRODUCT: $BASE_PRODUCT"
+  exit 1
+fi
+
+echo "ECLIPSE_HOME=$ECLIPSE_HOME"
+
+if [[ -x "$ECLIPSE_HOME/eclipse" ]]; then
+  LAUNCHER="$ECLIPSE_HOME/eclipse"
+elif [[ -x "$ECLIPSE_HOME/espressif-ide" ]]; then
+  LAUNCHER="$ECLIPSE_HOME/espressif-ide"
+else
+  echo "❌ No launcher found in $ECLIPSE_HOME (expected 'eclipse' or 'espressif-ide')"
+  ls -la "$ECLIPSE_HOME" || true
+  exit 1
+fi
+echo "Using launcher: $LAUNCHER"
+
+JAVA_LAUNCHER=""
+EQUINOX_LAUNCHER_JAR=""
+
+if [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+  EQUINOX_LAUNCHER_JAR="$(find "$ECLIPSE_HOME/plugins" -maxdepth 1 -name 'org.eclipse.equinox.launcher_*.jar' | head -n1 || true)"
+  [[ -n "$EQUINOX_LAUNCHER_JAR" ]] || { echo "❌ Equinox launcher jar not found under $ECLIPSE_HOME/plugins"; exit 1; }
+
+  JAVA_LAUNCHER=( java -jar "$EQUINOX_LAUNCHER_JAR" )
+  echo "Using Equinox launcher jar for Espressif-IDE: $EQUINOX_LAUNCHER_JAR"
+fi
+
+# Common director flags: IMPORTANT to keep same destination/profile/bundlepool across steps
+P2_DEST_ARGS=( -destination "$ECLIPSE_HOME" -profile SDKProfile -bundlepool "$WORKDIR/p2" -roaming )
+WORKSPACE_DIR="$WORKDIR/workspace"
+mkdir -p "$WORKSPACE_DIR"
+
+build_repo_list() {
+  local primary="$1"
+  local extra="${2:-}"
+  if [[ -n "$extra" ]]; then
+    echo "$primary,$extra"
+  else
+    echo "$primary"
+  fi
+}
+
+install_iu () {
+  local repo="$1"
+
+  if [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+    "${JAVA_LAUNCHER[@]}" \
+      -clean \
+      -nosplash \
+      -data "$WORKSPACE_DIR" \
+      -application org.eclipse.equinox.p2.director \
+      -repository "$repo" \
+      -installIU "$FEATURE_ID" \
+      -consoleLog
+  else
+    "$LAUNCHER" \
+      -nosplash \
+      -application org.eclipse.equinox.p2.director \
+      -repository "$repo" \
+      -installIU "$FEATURE_ID" \
+      "${P2_DEST_ARGS[@]}" \
+      -consoleLog
+  fi
+}
+
+replace_iu () {
+  local repo="$1"
+
+  if [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+    "${JAVA_LAUNCHER[@]}" \
+      -clean \
+      -nosplash \
+      -data "$WORKSPACE_DIR" \
+      -application org.eclipse.equinox.p2.director \
+      -repository "$repo" \
+      -uninstallIU "$FEATURE_ID" \
+      -installIU "$FEATURE_ID" \
+      -consoleLog
+  else
+    "$LAUNCHER" \
+      -nosplash \
+      -application org.eclipse.equinox.p2.director \
+      -repository "$repo" \
+      -uninstallIU "$FEATURE_ID" \
+      -installIU "$FEATURE_ID" \
+      "${P2_DEST_ARGS[@]}" \
+      -consoleLog
+  fi
+}
+
+list_ius () {
+  local out="$1"
+
+  if [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+    "${JAVA_LAUNCHER[@]}" \
+      -clean \
+      -nosplash \
+      -data "$WORKSPACE_DIR" \
+      -application org.eclipse.equinox.p2.director \
+      -list \
+      -consoleLog \
+      > "$LOGDIR/$out" 2>&1 || true
+  else
+    "$LAUNCHER" \
+      -nosplash \
+      -application org.eclipse.equinox.p2.director \
+      -list \
+      "${P2_DEST_ARGS[@]}" \
+      -consoleLog \
+      > "$LOGDIR/$out" 2>&1 || true
+  fi
+}
+
+list_roots () {
+  local out="$1"
+
+  if [[ "$BASE_PRODUCT" == "espressif-ide" ]]; then
+    "${JAVA_LAUNCHER[@]}" \
+      -clean \
+      -nosplash \
+      -data "$WORKSPACE_DIR" \
+      -application org.eclipse.equinox.p2.director \
+      -listInstalledRoots \
+      "${P2_DEST_ARGS[@]}" \
+      -consoleLog \
+      > "$LOGDIR/$out" 2>&1 || true
+  else
+    "$LAUNCHER" \
+      -nosplash \
+      -application org.eclipse.equinox.p2.director \
+      -listInstalledRoots \
+      "${P2_DEST_ARGS[@]}" \
+      -consoleLog \
+      > "$LOGDIR/$out" 2>&1 || true
+  fi
+}
+
+# --- Step A: install stable ---
+if [[ "${SKIP_STABLE_INSTALL:-0}" != "1" ]]; then
+  echo "Installing STABLE from $IEP_STABLE_REPO"
+  install_iu "$(build_repo_list "$IEP_STABLE_REPO" "${ECLIPSE_P2_REPO:-}")"
+else
+  echo "Skipping STABLE install (SKIP_STABLE_INSTALL=1)"
+fi
+
+# --- Step B: optional update to dev/nightly ---
+if [[ "${DO_DEV_UPDATE:-0}" == "1" ]]; then
+  echo "Updating to DEV/NIGHTLY from $IEP_DEV_REPO"
+  replace_iu "$(build_repo_list "$IEP_DEV_REPO" "${ECLIPSE_P2_REPO:-}")"
+fi
+
+# Diagnostics (kept as small separate files)
+list_ius "installed-ius.txt"
+list_roots "installed-roots.txt"
+
+# Conflict scan (from combined log)
+ERROR_PATTERNS='conflict|cannot complete|missing requirement|Only one of the following can be installed'
+if grep -Ein "$ERROR_PATTERNS" "$RUNLOG" >/dev/null 2>&1; then
+  HAS_CONFLICTS=1
+else
+  HAS_CONFLICTS=0
+fi
+
+# Summary
+echo ""
+echo "ESP Eclipse Plug-in Update Path Summary"
+echo "======================================="
+echo ""
+echo "Case: $CASE_ID"
+echo "Base product: $BASE_PRODUCT"
+[[ -n "${ECLIPSE_P2_REPO:-}" ]] && echo "Eclipse P2 repo: $ECLIPSE_P2_REPO"
+[[ -n "${ECLIPSE_URL:-}" ]] && echo "Eclipse URL: $ECLIPSE_URL"
+echo ""
+echo "IEP stable repo:  $IEP_STABLE_REPO"
+echo "IEP dev repo:     $IEP_DEV_REPO"
+echo ""
+
+ERROR_PATTERNS='conflict|cannot complete|missing requirement|Only one of the following can be installed'
+if grep -Ein "$ERROR_PATTERNS" "$RUNLOG" >/dev/null 2>&1; then
+  echo "Conflicts (grep scan in logs/run.log):"
+  echo "Found (see above in run.log)"
+  echo ""
+  echo "STATUS: FAILED"
+  exit 2
+else
+  echo "Conflicts (grep scan in logs/run.log):"
+  echo "None"
+  echo ""
+  echo "STATUS: PASSED"
+  exit 0
+fi

--- a/releng/update-site-tests/variables.sh
+++ b/releng/update-site-tests/variables.sh
@@ -1,0 +1,11 @@
+# Eclipse release metadata URLs (used to detect latest stable R release, milestone, RC, etc.)
+RELEASE_XML="https://ftp2.osuosl.org/pub/eclipse/technology/epp/downloads/release/release.xml"
+EPP_BASE="https://ftp2.osuosl.org/pub/eclipse/technology/epp/downloads/release"
+
+# Espressif-IDE / plugin metadata URLs
+IEP_TAGS_API="https://api.github.com/repos/espressif/idf-eclipse-plugin/tags"
+ESP_IDE_BASE="https://dl.espressif.com/dl/idf-eclipse-plugin/ide"
+
+# IEP update site URLs
+IEP_STABLE_REPO="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/"
+IEP_DEV_REPO="https://dl.espressif.com/dl/idf-eclipse-plugin/updates/nightly/"


### PR DESCRIPTION
## Description

This PR introduces automated update-path testing for Espressif-IDE and Eclipse-based setups using the p2 director on Linux runner.
It validates installation and update flows across multiple scenarios, including stable and nightly update paths.

Fixes # ([IEP-1685](https://jira.espressif.com:8443/browse/IEP-1685))


│   └── update-site-tests/
│       │
│       ├── variables.sh
│       │   # root config:
│       │   # - URLs (Eclipse, Espressif)
│       │   # - update sites
│       │
│       ├── detect-latest-eclipse-steams.sh
│       │   # - parses release.xml
│       │   # - detects latest R / M / RC
│       │   # - forms  URLs
│       │   # - exports variables
│       │
│       ├── run-all-cases.sh
│       │   # orchestrator
│       │   # - runs Case 1–4
│       │   # - prepares env
│       │   # - download Espressif-IDE
│       │
│       ├── run-single-case.sh
│       │   # case executor
│       │   # - install Eclipse / IDE
│       │   # - executes installIU / update
│       │   # - writes run.log
│       │
│       ├── out/
│       │   └── case*/
│       │       └── logs/
│       │           ├── run.log
│       │           ├── installed-ius.txt
│       │           └── installed-roots.txt

Scheduled daily execution at 00:00 UTC.

**Case 1:** Eclipse (latest R) → install stable plugin
**Case 2:** Eclipse (latest R) → install stable → update to nightly
**Case 3:** Eclipse (latest pre-release: M/RC) → install stable → update to nightly. ⚠️ optional test case (based on Milestone / Release Candidate availability) ⚠️
**Case 4:** Espressif-IDE (bundled) → update to nightly

**Results:**
Each test case produces:

run.log – full execution log
installed-ius.txt
installed-roots.txt
https://github.com/espressif/idf-eclipse-plugin/actions/runs/23256402453?pr=1397

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated Eclipse plugin upgrade test that installs stable and RC builds, checks for conflicts, verifies startup, and writes a structured success/failure report.

* **Chores**
  * CI Linux builds now run the upgrade test and always archive detailed logs and a summary report.
  * The active Maven build step in the Linux CI sequence has been disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->