### PR TITLE
IEP-1720: ci(macos) switch to release-sign action for code signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 21
       uses: actions/setup-java@v4
@@ -106,35 +106,28 @@ jobs:
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-${{ env.VERSION }}-linux.gtk.aarch64.tar.gz
   
     - name: Codesign Espressif-IDE
-      env: 
-        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-        MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-      run: |
-        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-        /usr/bin/security create-keychain -p espressif build.keychain
-        /usr/bin/security default-keychain -s build.keychain
-        /usr/bin/security unlock-keychain -p espressif build.keychain
-        /usr/bin/security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-        /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
-        
-        echo "codesigning espressif-ide-macosx.cocoa.x86_64"
-        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app -v
-        /usr/bin/codesign -v -vvv --deep $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/x86_64/Espressif-IDE.app
+      uses: espressif/release-sign@master
+      with:
+        path: releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa
+        macos-signing-identity: ${{ secrets.MACOS_CS_IDENTITY_ID }}
+        macos-certificate: ${{ secrets.MACOS_CS_CERTIFICATE }}
+        macos-certificate-pwd: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+        macos-entitlements: releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement
 
-        echo "codesigning espressif-ide-macosx.cocoa.aarch64"
-        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/aarch64/Espressif-IDE.app -v
-        /usr/bin/codesign -v -vvv --deep $PWD/releng/com.espressif.idf.product/target/products/com.espressif.idf.product/macosx/cocoa/aarch64/Espressif-IDE.app
-        
-        echo "Creating dmg for espressif-ide-macosx.cocoa.x86_64"
-        $PWD/releng/ide-dmg-builder/ide-dmg-builder.sh
-        /usr/bin/codesign --entitlements $PWD/releng/com.espressif.idf.product/entitlements/espressif-ide.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg -v
-        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
-      
-        echo "Creating dmg for espressif-ide-macosx.cocoa.aarch64"
-        $PWD/releng/ide-dmg-builder/ide-dmg-builder-aarch64.sh
-        /usr/bin/codesign --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg -v
-        /usr/bin/codesign -v -vvv --deep $PWD/releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg
-      
+    - name: Create DMG for macOS x86_64
+      run: $PWD/releng/ide-dmg-builder/ide-dmg-builder.sh
+
+    - name: Create DMG for macOS aarch64
+      run: $PWD/releng/ide-dmg-builder/ide-dmg-builder-aarch64.sh
+
+    - name: Codesign Espressif-IDE
+      uses: espressif/release-sign@master
+      with:
+        path: releng/ide-dmg-builder
+        macos-signing-identity: ${{ secrets.MACOS_CS_IDENTITY_ID }}
+        macos-certificate: ${{ secrets.MACOS_CS_CERTIFICATE }}
+        macos-certificate-pwd: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+
     - name: Upload espressif-ide-macosx.cocoa.x86_64 dmg
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

ci(macos): switch to release-sign action for code signing


Fixes # ([IEP-1720](https://jira.espressif.com:8443/browse/IEP-1720))

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS application signing and packaging processes.
  * Updated build infrastructure dependencies for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->