### PR TITLE
IEP-1765 Improve target detection UX by adding option for detailed detection script output

### DIFF
--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/Messages.java
@@ -22,11 +22,14 @@ public class Messages extends NLS
 	private static final String BUNDLE_NAME = "com.espressif.idf.launch.serial.ui.internal.messages"; //$NON-NLS-1$
 	public static String NewSerialFlashTargetWizard_Title;
 	public static String NewSerialFlashTargetWizardPage_Description;
+	public static String NewSerialFlashTargetWizardPage_EnableDetailedOutputCheckboxName;
 	public static String NewSerialFlashTargetWizardPage_Fetching;
 	public static String NewSerialFlashTargetWizardPage_IDFTarget;
 	public static String NewSerialFlashTargetWizardPage_IDFTargetToolTipMsg;
 	public static String NewSerialFlashTargetWizardPage_Name;
+	public static String NewSerialFlashTargetWizardPage_NoBoardsDetectedWarningMsg;
 	public static String NewSerialFlashTargetWizardPage_SerialPort;
+	public static String NewSerialFlashTargetWizardPage_TargetOutputGroupName;
 	public static String NewSerialFlashTargetWizardPage_Title;
 	public static String CMakeMainTab2_FlashComboLbl;
 	public static String CMakeMainTab2_Arguments;

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizard.java
@@ -30,6 +30,7 @@ import org.osgi.service.prefs.Preferences;
 
 import com.espressif.idf.core.LaunchBarTargetConstants;
 import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.StringUtil;
 
 public class NewSerialFlashTargetWizard extends LaunchTargetWizard
@@ -71,6 +72,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard
 
 		wc.save();
 		storeLastUsedSerialPort();
+		storeDetailedOutputCheckboxStatus();
 
 		// adding the target later to trigger LaunchBarListener with proper wc attributes
 		Job job = new Job(Messages.AddingTargetJobName)
@@ -85,6 +87,22 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard
 		};
 		job.schedule();
 		return true;
+	}
+
+	private void storeDetailedOutputCheckboxStatus()
+	{
+		Preferences preferences = InstanceScope.INSTANCE.getNode(Activator.PLUGIN_ID);
+		preferences.putBoolean(NewSerialFlashTargetWizardPage.PREF_ENABLE_DETAILED_OUTPUT,
+				page.isOutputDetailedChecked());
+
+		try
+		{
+			preferences.flush();
+		}
+		catch (BackingStoreException e)
+		{
+			Logger.log(e);
+		}
 	}
 
 	private void setOpenOCDAdaptorLocation(ILaunchTargetWorkingCopy wc)
@@ -113,7 +131,7 @@ public class NewSerialFlashTargetWizard extends LaunchTargetWizard
 		}
 		catch (BackingStoreException e)
 		{
-			e.printStackTrace();
+			Logger.log(e);
 		}
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -33,6 +33,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.wizard.WizardPage;
@@ -84,7 +86,14 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 	private Combo fBoardCombo;
 	private Combo fFlashVoltage;
 	private String previousBoard = null;
+
 	protected boolean isOutputDetailed;
+	public static final String PREF_ENABLE_DETAILED_OUTPUT = Activator.PLUGIN_ID + ".enableDetailedOutput"; //$NON-NLS-1$
+
+	public boolean isOutputDetailedChecked()
+	{
+		return isOutputDetailed;
+	}
 
 	public NewSerialFlashTargetWizardPage(ILaunchTarget launchTarget)
 	{
@@ -287,6 +296,10 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 		Button detailedOutputCheckbox = new Button(infoAreaGroup, SWT.CHECK);
 		detailedOutputCheckbox.setText(Messages.NewSerialFlashTargetWizardPage_EnableDetailedOutputCheckboxName);
 		detailedOutputCheckbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(Activator.PLUGIN_ID);
+		isOutputDetailed = preferences.getBoolean(PREF_ENABLE_DETAILED_OUTPUT, false);
+		detailedOutputCheckbox.setSelection(isOutputDetailed);
 
 		infoArea = new Text(infoAreaGroup, SWT.BORDER | SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI);
 		GridData infoAreaGridData = new GridData(SWT.FILL, SWT.FILL, true, true);
@@ -616,5 +629,4 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 		}
 		return boardDisplayNames;
 	}
-
 }

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
@@ -41,6 +42,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -82,6 +84,7 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 	private Combo fBoardCombo;
 	private Combo fFlashVoltage;
 	private String previousBoard = null;
