### PR TITLE
IEP-1767 shouldHaveClangFilesPresentAndContentCorrectForNewProject test is not stable

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
@@ -5,7 +5,6 @@
 package com.espressif.idf.ui.test.executable.cases.project;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -155,12 +154,14 @@ public class NewEspressifIDFProjectClangFilesTest
 
 		private static void thenClangdFileIsPresent(String projectName) throws IOException
 		{
-			assertTrue(bot.tree().getTreeItem(projectName).getNode(".clangd") != null);
+			boolean isPresent = bot.tree().getTreeItem(projectName).getNodes().contains(".clangd");
+			assertEquals("The .clangd file should be present", true, isPresent);
 		}
 
 		private static void thenClangFormatFileIsPresent(String projectName) throws IOException
 		{
-			assertTrue(bot.tree().getTreeItem(projectName).getNode(".clang-format") != null);
+			boolean isPresent = bot.tree().getTreeItem(projectName).getNodes().contains(".clang-format");
+			assertEquals("The .clang-format file should be present", true, isPresent);
 		}
 
 		private static void whenClangdFileDeleted(String projectName) throws IOException
@@ -173,7 +174,8 @@ public class NewEspressifIDFProjectClangFilesTest
 
 		private static void thenClangdFileIsAbsent(String projectName) throws IOException
 		{
-			assertTrue(!bot.tree().getTreeItem(projectName).getNodes().contains(".clangd"));
+			boolean isPresent = bot.tree().getTreeItem(projectName).getNodes().contains(".clangd");
+			assertEquals("The .clangd file should be absent", false, isPresent);
 		}
 
 		private static void thenCreateClangdFileUsingContextMenu(String projectName) throws IOException
@@ -213,33 +215,41 @@ public class NewEspressifIDFProjectClangFilesTest
 		private static void thenCleanProjectClangdFileContentChecked() throws Exception
 		{
 			bot.cTabItem(".clangd").activate();
-			assertTrue(ProjectTestOperations.checkExactMatchInTextEditor(
-					"CompileFlags:\n" + "  CompilationDatabase: build\n" + "  Remove: [-m*, -f*]", bot));
+			String actualText = bot.activeEditor().toTextEditor().getText();
+			String expectedText = "CompileFlags:\n  CompilationDatabase: build\n  Remove: [-m*, -f*]";
+
+			assertEquals("Clangd file content did not match", expectedText, actualText);
 		}
 
 		private static void thenClangdFileContentChecked(String projectName) throws Exception
 		{
 			String buildPath = getExpectedBuildFolderPATH(projectName);
 			bot.cTabItem(".clangd").activate();
-			assertTrue(ProjectTestOperations.checkExactMatchInTextEditor(
-					"CompileFlags:\n" + "  CompilationDatabase: " + buildPath + "\n" + "  Remove: [-m*, -f*]", bot));
+
+			String actualText = bot.activeEditor().toTextEditor().getText();
+			String expectedText = "CompileFlags:\n  CompilationDatabase: " + buildPath + "\n  Remove: [-m*, -f*]";
+
+			assertEquals("Clangd file content with build path did not match", expectedText, actualText);
 		}
 
 		private static void thenClangFormatContentChecked() throws Exception
 		{
 			bot.cTabItem(".clang-format").activate();
-			assertTrue(ProjectTestOperations.checkExactMatchInTextEditor(
-					"""
-							# We'll use defaults from the LLVM style, but with some modifications so that it's close to the CDT K&R style.
-							BasedOnStyle: LLVM
-							UseTab: Always
-							IndentWidth: 4
-							TabWidth: 4
-							BreakConstructorInitializers: AfterColon
-							IndentAccessModifiers: false
-							AccessModifierOffset: -4
-							""",
-					bot));
+
+			String actualText = bot.activeEditor().toTextEditor().getText();
+			String expectedText = """
+					# We'll use defaults from the LLVM style, but with some modifications so that it's close to the CDT K&R style.
+					BasedOnStyle: LLVM
+					UseTab: Always
+					IndentWidth: 4
+					TabWidth: 4
+					BreakConstructorInitializers: AfterColon
+					IndentAccessModifiers: false
+					AccessModifierOffset: -4
+					""";
+
+			// Using trim() to avoid mismatch purely due to trailing spaces/newlines from text block processing
+			assertEquals("ClangFormat content did not match", expectedText.trim(), actualText.trim());
 		}
 
 		private static void thenClangFormatContentEdited() throws Exception
@@ -278,7 +288,8 @@ public class NewEspressifIDFProjectClangFilesTest
 		private static void checkMainFileContentFormattedUnderActualSettings() throws Exception
 		{
 			bot.sleep(1000);
-			assertTrue(ProjectTestOperations.checkExactMatchInTextEditorwithWhiteSpaces("""
+			String actualText = bot.activeEditor().toTextEditor().getText();
+			String expectedText = """
 					#include <stdbool.h>
 					#include <stdio.h>
 					#include <unistd.h>
@@ -289,7 +300,9 @@ public class NewEspressifIDFProjectClangFilesTest
 					sleep(1);
 					}
 					}
-					""", bot));
+					""";
+
+			assertEquals("Formatted main file content did not match", expectedText.trim(), actualText.trim());
 		}
 
 		private static void setupAutoSave() throws Exception

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
@@ -122,6 +122,15 @@ public class NewEspressifIDFProjectClangFilesTest
 			bot.sleep(1000);
 		}
 
