### PR TITLE
IEP-1755 Build folder path fails to save on first apply in Launch Configuration

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -15,6 +15,7 @@ import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
@@ -77,7 +78,8 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 	@Override
 	public boolean launchConfigurationChanged(ILaunchConfiguration configuration) throws CoreException
 	{
-		// nothing to do
+		IDFUtil.updateProjectBuildFolder(configuration.getWorkingCopy());
+
 		return false;
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
@@ -18,12 +18,10 @@ package com.espressif.idf.launch.serial.ui.internal;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 
 import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.core.util.IDFUtil;
 
 public class SerialFlashLaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup
 {
@@ -31,16 +29,7 @@ public class SerialFlashLaunchConfigTabGroup extends AbstractLaunchConfiguration
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode)
 	{
-
 		setTabs();
-
-	}
-
-	@Override
-	public void performApply(ILaunchConfigurationWorkingCopy configuration)
-	{
-		super.performApply(configuration);
-		IDFUtil.updateProjectBuildFolder(configuration);
 	}
 
 	@Override


### PR DESCRIPTION
## Description

Moved IDFUtil.updateProjectBuildFolder() from the UI apply phase to the launchConfigurationChanged listener in IDFCoreLaunchConfigProvider. Previously, reading from an unsaved WorkingCopy resulted in saving the old build folder property. Deferring this to the listener ensures the configuration is completely saved to disk before we attempt to update the project properties.

Fixes # ([IEP-1755](https://jira.espressif.com:8443/browse/IEP-1755))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

1. Edit the launch configuration -> set new custom build folder -> save the changes -> click build -> make sure the build folder is updated immediately.

2. Create new configuration and set custom build folder -> click build -> make sure the build folder is updated immediately 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project build folder now updates when launch configurations change, ensuring consistency with current settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->