### PR TITLE
Add automatic update site verification after Espressif-IDE release workflow completes successfully.

### DIFF
--- a/.github/workflows/update-site-test.yml
+++ b/.github/workflows/update-site-test.yml
@@ -5,25 +5,43 @@ on:
     paths:
       - 'releng/update-site-tests/**'
       - '.github/workflows/update-site-tests.yml'
+
   pull_request:
     paths:
       - 'releng/update-site-tests/**'
       - '.github/workflows/update-site-tests.yml'
+
   schedule:
     # Runs every day at 00:00 UTC
     - cron: '0 0 * * *'
+
   workflow_dispatch:
+
+  workflow_run:
+    workflows: ["Espressif-IDE Cross-platform Release"]
+    types:
+      - completed
 
 permissions:
   contents: read
 
 jobs:
   update-site-tests:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, eclipse, BrnoUBU0004]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Print trigger info
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "Triggered by workflow: ${{ github.event.workflow_run.name }}"
+            echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
+            echo "Head branch: ${{ github.event.workflow_run.head_branch }}"
+          fi
 
       - name: Make scripts executable
         run: |


### PR DESCRIPTION
## Description

add a workflow_run trigger for "Espressif-IDE Cross-platform Release"
run the update-site tests only when the release workflow finishes with success

Fixes # ([IEP-1752](https://jira.espressif.com:8443/browse/IEP-1752))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [X] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow automation to improve test execution timing and reliability based on upstream build completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->