+		private static void assertTextEqualsNormalized(String message, String expected, String actual)
+		{
+			// Standardize all line endings to \n and trim outer whitespace
+			String normalizedExpected = expected.replace("\r\n", "\n").replace("\r", "\n").trim();
+			String normalizedActual = actual.replace("\r\n", "\n").replace("\r", "\n").trim();
+
+			assertEquals(message, normalizedExpected, normalizedActual);
+		}
+
 		private static void thenClangdDriversUpdateOnSelectedTarget() throws Exception
 		{
 			whenOpenClangdPreferences();
@@ -218,7 +227,7 @@ public class NewEspressifIDFProjectClangFilesTest
 			String actualText = bot.activeEditor().toTextEditor().getText();
 			String expectedText = "CompileFlags:\n  CompilationDatabase: build\n  Remove: [-m*, -f*]";
 
-			assertEquals("Clangd file content did not match", expectedText, actualText);
+			assertTextEqualsNormalized("Clangd file content did not match", expectedText, actualText);
 		}
 
 		private static void thenClangdFileContentChecked(String projectName) throws Exception
@@ -229,7 +238,7 @@ public class NewEspressifIDFProjectClangFilesTest
 			String actualText = bot.activeEditor().toTextEditor().getText();
 			String expectedText = "CompileFlags:\n  CompilationDatabase: " + buildPath + "\n  Remove: [-m*, -f*]";
 
-			assertEquals("Clangd file content with build path did not match", expectedText, actualText);
+			assertTextEqualsNormalized("Clangd file content with build path did not match", expectedText, actualText);
 		}
 
 		private static void thenClangFormatContentChecked() throws Exception
@@ -249,7 +258,7 @@ public class NewEspressifIDFProjectClangFilesTest
 					""";
 
 			// Using trim() to avoid mismatch purely due to trailing spaces/newlines from text block processing
-			assertEquals("ClangFormat content did not match", expectedText.trim(), actualText.trim());
+			assertTextEqualsNormalized("ClangFormat content did not match", expectedText.trim(), actualText.trim());
 		}
 
 		private static void thenClangFormatContentEdited() throws Exception
@@ -302,7 +311,8 @@ public class NewEspressifIDFProjectClangFilesTest
 					}
 					""";
 
-			assertEquals("Formatted main file content did not match", expectedText.trim(), actualText.trim());
+			assertTextEqualsNormalized("Formatted main file content did not match", expectedText.trim(),
+					actualText.trim());
 		}
 
 		private static void setupAutoSave() throws Exception

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
@@ -66,7 +66,7 @@ public class NewEspressifIDFProjectClangFilesTest
 	{
 		Fixture.thenClangdFileIsPresent(CLEAN_PROJECT1);
 		Fixture.whenClangdFileOpenedUsingDoubleClick(CLEAN_PROJECT1);
-		Fixture.thenCleanProjectClangdFileContentChecked();
+		Fixture.thenClangFormatContentChecked();
 		Fixture.thenClangdShellClosed();
 		Fixture.thenClangFormatFileIsPresent(CLEAN_PROJECT1);
 		Fixture.whenClangFormatFileOpenedUsingDoubleClick(CLEAN_PROJECT1);
@@ -219,15 +219,6 @@ public class NewEspressifIDFProjectClangFilesTest
 			{
 				throw new IOException("Failed to get build directory for project: " + projectName, e);
 			}
-		}
-
-		private static void thenCleanProjectClangdFileContentChecked() throws Exception
-		{
-			bot.cTabItem(".clangd").activate();
-			String actualText = bot.activeEditor().toTextEditor().getText();
-			String expectedText = "CompileFlags:\n  CompilationDatabase: build\n  Remove: [-m*, -f*]";
-
-			assertTextEqualsNormalized("Clangd file content did not match", expectedText, actualText);
 		}
 
 		private static void thenClangdFileContentChecked(String projectName) throws Exception

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectClangFilesTest.java
@@ -66,7 +66,7 @@ public class NewEspressifIDFProjectClangFilesTest
 	{
 		Fixture.thenClangdFileIsPresent(CLEAN_PROJECT1);
 		Fixture.whenClangdFileOpenedUsingDoubleClick(CLEAN_PROJECT1);
-		Fixture.thenClangFormatContentChecked();
+		Fixture.thenClangdFileContentChecked(CLEAN_PROJECT1);
 		Fixture.thenClangdShellClosed();
 		Fixture.thenClangFormatFileIsPresent(CLEAN_PROJECT1);
 		Fixture.whenClangFormatFileOpenedUsingDoubleClick(CLEAN_PROJECT1);


### PR DESCRIPTION
## Description

This PR contains a refactor of the test by replacing assertTrue with assertEquals for better diffs, as well as a test fix. The test was failing because we expected CompilationDatabase as the build value after creating a new project, but it is actually an absolute path now.

Fixes # ([IEP-1767](https://jira.espressif.com:8443/browse/IEP-1767))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened automated checks by switching to strict equality assertions for file presence.
  * Improved editor-content comparisons using normalized text (consistent line endings and trimmed whitespace) to reduce flakiness.
  * Enhanced validation of clang-related config files and main-source formatting, including verification of build-path-specific compilation database entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/idf-eclipse-plugin/pull/1461)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->