### PR TITLE
IEP-1763 Missing Eclipse Marketplace in Espressif-IDE

### DIFF
--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -2,6 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Espressif-IDE" uid="com.espressif.idf.product" id="com.espressif.idf.branding.idf" application="org.eclipse.ui.ide.workbench" version="4.3.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+
    <aboutInfo>
       <image path="/com.espressif.idf.branding/icons/alt_about.png"/>
       <text>
@@ -78,6 +79,7 @@
       <feature id="org.eclipse.nebula.widgets.xviewer.feature" installMode="root"/>
       <feature id="org.eclipse.cdt.lsp.feature" installMode="root"/>
       <feature id="org.eclipse.tm4e.feature" installMode="root"/>
+      <feature id="org.eclipse.epp.mpc" installMode="root"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
## Description

Added eclipse marketplace feature to the idf.product, so the eclipse marketplace is available in the Espressif-IDE by default

Fixes # ([IEP-1763](https://jira.espressif.com:8443/browse/IEP-1763))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Download Espressif-IDE from this PR -> test that eclipse marketplace present there and it's functional 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Eclipse market place

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integrated marketplace client enabling users to discover, browse, and install extensions directly from the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->