+	protected boolean isOutputDetailed;
 
 	public NewSerialFlashTargetWizardPage(ILaunchTarget launchTarget)
 	{
@@ -175,8 +178,13 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 				}
 				display.asyncExec(() -> {
 					fBoardCombo.setItems(boardDisplayNames.toArray(new String[0]));
+					if (boardDisplayNames.isEmpty())
+						setMessage(Messages.NewSerialFlashTargetWizardPage_NoBoardsDetectedWarningMsg,
+								IMessageProvider.WARNING);
+
 					if (!boardDisplayNames.isEmpty())
 					{
+						setMessage(null);
 						int defaultIdx = 0;
 						if (jsonHolder[0] == null)
 						{
@@ -265,12 +273,34 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 			Activator.log(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
 					Messages.NewSerialFlashTargetWizardPage_Fetching, e));
 		}
+		createInfoAreaGroup(comp);
+		setDefaults();
+	}
 
-		infoArea = new Text(comp, SWT.BORDER | SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI);
-		GridData infoAreaGridData = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
+	private void createInfoAreaGroup(Composite parentComp)
+	{
+		Group infoAreaGroup = new Group(parentComp, SWT.BORDER);
+		infoAreaGroup.setText(Messages.NewSerialFlashTargetWizardPage_TargetOutputGroupName);
+		infoAreaGroup.setLayout(new GridLayout(1, false));
+		infoAreaGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
+
+		Button detailedOutputCheckbox = new Button(infoAreaGroup, SWT.CHECK);
+		detailedOutputCheckbox.setText(Messages.NewSerialFlashTargetWizardPage_EnableDetailedOutputCheckboxName);
+		detailedOutputCheckbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		infoArea = new Text(infoAreaGroup, SWT.BORDER | SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI);
+		GridData infoAreaGridData = new GridData(SWT.FILL, SWT.FILL, true, true);
 		infoAreaGridData.heightHint = 100;
 		infoArea.setLayoutData(infoAreaGridData);
-		setDefaults();
+
+		detailedOutputCheckbox.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				isOutputDetailed = detailedOutputCheckbox.getSelection();
+			}
+		});
 	}
 
 	/**
@@ -332,7 +362,7 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 
 	private void setDefaultSerialPort()
 	{
-		if (serialPortCombo.getItemCount() < 0 || launchTarget == null)
+		if (serialPortCombo.getItemCount() == 0 || launchTarget == null)
 		{
 			return;
 		}
@@ -502,22 +532,33 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 				while ((readLine = bufferedReader.readLine()) != null)
 				{
 					appendToInfoArea("."); //$NON-NLS-1$
+					if (isOutputDetailed)
+					{
+						appendToInfoArea(readLine + System.lineSeparator());
+					}
+					else
+					{
+						appendToInfoArea("."); //$NON-NLS-1$
+						chipInfo.append(readLine).append(System.lineSeparator());
+					}
 
-					chipInfo.append(readLine);
-					chipInfo.append(System.lineSeparator());
 				}
 				String chipType = extractChipFromChipInfoOutput(chipInfo.toString());
 
-				if (StringUtil.isEmpty(chipType))
+				if (!isOutputDetailed)
 				{
-					appendToInfoArea(
-							System.lineSeparator() + String.format(Messages.TargetPortNotFoundMessage, serialPort));
+					if (StringUtil.isEmpty(chipType))
+					{
+						appendToInfoArea(
+								System.lineSeparator() + String.format(Messages.TargetPortNotFoundMessage, serialPort));
+					}
+					else
+					{
+						appendToInfoArea(System.lineSeparator()
+								+ String.format(Messages.TargetPortFoundMessage, serialPort, chipType));
+					}
 				}
-				else
-				{
-					appendToInfoArea(System.lineSeparator()
-							+ String.format(Messages.TargetPortFoundMessage, serialPort, chipType));
-				}
+
 			}
 			catch (Exception e)
 			{

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/NewSerialFlashTargetWizardPage.java
@@ -531,7 +531,6 @@ public class NewSerialFlashTargetWizardPage extends WizardPage
 				String readLine;
 				while ((readLine = bufferedReader.readLine()) != null)
 				{
-					appendToInfoArea("."); //$NON-NLS-1$
 					if (isOutputDetailed)
 					{
 						appendToInfoArea(readLine + System.lineSeparator());

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/messages.properties
@@ -10,11 +10,14 @@
 ################################################################################
 NewSerialFlashTargetWizard_Title=New ESP Target
 NewSerialFlashTargetWizardPage_Description=Enter name and properties for the target.
+NewSerialFlashTargetWizardPage_EnableDetailedOutputCheckboxName=Enable detailed output
 NewSerialFlashTargetWizardPage_Fetching=Fetching serial ports
 NewSerialFlashTargetWizardPage_IDFTarget=IDF Target
 NewSerialFlashTargetWizardPage_IDFTargetToolTipMsg=This will be configured as IDF_TARGET during the build process
 NewSerialFlashTargetWizardPage_Name=Name:
+NewSerialFlashTargetWizardPage_NoBoardsDetectedWarningMsg=No boards detected. Please check your connection or select a different target.
 NewSerialFlashTargetWizardPage_SerialPort=Serial Port:
+NewSerialFlashTargetWizardPage_TargetOutputGroupName=Target Detection Output
 NewSerialFlashTargetWizardPage_Title=ESP Target
 CMakeMainTab2_FlashComboLbl=Flash over:
 CMakeMainTab2_Arguments=Arguments:


### PR DESCRIPTION
## Description

Added a new warning message for when boards are not detected. Additionally, added a checkbox to enable detailed script output, which contains useful debugging information—such as the MAC address—if the target is not detected.

<img width="1152" height="888" alt="image" src="https://github.com/user-attachments/assets/c4fa9d23-ee57-46b9-b4ee-c1d51ecf77c3" />

Fixes # ([IEP-1765](https://jira.espressif.com:8443/browse/IEP-1765))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Edit target wizard

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Enable detailed output" checkbox to the serial target wizard and persisted its setting.
  * New output/info group in the wizard to show probe output and status.

* **Bug Fixes**
  * Wizard now shows a warning when no boards are detected.
  * Improved handling when no serial ports are available and clearer probe output modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/idf-eclipse-plugin/pull/1459)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->