### PR TITLE
IEP-1724: SWT resource leaks and disposal crashes in IDF Size Analysis Editor

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeAnalysisEditor.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeAnalysisEditor.java
@@ -150,7 +150,15 @@ public class IDFSizeAnalysisEditor extends MultiPageEditorPart
 
 		// Apply bold style to default system font
 		FontDescriptor boldFontDescriptor = FontDescriptor.createFrom(title.getFont()).setStyle(SWT.BOLD);
-		title.setFont(boldFontDescriptor.createFont(parent.getDisplay()));
+		Font boldFont = boldFontDescriptor.createFont(parent.getDisplay());
+		title.setFont(boldFont);
+		
+		title.addDisposeListener(e -> {
+			if (boldFont != null && !boldFont.isDisposed())
+			{
+				boldFont.dispose();
+			}
+		});
 
 		// Subtext explanation
 		Label explanation = new Label(parent, SWT.CENTER | SWT.WRAP);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeChartsComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeChartsComposite.java
@@ -146,6 +146,11 @@ public class IDFSizeChartsComposite
 
 	private void plotCharts()
 	{
+		if (chartComp == null || chartComp.isDisposed()) 
+		{
+			return;
+		}
+		
 		for (var child : chartComp.getChildren())
 			child.dispose();
 
@@ -310,6 +315,12 @@ public class IDFSizeChartsComposite
 			Image swtImg = new Image(parent.getDisplay(), imgData);
 			Label imgLabel = new Label(parent, SWT.NONE);
 			imgLabel.setImage(swtImg);
+			imgLabel.addDisposeListener(e -> {
+				if (swtImg != null && !swtImg.isDisposed())
+				{
+					swtImg.dispose();
+				}
+			});
 		}
 		catch (Exception e)
 		{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/size/IDFSizeOverviewComposite.java
@@ -4,6 +4,9 @@
  *******************************************************************************/
 package com.espressif.idf.ui.size;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.TableEditor;
@@ -35,6 +38,7 @@ public class IDFSizeOverviewComposite
 	private Table table;
 	private JSONObject overviewJson;
 	private Font boldFont;
+	private List<TableEditor> tableEditors = new ArrayList<>();
 
 	private enum MemoryUnit
 	{
@@ -113,10 +117,28 @@ public class IDFSizeOverviewComposite
 		// Bold header
 		Font headerFont = applyBold(table.getFont());
 		table.setFont(headerFont);
+		parent.addDisposeListener(e -> {
+			if (boldFont != null && !boldFont.isDisposed())
+			{
+				boldFont.dispose();
+			}
+		});
 	}
 
 	private void populateTable()
 	{
+		if (table == null || table.isDisposed()) return;
+		
+		for (TableEditor editor : tableEditors)
+		{
+			if (editor.getEditor() != null && !editor.getEditor().isDisposed())
+			{
+				editor.getEditor().dispose(); 
+			}
+			editor.dispose(); 
+		}
+		tableEditors.clear();
+		
 		table.removeAll();
 
 		// Defensive check: Handle unexpected empty data gracefully to prevent UI crash.
@@ -175,6 +197,7 @@ public class IDFSizeOverviewComposite
 			return;
 
 		TableEditor editor = new TableEditor(table);
+		tableEditors.add(editor);
 		editor.grabHorizontal = true;
 		editor.grabVertical = true;
 		editor.horizontalAlignment = SWT.FILL;


### PR DESCRIPTION
## Description

During testing of the application size analysis, I noticed some SWT exceptions and discovered resource leaks that are addressed in this PR.

Fixes # ([IEP-1724](https://jira.espressif.com:8443/browse/IEP-1724))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Open Activity Monitor and run the application size analysis. Go to Charts and click “Switch to …”. The error log should contain no SWT exceptions, and there should be no significant increase in memory usage.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Application Size Analysis Editor

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management in the Size Analysis feature by ensuring UI components are properly cleaned up when no longer needed, preventing memory leaks and enhancing application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->