### PR TITLE
IEP-1758 GH #1451: On Windows the ESP-IDF Manager is not compatible with latest version of EIM

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimConstants.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimConstants.java
@@ -27,5 +27,5 @@ public interface EimConstants
 	
 	String USER_EIM_DIR = Paths.get(System.getProperty("user.home"), ".espressif", "eim_gui").toString(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	String EIM_JSON_VALID_VERSION = "1.0"; //$NON-NLS-1$
+	String EIM_JSON_VALID_VERSION = "2.0"; //$NON-NLS-1$
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
@@ -40,9 +40,9 @@ public class EimIdfConfiguratinParser
 			eimJson = gson.fromJson(fileReader, EimJson.class);
 		}
 		
-		if (!eimJson.getVersion().equals(EimConstants.EIM_JSON_VALID_VERSION))
+		if (Double.parseDouble(eimJson.getVersion()) < Double.parseDouble(EimConstants.EIM_JSON_VALID_VERSION))
 		{
-			throw new EimVersionMismatchException(EimConstants.EIM_JSON_VALID_VERSION,eimJson.getVersion());
+			throw new EimVersionMismatchException(EimConstants.EIM_JSON_VALID_VERSION, eimJson.getVersion());
 		}
 	}
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/EimIdfConfiguratinParser.java
@@ -40,7 +40,7 @@ public class EimIdfConfiguratinParser
 			eimJson = gson.fromJson(fileReader, EimJson.class);
 		}
 		
-		if (Double.parseDouble(eimJson.getVersion()) < Double.parseDouble(EimConstants.EIM_JSON_VALID_VERSION))
+		if (Double.parseDouble(eimJson.getVersion()) > Double.parseDouble(EimConstants.EIM_JSON_VALID_VERSION))
 		{
 			throw new EimVersionMismatchException(EimConstants.EIM_JSON_VALID_VERSION, eimJson.getVersion());
 		}


### PR DESCRIPTION
## Description

We can safely parse version 2.0 using the existing code and allow users to activate their ESP-IDF in the IDE. The new changes introduced in eim_idf.json 2.0 can be handled separately at a later stage.

Fixes # ([IEP-1758](https://jira.espressif.com:8443/browse/IEP-1758))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Install some esp-idf with latest eim manager and make sure that eim_idf.json version is 2.0. Try to activate and use esp-idf via Espressif-IDE

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Espressif-IDE manager

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file version validation threshold to 2.0 with enhanced compatibility for version checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->