### PR TITLE
IEP-1534 DEPRECATED! use 'gdb port', not 'gdb_port'

### DIFF
--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -16,6 +16,8 @@ package com.espressif.idf.debug.gdbjtag.openocd;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
 import org.eclipse.cdt.debug.gdbjtag.core.IGDBJtagConstants;
@@ -89,10 +91,16 @@ public class Configuration
 				return null;
 
 			String executable = getGdbServerCommand(configuration, null);
-			if (executable == null || executable.length() == 0)
+			if (executable == null || executable.isEmpty())
 				return null;
 
+
 			lst.add(executable);
+
+			boolean useModernSyntax = useModernPortSyntax(executable);
+			String fmtGdbPort = useModernSyntax ? "gdb port %d" : "gdb_port %d"; //$NON-NLS-1$ //$NON-NLS-2$
+			String fmtTelnetPort = useModernSyntax ? "telnet port %d" : "telnet_port %d"; //$NON-NLS-1$ //$NON-NLS-2$
+			String fmtTclPort = useModernSyntax ? "tcl port %d" : "tcl_port %d"; //$NON-NLS-1$ //$NON-NLS-2$
 
 			int port = PortChecker
 					.getAvailablePort(DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
@@ -102,21 +110,21 @@ public class Configuration
 			configurationWorkingCopy.doSave();
 			
 			lst.add("-c"); //$NON-NLS-1$
-			lst.add("gdb_port " + port); //$NON-NLS-1$
+			lst.add(String.format(fmtGdbPort, port));
 
 			port = PortChecker
 					.getAvailablePort(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
 							DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT));
 
 			lst.add("-c"); //$NON-NLS-1$
-			lst.add("telnet_port " + port); //$NON-NLS-1$
+			lst.add(String.format(fmtTelnetPort, port));
 
 			port = PortChecker.getAvailablePort(
 					Integer.parseInt(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
 							DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT)));
 
 			lst.add("-c"); //$NON-NLS-1$
-			lst.add("tcl_port " + port); //$NON-NLS-1$
+			lst.add(String.format(fmtTclPort, port));
 
 			String other = configuration
 					.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
@@ -322,4 +330,34 @@ public class Configuration
 	}
 
 	// ------------------------------------------------------------------------
