### PR TITLE
SWTException: Widget is disposed in NewSerialFlashTargetWizardPage during background chip detection

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -273,6 +273,24 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 		setDefaults();
 	}
 
+	/**
+	 * Helper method to safely append text to the infoArea from any thread. Checks for widget disposal to prevent
+	 * SWTExceptions.
+	 */
+	private void appendToInfoArea(final String text)
+	{
+		if (display == null || display.isDisposed())
+		{
+			return;
+		}
+		display.asyncExec(() -> {
+			if (infoArea != null && !infoArea.isDisposed())
+			{
+				infoArea.append(text);
+			}
+		});
+	}
+
 	private void setDefaults()
 	{
 		if (launchTarget == null)
@@ -471,10 +489,9 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 			EspToolCommands espToolCommands = new EspToolCommands();
 
 			String message = String.format(Messages.TargetPortUpdatingMessage, serialPort);
-			display.asyncExec(() -> {
-				if (infoArea != null && !infoArea.isDisposed())
-					infoArea.append(System.lineSeparator() + message);
-			});
+
+			appendToInfoArea(System.lineSeparator() + message);
+
 			try
 			{
 				Process chipInfoProcess = espToolCommands.chipInformation(serialPort);
@@ -484,31 +501,30 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 				String readLine;
 				while ((readLine = bufferedReader.readLine()) != null)
 				{
-					display.asyncExec(() -> infoArea.append(".")); //$NON-NLS-1$
+					appendToInfoArea("."); //$NON-NLS-1$
+
 					chipInfo.append(readLine);
 					chipInfo.append(System.lineSeparator());
 				}
 				String chipType = extractChipFromChipInfoOutput(chipInfo.toString());
-				display.asyncExec(() -> {
-					if (StringUtil.isEmpty(chipType))
-					{
-						if (infoArea != null && !infoArea.isDisposed())
-							infoArea.setText(infoArea.getText() + System.lineSeparator()
-									+ String.format(Messages.TargetPortNotFoundMessage, serialPort));
-					}
-					else
-					{
-						infoArea.append(System.lineSeparator());
-						infoArea.append(String.format(Messages.TargetPortFoundMessage, serialPort, chipType));
-					}
-				});
+
+				if (StringUtil.isEmpty(chipType))
+				{
+					appendToInfoArea(
+							System.lineSeparator() + String.format(Messages.TargetPortNotFoundMessage, serialPort));
+				}
+				else
+				{
+					appendToInfoArea(System.lineSeparator()
+							+ String.format(Messages.TargetPortFoundMessage, serialPort, chipType));
+				}
 			}
 			catch (Exception e)
 			{
 				Logger.log(e);
 			}
 
-			display.asyncExec(() -> infoArea.append(System.lineSeparator()));
+			appendToInfoArea(System.lineSeparator());
 
 			return Status.OK_STATUS;
 		}


### PR DESCRIPTION
## Description

Created a method appendToInfoArea that checks whether the widget is disposed before using it.

Fixes # ([IEP-1757](https://jira.espressif.com:8443/browse/IEP-1757))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Edit the launch target and select the port. While information is being appended to the widget, close the dialog or click Apply. Then check the log — there should be no SWT “widget is disposed” exception.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Launch target dialog

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for UI update operations, enhancing code maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->