### PR TITLE
IEP-1764 Target detection is failing with ESP-IDF 6.0.1

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -531,7 +531,7 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 
 		private String extractChipFromChipInfoOutput(String chipInfoOutput)
 		{
-			Pattern pattern = Pattern.compile("Chip is (ESP32[^\\s]*)"); //$NON-NLS-1$
+			Pattern pattern = Pattern.compile("(?:Chip is|Chip type:)\\s+(ESP32[^\\s]*)", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
 			Matcher matcher = pattern.matcher(chipInfoOutput);
 			if (matcher.find())
 			{


### PR DESCRIPTION
## Description

With ESP-IDF 6.0.1, the output format of the esptool detection script has changed. The script now prints Chip type: instead of Chip: during target detection, causing the current regex to fail.

Example output:
Detecting chip type... ESP32
Connected to ESP32 on COM4:
Chip type: ESP32-D0WD-V3 (revision v3.0)

So in this PR I've changed the regex to support both type of output `Chip is` and `Chip type`

Fixes # ([IEP-1764](https://jira.espressif.com:8443/browse/IEP-1764))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Install esp-idf 5.2 and esp-idf 6.0.1 and check target detection on both of them 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chip type detection in the serial flash target wizard to support additional device identification output formats, improving compatibility when detecting target devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->