+
+	private static boolean useModernPortSyntax(String executablePath)
+	{
+		if (executablePath == null)
+		{
+			return false;
+		}
+
+		Pattern pattern = Pattern.compile("v(\\d+)\\.(\\d+)\\.\\d+-esp32-\\d{8}"); //$NON-NLS-1$
+		Matcher matcher = pattern.matcher(executablePath);
+
+		if (matcher.find())
+		{
+			try
+			{
+				int major = Integer.parseInt(matcher.group(1));
+				int minor = Integer.parseInt(matcher.group(2));
+
+				if (major > 0 || (major == 0 && minor >= 12))
+				{
+					return true;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				Activator.log(e);
+			}
+		}
+		return false;
+	}
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -352,6 +352,11 @@ public class Configuration
 
 			try
 			{
+				if (!process.waitFor(2, TimeUnit.SECONDS))
+				{
+					return false;
+				}
+
 				try (BufferedReader reader = process.inputReader())
 				{
 					return reader.lines().map(outputPattern::matcher).filter(Matcher::find).findFirst().map(matcher -> {
@@ -364,29 +369,22 @@ public class Configuration
 			{
 				if (process.isAlive())
 				{
-					process.destroy();
-
-					if (!process.waitFor(500, TimeUnit.MILLISECONDS))
-					{
-						process.destroyForcibly();
-					}
+					process.destroyForcibly();
 				}
 			}
 		}
-		catch (
-				IOException
-				| NumberFormatException e)
+		catch (IOException e)
 		{
 			Activator.log(new CoreException(new Status(IStatus.WARNING, Activator.PLUGIN_ID,
 					"Failed to execute or parse OpenOCD version fallback for path: " + executablePath, e))); //$NON-NLS-1$
+			return false;
 		}
 		catch (InterruptedException e)
 		{
 			Thread.currentThread().interrupt();
 			Activator.log(new CoreException(new Status(IStatus.WARNING, Activator.PLUGIN_ID,
 					"Thread was interrupted while waiting for OpenOCD process to exit.", e))); //$NON-NLS-1$
+			return false;
 		}
-
-		return false;
 	}
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -14,8 +14,11 @@
 
 package com.espressif.idf.debug.gdbjtag.openocd;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,7 +29,9 @@ import org.eclipse.cdt.dsf.gdb.IGdbDebugPreferenceConstants;
 import org.eclipse.cdt.dsf.gdb.internal.GdbPlugin;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.embedcdt.core.EclipseUtils;
@@ -333,31 +338,55 @@ public class Configuration
 
 	private static boolean useModernPortSyntax(String executablePath)
 	{
-		if (executablePath == null)
+		if (executablePath == null || executablePath.isEmpty())
 		{
 			return false;
 		}
+		Pattern outputPattern = Pattern.compile("(?:Open On-Chip Debugger |v)(?<major>\\d+)\\.(?<minor>\\d+)"); //$NON-NLS-1$
 
-		Pattern pattern = Pattern.compile("v(\\d+)\\.(\\d+)\\.\\d+-esp32-\\d{8}"); //$NON-NLS-1$
-		Matcher matcher = pattern.matcher(executablePath);
-
-		if (matcher.find())
+		try
 		{
+			ProcessBuilder pb = new ProcessBuilder(executablePath, "--version"); //$NON-NLS-1$
+			pb.redirectErrorStream(true);
+			Process process = pb.start();
+
 			try
 			{
-				int major = Integer.parseInt(matcher.group(1));
-				int minor = Integer.parseInt(matcher.group(2));
-
-				if (major > 0 || (major == 0 && minor >= 12))
+				try (BufferedReader reader = process.inputReader())
 				{
-					return true;
+					return reader.lines().map(outputPattern::matcher).filter(Matcher::find).findFirst().map(matcher -> {
+						int major = Integer.parseInt(matcher.group("major")); //$NON-NLS-1$
+						int minor = Integer.parseInt(matcher.group("minor")); //$NON-NLS-1$
+						return major > 0 || (major == 0 && minor >= 12);
+					}).orElse(false);
+				}
+			} finally
+			{
+				if (process.isAlive())
+				{
+					process.destroy();
+
+					if (!process.waitFor(500, TimeUnit.MILLISECONDS))
+					{
+						process.destroyForcibly();
+					}
 				}
 			}
-			catch (NumberFormatException e)
-			{
-				Activator.log(e);
-			}
 		}
+		catch (
+				IOException
+				| NumberFormatException e)
+		{
+			Activator.log(new CoreException(new Status(IStatus.WARNING, Activator.PLUGIN_ID,
+					"Failed to execute or parse OpenOCD version fallback for path: " + executablePath, e))); //$NON-NLS-1$
+		}
+		catch (InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+			Activator.log(new CoreException(new Status(IStatus.WARNING, Activator.PLUGIN_ID,
+					"Thread was interrupted while waiting for OpenOCD process to exit.", e))); //$NON-NLS-1$
+		}
+
 		return false;
 	}
 }


### PR DESCRIPTION
## Description

Parse the OpenOCD version from the executable path to dynamically determine whether to use the old (gdb_port) or new (gdb port) syntax.

Fixes # ([IEP-1534](https://jira.espressif.com:8443/browse/IEP-1534))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Debug with different esp-idf versions and see if there are no "deprecated" message in logs
 
**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenOCD by auto-detecting and applying the correct command-line syntax for GDB, Telnet, and TCL ports.
  * Added warnings when automatic detection fails or times out to surface issues.

* **Improvements**
  * Stricter validation of executable inputs.
  * More consistent, formatted construction of port option arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->