### PR TITLE
feat: unify launch and debug configurations

### DIFF
--- a/bundles/com.espressif.idf.core/plugin.xml
+++ b/bundles/com.espressif.idf.core/plugin.xml
@@ -2,6 +2,7 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension-point id="com.espressif.idf.core.toolchain" name="esptoolchain" schema="schema/com.espressif.idf.core.toolchain.exsd"/>
+   <extension-point id="com.espressif.idf.core.launchDefaultsContributor" name="Launch Defaults Contributor" schema="schema/launchDefaultsContributor.exsd"/>
    <extension
          id="idfNature"
          name="IDF Nature"

--- a/bundles/com.espressif.idf.core/schema/launchDefaultsContributor.exsd
+++ b/bundles/com.espressif.idf.core/schema/launchDefaultsContributor.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="com.espressif.idf.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="com.espressif.idf.core" id="launchDefaultsContributor" name="Launch Defaults Contributor"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="contributor"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="contributor">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":com.espressif.idf.core.util.ILaunchDefaultsContributor"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/com.espressif.idf.core/schema/launchDefaultsContributor.exsd
+++ b/bundles/com.espressif.idf.core/schema/launchDefaultsContributor.exsd
@@ -6,7 +6,7 @@
          <meta.schema plugin="com.espressif.idf.core" id="launchDefaultsContributor" name="Launch Defaults Contributor"/>
       </appinfo>
       <documentation>
-         [Enter description of this extension point.]
+         Contributors supply default values for launch configuration attributes that are missing or empty. Implementations must not overwrite attributes the user already set. Called when a configuration is created and when an existing configuration is launched.
       </documentation>
    </annotation>
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/IDFEnvironmentVariables.java
@@ -134,6 +134,7 @@ public class IDFEnvironmentVariables
 		IEnvironmentVariableManager buildEnvironmentManager = CCorePlugin.getDefault().getBuildEnvironmentManager();
 		IEnvironmentVariable[] variables = buildEnvironmentManager.getVariables((ICConfigurationDescription) null,
 				true);
+
 		Map<String, String> envMap = new HashMap<String, String>(System.getenv());
 		if (variables != null)
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationProvider.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
 import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.CBuildConfigUtils;
 import org.eclipse.cdt.core.build.CBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
@@ -21,10 +22,8 @@ import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
-import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.logging.Logger;
 
 /**
@@ -49,8 +48,6 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 	public synchronized ICBuildConfiguration getCBuildConfiguration(IBuildConfiguration config, String name)
 			throws CoreException
 	{
-		ILaunchBarManager barManager = IDFCorePlugin.getService(ILaunchBarManager.class);
-		ILaunchTarget target = barManager != null ? barManager.getActiveLaunchTarget() : null;
 		if (config.getName().equals(IBuildConfiguration.DEFAULT_CONFIG_NAME))
 		{
 			Logger.log("Default config name is not supported"); //$NON-NLS-1$
@@ -69,7 +66,7 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 		{
 			// toolchain changed
 			return new IDFBuildConfiguration(config, name, tcFile.getToolChain(), tcFile, cmakeConfig.getLaunchMode(),
-					target);
+					cmakeConfig.getLaunchTarget());
 		}
 		else
 		{
@@ -105,18 +102,9 @@ public class IDFBuildConfigurationProvider implements ICBuildConfigurationProvid
 			}
 		}
 
-		// Let's generate build artifacts directly under the build folder so that CLI and eclipse IDF will be in sync
-		String name = ICBuildConfiguration.TOOLCHAIN_ID;
-		IBuildConfiguration buildConfig;
-		if (configManager.hasConfiguration(this, project, name))
-		{
-			buildConfig = project.getBuildConfig(ID + '/' + name);
-		}
-		else
-		{
-			buildConfig = configManager.createBuildConfiguration(this, project, name, monitor);
-
-		}
+		String name = getCBuildConfigName(project, "idf", toolChain, launchMode, launchTarget); //$NON-NLS-1$
+		IBuildConfiguration buildConfig = CBuildConfigUtils.createBuildConfiguration(this, project, name, configManager,
+				monitor);
 
 		CBuildConfiguration cmakeConfig = new IDFBuildConfiguration(buildConfig, name, toolChain, file, launchMode,
 				launchTarget);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationSetup.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/IDFBuildConfigurationSetup.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.build;
+
+import java.text.MessageFormat;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.build.CBuildConfiguration;
+import org.eclipse.cdt.core.build.ICBuildConfiguration;
+import org.eclipse.cdt.core.build.ICBuildConfiguration2;
+import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
+import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.build.IToolChainManager;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunchMode;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+import org.eclipse.launchbar.core.target.ILaunchTarget;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * Creates the Core Build configuration of a freshly created IDF project and makes it active.
+ * <p>
+ * Normally CDT's {@code CoreBuildLaunchBarTracker} does this in response to Launch Bar changes, but it skips the work
+ * whenever the incoming descriptor, mode and target all equal the ones it handled last. Deleting a project leaves those
+ * fields pointing at it, so a project created afterwards under the same name matches all three and is silently left
+ * without a configuration. The wizard knows the project and the chip it just created, so it performs the assignment
+ * itself instead of relying on an event reaching the tracker.
+ * </p>
+ * <p>
+ * The call is idempotent: when the tracker did run, the configuration already exists and is already active, and this
+ * becomes a no-op.
+ * </p>
+ */
+public final class IDFBuildConfigurationSetup
+{
+	private IDFBuildConfigurationSetup()
+	{
+	}
+
+	/**
+	 * Schedules creation and activation of the Core Build configuration for a newly created project.
+	 *
+	 * @param project newly created IDF project
+	 * @param launchTarget launch target of the chip selected in the wizard
+	 */
+	public static void schedule(IProject project, ILaunchTarget launchTarget)
+	{
+		if (project == null || launchTarget == null || ILaunchTarget.NULL_TARGET.equals(launchTarget))
+		{
+			return;
+		}
+
+		Job job = new Job(Messages.IDFBuildConfigurationSetup_JobName)
+		{
+			@Override
+			protected IStatus run(IProgressMonitor monitor)
+			{
+				if (monitor.isCanceled() || !project.isAccessible())
+				{
+					return Status.OK_STATUS;
+				}
+
+				try
+				{
+					assignConfiguration(project, launchTarget, monitor);
+				}
+				catch (CoreException e)
+				{
+					Logger.log(e);
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		// Serialises against the tracker job, which takes the same rule, so whichever runs second sees the result of
+		// the first instead of racing it over the project description
+		job.setRule(project.getWorkspace().getRoot());
+		job.schedule();
+	}
+
+	private static void assignConfiguration(IProject project, ILaunchTarget launchTarget, IProgressMonitor monitor)
+			throws CoreException
+	{
+		ICBuildConfigurationManager configManager = CCorePlugin.getService(ICBuildConfigurationManager.class);
+		IToolChainManager toolChainManager = CCorePlugin.getService(IToolChainManager.class);
+		ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+		if (configManager == null || toolChainManager == null || launchBarManager == null
+				|| !configManager.supports(project))
+		{
+			return;
+		}
+
+		ILaunchMode launchMode = launchBarManager.getActiveLaunchMode();
+		String launchModeId = launchMode != null ? launchMode.getIdentifier() : ILaunchManager.RUN_MODE;
+		for (IToolChain toolChain : toolChainManager.getToolChainsMatching(launchTarget.getAttributes()))
+		{
+			ICBuildConfiguration buildConfig = configManager.getBuildConfiguration(project, toolChain, launchModeId,
+					launchTarget, monitor);
+			if (buildConfig != null)
+			{
+				setActive(buildConfig, monitor);
+				return;
+			}
+		}
+
+		Logger.log(MessageFormat.format("No IDF build configuration is available for project {0} and target {1}", //$NON-NLS-1$
+				project.getName(), launchTarget.getId()));
+	}
+
+	private static void setActive(ICBuildConfiguration buildConfig, IProgressMonitor monitor) throws CoreException
+	{
+		if (buildConfig instanceof CBuildConfiguration)
+		{
+			((CBuildConfiguration) buildConfig).setActive(monitor);
+		}
+		if (buildConfig instanceof ICBuildConfiguration2)
+		{
+			((ICBuildConfiguration2) buildConfig).setActive();
+		}
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/Messages.java
@@ -38,6 +38,7 @@ public class Messages extends NLS
 	public static String ToolsInitializationEimMissingMsgBoxMessage;
 
 	public static String RefreshingProjects_JobName;
+	public static String IDFBuildConfigurationSetup_JobName;
 	
 	public static String NoActiveEspIdfInWorkspaceMsgTitle;
 	public static String NoActiveEspIdfInWorkspaceMsg;

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/build/messages.properties
@@ -25,6 +25,7 @@ ToolsInitializationDifferentPathMessageBoxMessage=A different ESP-IDF path was f
 ToolsInitializationDifferentPathMessageBoxOptionYes=Yes
 ToolsInitializationDifferentPathMessageBoxOptionNo=No
 RefreshingProjects_JobName=Refreshing Projects...
+IDFBuildConfigurationSetup_JobName=Setting up build configuration...
 IDFBuildConfiguration_PreCheck_DifferentIdfPath=The project was built using the ESP-IDF located at the {0} path.\nThe currently active ESP-IDF path in the IDE is {1}.\nPlease clean the project using "ESP-IDF:Project Full Clean" menu option to use the active ESP-IDF configuration. 
 IDFToolChainsMissingErrorMsg=Toolchains are missing. Please use ESP-IDF Manager for configuring
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangdConfigFileHandler.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ClangdConfigFileHandler.java
@@ -20,11 +20,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.QualifiedName;
 import org.yaml.snakeyaml.Yaml;
 
 import com.espressif.idf.core.IDFConstants;
-import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.ILSPConstants;
 
 /**
@@ -53,8 +51,7 @@ public class ClangdConfigFileHandler
 				compileFlags = new LinkedHashMap<>();
 				data.put("CompileFlags", compileFlags); //$NON-NLS-1$
 			}
-			updateCompileFlagsSection(compileFlags, project.getPersistentProperty(
-					new QualifiedName(IDFCorePlugin.PLUGIN_ID, IDFConstants.BUILD_DIR_PROPERTY)));
+			updateCompileFlagsSection(compileFlags, IDFUtil.getBuildDir(project));
 
 			// Write updated clangd back to file
 			try (Writer writer = new FileWriter(file, StandardCharsets.UTF_8))
@@ -82,10 +79,10 @@ public class ClangdConfigFileHandler
 		return new LinkedHashMap<>();
 	}
 
-	private void updateCompileFlagsSection(Map<String, Object> compileFlags, String buildFolderName)
+	private void updateCompileFlagsSection(Map<String, Object> compileFlags, String buildFolderPath)
 	{
 		compileFlags.put("CompilationDatabase", //$NON-NLS-1$
-				buildFolderName == null || buildFolderName.isEmpty() ? "build" : buildFolderName); //$NON-NLS-1$
+				buildFolderPath == null || buildFolderPath.isEmpty() ? IDFConstants.BUILD_FOLDER : buildFolderPath);
 		compileFlags.put("Remove", Arrays.asList("-m*", "-f*")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ILaunchDefaultsContributor.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ILaunchDefaultsContributor.java
@@ -1,0 +1,11 @@
+package com.espressif.idf.core.util;
+
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+public interface ILaunchDefaultsContributor
+{
+	/**
+	 * Applies plugin-specific default values to a newly created launch configuration.
+	 */
+	void applyDefaults(ILaunchConfigurationWorkingCopy wc);
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ILaunchDefaultsContributor.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/ILaunchDefaultsContributor.java
@@ -5,7 +5,8 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 public interface ILaunchDefaultsContributor
 {
 	/**
-	 * Applies plugin-specific default values to a newly created launch configuration.
+	 * Fills plugin-specific defaults for attributes that are missing or empty. Must not overwrite values the user
+	 * already set. Safe on both new and existing launch configurations.
 	 */
 	void applyDefaults(ILaunchConfigurationWorkingCopy wc);
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchAttributes.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchAttributes.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+/**
+ * Helpers for launch configuration attributes. Missing keys and blank strings are treated as "use the default".
+ */
+public final class LaunchAttributes
+{
+	private LaunchAttributes()
+	{
+	}
+
+	public static String getString(ILaunchConfiguration configuration, String key, String defaultValue)
+			throws CoreException
+	{
+		String value = configuration.getAttribute(key, defaultValue);
+		return StringUtil.isEmpty(value) ? defaultValue : value;
+	}
+
+	/**
+	 * Returns the stored string as shown in the editor. Missing keys are empty, not substituted with a default.
+	 */
+	public static String getStoredString(ILaunchConfiguration configuration, String key) throws CoreException
+	{
+		if (!configuration.hasAttribute(key))
+		{
+			return StringUtil.EMPTY;
+		}
+		return configuration.getAttribute(key, StringUtil.EMPTY);
+	}
+
+	/**
+	 * Returns the stored integer as text for the editor. Missing keys are empty, not substituted with a default.
+	 */
+	public static String getStoredIntText(ILaunchConfiguration configuration, String key) throws CoreException
+	{
+		if (!configuration.hasAttribute(key))
+		{
+			return StringUtil.EMPTY;
+		}
+		return Integer.toString(configuration.getAttribute(key, 0));
+	}
+
+	/**
+	 * Persists {@code value}, or removes the attribute when it is blank so launch-time defaults apply.
+	 */
+	public static void setOrClearString(ILaunchConfigurationWorkingCopy configuration, String key, String value)
+	{
+		if (StringUtil.isEmpty(value))
+		{
+			configuration.setAttribute(key, (String) null);
+		}
+		else
+		{
+			configuration.setAttribute(key, value);
+		}
+	}
+
+	/**
+	 * Persists a parsed integer, or removes the attribute when {@code text} is blank so launch-time defaults apply.
+	 */
+	public static void setOrClearInt(ILaunchConfigurationWorkingCopy configuration, String key, String text)
+	{
+		if (StringUtil.isEmpty(text))
+		{
+			configuration.setAttribute(key, (String) null);
+			return;
+		}
+		configuration.setAttribute(key, Integer.parseInt(text.trim()));
+	}
+
+	/**
+	 * Writes {@code value} only when the attribute is absent or blank. Does not overwrite a user-set string.
+	 */
+	public static void setStringIfEmpty(ILaunchConfigurationWorkingCopy configuration, String key, String value)
+			throws CoreException
+	{
+		if (StringUtil.isEmpty(configuration.getAttribute(key, StringUtil.EMPTY)))
+		{
+			configuration.setAttribute(key, value);
+		}
+	}
+
+	/**
+	 * Writes {@code value} only when the attribute has never been stored. {@code false} is a valid user choice.
+	 */
+	public static void setIfAbsent(ILaunchConfigurationWorkingCopy configuration, String key, boolean value)
+			throws CoreException
+	{
+		if (!configuration.hasAttribute(key))
+		{
+			configuration.setAttribute(key, value);
+		}
+	}
+
+	/**
+	 * Writes {@code value} only when the attribute has never been stored. {@code 0} is a valid user choice.
+	 */
+	public static void setIfAbsent(ILaunchConfigurationWorkingCopy configuration, String key, int value)
+			throws CoreException
+	{
+		if (!configuration.hasAttribute(key))
+		{
+			configuration.setAttribute(key, value);
+		}
+	}
+}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchDefaults.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/LaunchDefaults.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+import com.espressif.idf.core.logging.Logger;
+
+/**
+ * Invokes {@link ILaunchDefaultsContributor} extensions so missing or empty launch attributes get plugin defaults.
+ */
+public final class LaunchDefaults
+{
+	public static final String EXTENSION_POINT_ID = "com.espressif.idf.core.launchDefaultsContributor"; //$NON-NLS-1$
+
+	private LaunchDefaults()
+	{
+	}
+
+	public static void apply(ILaunchConfigurationWorkingCopy workingCopy)
+	{
+		IConfigurationElement[] elements = Platform.getExtensionRegistry()
+				.getConfigurationElementsFor(EXTENSION_POINT_ID);
+		for (IConfigurationElement element : elements)
+		{
+			try
+			{
+				Object obj = element.createExecutableExtension("class"); //$NON-NLS-1$
+				if (obj instanceof ILaunchDefaultsContributor contributor)
+				{
+					contributor.applyDefaults(workingCopy);
+				}
+			}
+			catch (CoreException e)
+			{
+				Logger.log(e);
+			}
+		}
+	}
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -14,14 +14,16 @@
 -->
 
 <plugin>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+            id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
+            modes="debug,run"
+            name="%launchConfig.name"
+            public="true">
+      </launchConfigurationType>
+   </extension>
 
-	<extension point="org.eclipse.debug.core.launchConfigurationTypes">
-		<launchConfigurationType
-			id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
-			modes="debug,run"
-			name="%launchConfig.name"
-			public="true" />
-	</extension>
 
 	<extension point="org.eclipse.debug.core.launchDelegates">
 		<launchDelegate
@@ -34,6 +36,16 @@
 			sourcePathComputerId="org.eclipse.cdt.debug.core.sourcePathComputer"
 			type="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType">
 		</launchDelegate>
+  <launchDelegate
+        delegate="com.espressif.idf.debug.gdbjtag.openocd.dsf.LaunchConfigurationDelegate"
+        delegateDescription="%launchDelegate.jtagDsf.description"
+        id="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified"
+        modes="debug"
+        name="%launchDelegate.jtagDsf.name"
+        sourceLocatorId="org.eclipse.cdt.debug.core.sourceLocator"
+        sourcePathComputerId="org.eclipse.cdt.debug.core.sourcePathComputer"
+        type="com.espressif.idf.launch.serial.launchConfigurationType">
+  </launchDelegate>
 	</extension>
 
 	<extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
@@ -175,67 +187,130 @@
           plugin="com.espressif.idf.debug.gdbjtag.openocd">
     </statusHandler>
  </extension>
- <extension
-       point="org.eclipse.debug.ui.launchConfigurationTabs">
+ <extension point="org.eclipse.debug.ui.launchConfigurationTabs">
+    
+    <!-- LEGACY LAYOUT: Main Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabMain"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="org.eclipse.cdt.cdi.launch.mainTab"
           name="Main">
     </tab>
+
+    <!-- LEGACY LAYOUT: Debugger Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabDebugger"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab"
           name="Debugger">
-       <placement
-             after="org.eclipse.cdt.cdi.launch.mainTab">
-       </placement>
+       <placement after="org.eclipse.cdt.cdi.launch.mainTab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Startup Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabStartup"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab"
           name="Startup">
-       <placement
-             after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab">
-       </placement>
+       <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Source Lookup Tab -->
     <tab
           class="org.eclipse.debug.ui.sourcelookup.SourceLookupTab"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
-          id="org.eclipse.debug.ui.sourceLookupTab"
+          id= "org.eclipse.debug.ui.sourceLookupTab"
           name="SourceLookupTab">
-       <placement
-             after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab">
-       </placement>
+       <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Common Tab -->
+
+    <!-- 5. Common Tab -->
     <tab
-          class="org.eclipse.debug.ui.CommonTab"
-          group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
-          id="org.eclipse.debug.ui.commonTab"
-          name="CommonTab">
-       <placement
-             after="org.eclipse.debug.ui.sourceLookupTab">
-       </placement>
+         class="org.eclipse.debug.ui.CommonTab"
+         group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
+         id="org.eclipse.debug.ui.commonTab"
+         name="CommonTab">
+       	 <placement after="org.eclipse.debug.ui.sourceLookupTab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: SVD Target Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="org.eclipse.embedcdt.debug.gdbjtag.ui.svdtab"
           name="TabSvdTarget">
-       <placement
-             after="org.eclipse.debug.ui.commonTab">
-       </placement>
+       <placement after="org.eclipse.debug.ui.commonTab" />
     </tab>
+
+</extension>
+<extension point="org.eclipse.debug.ui.launchConfigurationTabs">
+    <!-- 1. Main Tab -->
     <tab
-          class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabDebugger"
-          group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
-          id="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab"
-          name="Debugger">
-       <placement
-             after="org.eclipse.cdt.cdi.launch.mainTab">
-       </placement>
+          class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabMain"
+          group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+          id="org.eclipse.cdt.cdi.launch.mainTab"
+          name="Main">
+       <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
     </tab>
- </extension>
+
+    <!-- 2. Debugger Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabDebugger"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab"
+        name="Debugger">
+        <placement after="org.eclipse.cdt.cdi.launch.mainTab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 3. Startup Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabStartup"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab"
+        name="Startup">
+        <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 4. Source Lookup Tab -->
+    <tab
+        class="org.eclipse.debug.ui.sourcelookup.SourceLookupTab"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="org.eclipse.debug.ui.sourceLookupTab"
+        name="SourceLookupTab">
+        <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+    
+    <!-- 5. Common Tab -->
+    <tab
+         class="org.eclipse.debug.ui.CommonTab"
+         group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+         id="org.eclipse.debug.ui.commonTab"
+         name="CommonTab">
+       	 <placement after="org.eclipse.debug.ui.sourceLookupTab" />
+       	 <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 6. Svd Target Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="org.eclipse.embedcdt.debug.gdbjtag.ui.svdtab"
+        name="TabSvdTarget">
+        <placement after="org.eclipse.debug.ui.commonTab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+</extension>
+<extension
+      point="com.espressif.idf.core.launchDefaultsContributor">
+   <contributor
+         class="com.espressif.idf.debug.gdbjtag.openocd.preferences.OpenOCDDefaultsInjector">
+   </contributor>
+</extension>
+
 </plugin>

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -14,14 +14,16 @@
 -->
 
 <plugin>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+            id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
+            modes="debug,run"
+            name="%launchConfig.name"
+            public="true">
+      </launchConfigurationType>
+   </extension>
 
-	<extension point="org.eclipse.debug.core.launchConfigurationTypes">
-		<launchConfigurationType
-			id="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType"
-			modes="debug,run"
-			name="%launchConfig.name"
-			public="true" />
-	</extension>
 
 	<extension point="org.eclipse.debug.core.launchDelegates">
 		<launchDelegate
@@ -34,6 +36,16 @@
 			sourcePathComputerId="org.eclipse.cdt.debug.core.sourcePathComputer"
 			type="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationType">
 		</launchDelegate>
+  <launchDelegate
+        delegate="com.espressif.idf.debug.gdbjtag.openocd.dsf.LaunchConfigurationDelegate"
+        delegateDescription="%launchDelegate.jtagDsf.description"
+        id="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified"
+        modes="debug"
+        name="%launchDelegate.jtagDsf.name"
+        sourceLocatorId="org.eclipse.cdt.debug.core.sourceLocator"
+        sourcePathComputerId="org.eclipse.cdt.debug.core.sourcePathComputer"
+        type="com.espressif.idf.launch.serial.launchConfigurationType">
+  </launchDelegate>
 	</extension>
 
 	<extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
@@ -181,58 +193,128 @@
           plugin="com.espressif.idf.debug.gdbjtag.openocd">
     </statusHandler>
  </extension>
- <extension
-       point="org.eclipse.debug.ui.launchConfigurationTabs">
+ <extension point="org.eclipse.debug.ui.launchConfigurationTabs">
+    
+    <!-- LEGACY LAYOUT: Main Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabMain"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="org.eclipse.cdt.cdi.launch.mainTab"
           name="Main">
     </tab>
+
+    <!-- LEGACY LAYOUT: Debugger Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabDebugger"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab"
           name="Debugger">
-       <placement
-             after="org.eclipse.cdt.cdi.launch.mainTab">
-       </placement>
+       <placement after="org.eclipse.cdt.cdi.launch.mainTab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Startup Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabStartup"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab"
           name="Startup">
-       <placement
-             after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab">
-       </placement>
+       <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Source Lookup Tab -->
     <tab
           class="org.eclipse.debug.ui.sourcelookup.SourceLookupTab"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
-          id="org.eclipse.debug.ui.sourceLookupTab"
+          id= "org.eclipse.debug.ui.sourceLookupTab"
           name="SourceLookupTab">
-       <placement
-             after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab">
-       </placement>
+       <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: Common Tab -->
+
+    <!-- 5. Common Tab -->
     <tab
-          class="org.eclipse.debug.ui.CommonTab"
-          group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
-          id="org.eclipse.debug.ui.commonTab"
-          name="CommonTab">
-       <placement
-             after="org.eclipse.debug.ui.sourceLookupTab">
-       </placement>
+         class="org.eclipse.debug.ui.CommonTab"
+         group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
+         id="org.eclipse.debug.ui.commonTab"
+         name="CommonTab">
+       	 <placement after="org.eclipse.debug.ui.sourceLookupTab" />
     </tab>
+
+    <!-- LEGACY LAYOUT: SVD Target Tab -->
     <tab
           class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget"
           group="com.espressif.idf.debug.gdbjtag.openocd.launchConfigurationTabGroup"
           id="org.eclipse.embedcdt.debug.gdbjtag.ui.svdtab"
           name="TabSvdTarget">
-       <placement
-             after="org.eclipse.debug.ui.commonTab">
-       </placement>
+       <placement after="org.eclipse.debug.ui.commonTab" />
     </tab>
  </extension>
+<extension point="org.eclipse.debug.ui.launchConfigurationTabs">
+    <!-- 1. Main Tab -->
+    <tab
+          class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabMain"
+          group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+          id="org.eclipse.cdt.cdi.launch.mainTab"
+          name="Main">
+       <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 2. Debugger Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabDebugger"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab"
+        name="Debugger">
+        <placement after="org.eclipse.cdt.cdi.launch.mainTab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 3. Startup Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabStartup"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab"
+        name="Startup">
+        <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.debuggertab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 4. Source Lookup Tab -->
+    <tab
+        class="org.eclipse.debug.ui.sourcelookup.SourceLookupTab"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="org.eclipse.debug.ui.sourceLookupTab"
+        name="SourceLookupTab">
+        <placement after="com.espressif.idf.debug.gdbjtag.openocd.ui.startuptab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+    
+    <!-- 5. Common Tab -->
+    <tab
+         class="org.eclipse.debug.ui.CommonTab"
+         group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+         id="org.eclipse.debug.ui.commonTab"
+         name="CommonTab">
+       	 <placement after="org.eclipse.debug.ui.sourceLookupTab" />
+       	 <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+    <!-- 6. Svd Target Tab -->
+    <tab
+        class="com.espressif.idf.debug.gdbjtag.openocd.ui.TabSvdTarget"
+        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+        id="org.eclipse.embedcdt.debug.gdbjtag.ui.svdtab"
+        name="TabSvdTarget">
+        <placement after="org.eclipse.debug.ui.commonTab" />
+        <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />
+    </tab>
+
+</extension>
+<extension
+      point="com.espressif.idf.core.launchDefaultsContributor">
+   <contributor
+         class="com.espressif.idf.debug.gdbjtag.openocd.preferences.OpenOCDDefaultsInjector">
+   </contributor>
+</extension>
 </plugin>

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/plugin.xml
@@ -291,10 +291,12 @@
     </tab>
     
     <!-- 5. Common Tab -->
+    <!-- Contributed tabs are registered per group under their id, so this declaration needs an id of its own to
+         coexist with the Run mode Common tab of com.espressif.idf.launch.serial.ui instead of replacing it. -->
     <tab
          class="org.eclipse.debug.ui.CommonTab"
          group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
-         id="org.eclipse.debug.ui.commonTab"
+         id="com.espressif.idf.debug.gdbjtag.openocd.ui.commonTab"
          name="CommonTab">
        	 <placement after="org.eclipse.debug.ui.sourceLookupTab" />
        	 <associatedDelegate delegate="com.espressif.idf.debug.gdbjtag.openocd.core.dsfLaunchDelegate.unified" />

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/Configuration.java
@@ -20,11 +20,8 @@ import java.util.List;
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
 import org.eclipse.cdt.debug.gdbjtag.core.IGDBJtagConstants;
 import org.eclipse.cdt.dsf.gdb.IGDBLaunchConfigurationConstants;
-import org.eclipse.cdt.dsf.gdb.IGdbDebugPreferenceConstants;
-import org.eclipse.cdt.dsf.gdb.internal.GdbPlugin;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.embedcdt.core.EclipseUtils;
@@ -34,8 +31,10 @@ import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.util.LaunchAttributes;
 import com.espressif.idf.core.util.OpenOcdVersionManager;
 import com.espressif.idf.core.util.PortChecker;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.launch.serial.util.ESPFlashUtil;
 
@@ -51,13 +50,13 @@ public class Configuration
 		try
 		{
 
-			if (executable == null)
+			if (StringUtil.isEmpty(executable))
 			{
 				if (!configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_SERVER,
 						DefaultPreferences.DO_START_GDB_SERVER_DEFAULT))
 					return null;
 
-				executable = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
+				executable = LaunchAttributes.getString(configuration, ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
 						DefaultPreferences.GDB_SERVER_EXECUTABLE_DEFAULT);
 				// executable = Utils.escapeWhitespaces(executable).trim();
 			}
@@ -139,14 +138,16 @@ public class Configuration
 			lst.add("-c"); //$NON-NLS-1$
 			lst.add(String.format(fmtTelnetPort, port));
 
-			port = Integer.parseInt(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+			port = Integer.parseInt(LaunchAttributes.getString(configuration,
+					ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
 					DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT));
 
 			lst.add("-c"); //$NON-NLS-1$
 			lst.add(String.format(fmtTclPort, port));
 
-			String other = configuration
-					.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
+			String other = LaunchAttributes
+					.getString(configuration, ConfigurationAttributes.GDB_SERVER_OTHER,
+							DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
 					.trim();
 			other = resolveAll(other, configuration);
 
@@ -182,7 +183,8 @@ public class Configuration
 
 	private static boolean isVerboseOutputEnabled(ILaunchConfiguration configuration) throws CoreException
 	{
-		return configuration.getAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, false);
+		return configuration.getAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT,
+				DefaultPreferences.ENABLE_VERBOSE_OUTPUT_DEFAULT);
 	}
 
 	public static String getGdbServerCommandName(ILaunchConfiguration config)
@@ -195,8 +197,8 @@ public class Configuration
 	public static String getGdbServerOtherConfig(ILaunchConfiguration config) throws CoreException
 	{
 
-		return config
-				.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
+		return LaunchAttributes
+				.getString(config, ConfigurationAttributes.GDB_SERVER_OTHER, DefaultPreferences.GDB_SERVER_OTHER_DEFAULT)
 				.trim();
 	}
 
@@ -208,14 +210,10 @@ public class Configuration
 		try
 		{
 
-			if (executable == null)
+			if (StringUtil.isEmpty(executable))
 			{
-				String defaultGdbCommand = Platform.getPreferencesService().getString(GdbPlugin.PLUGIN_ID,
-						IGdbDebugPreferenceConstants.PREF_DEFAULT_GDB_COMMAND,
-						IGDBLaunchConfigurationConstants.DEBUGGER_DEBUG_NAME_DEFAULT, null);
-
-				executable = configuration.getAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
-						defaultGdbCommand);
+				executable = LaunchAttributes.getString(configuration, IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
+						DefaultPreferences.GDB_CLIENT_EXECUTABLE_DYNAMIC_DEFAULT);
 			}
 
 			executable = resolveAll(executable, configuration);
@@ -232,7 +230,8 @@ public class Configuration
 
 	public static boolean getDoFlashBeforeStart(ILaunchConfiguration configuration) throws CoreException
 	{
-		return configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, false);
+		return configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START,
+				DefaultPreferences.DO_FLASH_BEFORE_START_DEFAULT);
 	}
 
 	public static String[] getGdbClientCommandLineArray(ILaunchConfiguration configuration)
@@ -257,7 +256,7 @@ public class Configuration
 		String other;
 		try
 		{
-			other = configuration.getAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
+			other = LaunchAttributes.getString(configuration, ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
 					DefaultPreferences.GDB_CLIENT_OTHER_OPTIONS_DEFAULT).trim();
 
 			other = DebugUtils.resolveAll(other, configuration.getAttributes());
@@ -363,7 +362,7 @@ public class Configuration
 				DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT));
 		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER, telnetPort);
 
-		int tclPort = PortChecker.getAvailablePort(Integer.parseInt(configuration.getAttribute(
+		int tclPort = PortChecker.getAvailablePort(Integer.parseInt(LaunchAttributes.getString(configuration,
 				ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
 				DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT)));
 		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER, String.valueOf(tclPort));

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/DebuggerCommands.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/DebuggerCommands.java
@@ -30,6 +30,7 @@ import org.osgi.framework.BundleContext;
 
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.IIDFGDBJtagConstants;
@@ -58,7 +59,7 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 	@Override
 	public IStatus addGdbInitCommandsCommands(List<String> commandsList)
 	{
-		String otherInits = CDebugUtils.getAttribute(fAttributes, ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
+		String otherInits = getStringAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
 				DefaultPreferences.GDB_CLIENT_OTHER_COMMANDS_DEFAULT).trim();
 
 		otherInits = DebugUtils.resolveAll(otherInits, fAttributes);
@@ -127,7 +128,7 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 		{
 
 			String commandStr = DefaultPreferences.DO_FIRST_RESET_COMMAND;
-			String resetType = CDebugUtils.getAttribute(fAttributes, ConfigurationAttributes.FIRST_RESET_TYPE,
+			String resetType = getStringAttribute(ConfigurationAttributes.FIRST_RESET_TYPE,
 					DefaultPreferences.FIRST_RESET_TYPE_DEFAULT);
 			commandsList.add(commandStr + resetType);
 
@@ -137,7 +138,7 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 			commandsList.add(commandStr);
 		}
 
-		String otherInits = CDebugUtils.getAttribute(fAttributes, ConfigurationAttributes.OTHER_INIT_COMMANDS,
+		String otherInits = getStringAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS,
 				DefaultPreferences.OTHER_INIT_COMMANDS_DEFAULT).trim();
 
 		otherInits = otherInits.replace(DefaultPreferences.IDF_TARGET_CPU_WATCHPOINT_NUM,
@@ -169,7 +170,7 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 					DefaultPreferences.DO_SECOND_RESET_DEFAULT))
 			{
 				String commandStr = DefaultPreferences.DO_SECOND_RESET_COMMAND;
-				String resetType = CDebugUtils.getAttribute(fAttributes, ConfigurationAttributes.SECOND_RESET_TYPE,
+				String resetType = getStringAttribute(ConfigurationAttributes.SECOND_RESET_TYPE,
 						DefaultPreferences.SECOND_RESET_TYPE_DEFAULT);
 				commandsList.add(commandStr + resetType);
 
@@ -194,7 +195,7 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 			}
 		}
 
-		String userCmd = CDebugUtils.getAttribute(fAttributes, ConfigurationAttributes.OTHER_RUN_COMMANDS,
+		String userCmd = getStringAttribute(ConfigurationAttributes.OTHER_RUN_COMMANDS,
 				DefaultPreferences.OTHER_RUN_COMMANDS_DEFAULT).trim();
 
 		userCmd = DebugUtils.resolveAll(userCmd, fAttributes);
@@ -219,6 +220,12 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService
 		}
 
 		return Status.OK_STATUS;
+	}
+
+	private String getStringAttribute(String key, String defaultValue)
+	{
+		String value = CDebugUtils.getAttribute(fAttributes, key, defaultValue);
+		return StringUtil.isEmpty(value) ? defaultValue : value;
 	}
 
 	// ------------------------------------------------------------------------

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/Launch.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 
-import org.eclipse.cdt.debug.gdbjtag.core.IGDBJtagConstants;
-import org.eclipse.cdt.dsf.gdb.IGDBLaunchConfigurationConstants;
 import org.eclipse.cdt.dsf.gdb.internal.GdbPlugin;
 import org.eclipse.cdt.dsf.gdb.launching.GdbLaunch;
 import org.eclipse.cdt.dsf.service.DsfServicesTracker;
@@ -41,11 +39,10 @@ import org.eclipse.debug.core.model.ISourceLocator;
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.GnuMcuLaunch;
 
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.LaunchDefaults;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
-import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.dsf.process.CustomIdfProcessFactory;
-import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 
 @SuppressWarnings("restriction")
 public class Launch extends GnuMcuLaunch
@@ -125,24 +122,7 @@ public class Launch extends GnuMcuLaunch
 	protected void provideDefaults(ILaunchConfigurationWorkingCopy config) throws CoreException
 	{
 		super.provideDefaults(config);
-
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS))
-			config.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
-
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID))
-			config.setAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID, ConfigurationAttributes.JTAG_DEVICE);
-
-		if (!config.hasAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER))
-			config.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
-					DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
-
-		if (!config.hasAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME))
-			config.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
-					Activator.getInstance().getDefaultPreferences().getGdbClientExecutable());
-
-		if (Configuration.getDoStartGdbServer(config))
-			config.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
-
+		LaunchDefaults.apply(config);
 		config.setAttribute(DebugPlugin.ATTR_PROCESS_FACTORY_ID, CustomIdfProcessFactory.ID);
 	}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -65,6 +65,7 @@ import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.AbstractGnuMcuLaunchConfigura
 import org.eclipse.embedcdt.debug.gdbjtag.core.dsf.GnuMcuServerServicesLaunchSequence;
 
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.LaunchDefaults;
 import com.espressif.idf.core.variable.JtagVariableResolver;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
@@ -127,6 +128,7 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			throws CoreException
 	{
 		ILaunchConfigurationWorkingCopy wc = configuration.getWorkingCopy();
+		LaunchDefaults.apply(wc);
 		if (Configuration.getDoStartGdbServer(wc))
 		{
 			Configuration.allocateServerPorts(wc);

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/dsf/LaunchConfigurationDelegate.java
@@ -327,9 +327,16 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			return;
 		}
 
-		SessionType sessionType = LaunchUtils.getSessionType(config);
-		boolean attach = LaunchUtils.getIsAttach(config);
 		final Launch launch = (Launch) l;
+		// CDT reads ATTR_PROGRAM_NAME from this object. Empty C/C++ Application means
+		// ${default_app}; apply that on the launch working copy so the binary check
+		// does not report "Program file not specified".
+		ILaunchConfiguration source = launch.getLaunchConfiguration() != null ? launch.getLaunchConfiguration()
+				: config;
+		ILaunchConfiguration resolvedConfig = applyLaunchDefaults(source);
+
+		SessionType sessionType = LaunchUtils.getSessionType(resolvedConfig);
+		boolean attach = LaunchUtils.getIsAttach(resolvedConfig);
 
 		if (sessionType == SessionType.REMOTE)
 			monitor.subTask(LaunchMessages.getString("GdbLaunchDelegate.1"));
@@ -339,34 +346,35 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			monitor.subTask(LaunchMessages.getString("GdbLaunchDelegate.3"));
 
 		if (!attach)
-			checkBinaryDetails(config);
+			checkBinaryDetails(resolvedConfig);
 
 		monitor.worked(1);
-		fIsNonStopSession = LaunchUtils.getIsNonStopMode(config);
+		fIsNonStopSession = LaunchUtils.getIsNonStopMode(resolvedConfig);
 
 		if (launch.getDoStartGdbClient())
 		{
-			String gdbVersion = getGDBVersion(config);
+			String gdbVersion = getGDBVersion(resolvedConfig);
 
-			if (LaunchUtils.getIsNonStopMode(config) && !isNonStopSupportedInGdbVersion(gdbVersion))
+			if (LaunchUtils.getIsNonStopMode(resolvedConfig) && !isNonStopSupportedInGdbVersion(gdbVersion))
 			{
 				cleanupLaunch(launch);
 				throw new DebugException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, DebugException.REQUEST_FAILED,
 						"Non-stop mode is not supported", null));
 			}
 
-			if (LaunchUtils.getIsPostMortemTracing(config) && !isPostMortemTracingSupportedInGdbVersion(gdbVersion))
+			if (LaunchUtils.getIsPostMortemTracing(resolvedConfig)
+					&& !isPostMortemTracingSupportedInGdbVersion(gdbVersion))
 			{
 				cleanupLaunch(launch);
 				throw new DebugException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, DebugException.REQUEST_FAILED,
 						"Post-mortem tracing is not supported", null));
 			}
 
-			launch.setServiceFactory(newServiceFactory(config, gdbVersion, launch.getLaunchMode()));
+			launch.setServiceFactory(newServiceFactory(resolvedConfig, gdbVersion, launch.getLaunchMode()));
 		}
 		else
 		{
-			launch.setServiceFactory(newServiceFactory(config, "7.0", launch.getLaunchMode()));
+			launch.setServiceFactory(newServiceFactory(resolvedConfig, "7.0", launch.getLaunchMode()));
 		}
 
 		launch.initialize();
@@ -592,10 +600,12 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 	@Override
 	protected IPath checkBinaryDetails(final ILaunchConfiguration config) throws CoreException
 	{
+		ILaunchConfiguration resolvedConfig = applyLaunchDefaults(config);
+
 		boolean doStartServer = true;
 		try
 		{
-			doStartServer = Configuration.getDoStartGdbServer(config);
+			doStartServer = Configuration.getDoStartGdbServer(resolvedConfig);
 		}
 		catch (CoreException e)
 		{
@@ -607,7 +617,7 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			String configOptions = "";
 			try
 			{
-				configOptions = Configuration.getGdbServerOtherConfig(config);
+				configOptions = Configuration.getGdbServerOtherConfig(resolvedConfig);
 			}
 			catch (CoreException e)
 			{
@@ -620,7 +630,7 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 			// Abort early with a clear, actionable message when no board is selected for the active target. Otherwise
 			// OpenOCD would start without a board configuration and fail later with the cryptic
 			// "invalid command name \"program_esp_bins\"" error.
-			if (!isBoardConfigured(config))
+			if (!isBoardConfigured(resolvedConfig))
 			{
 				IStatus status = new Status(IStatus.OK, Activator.PLUGIN_ID, BOARD_NOT_SELECTED_STATUS_CODE,
 						"No board is selected for the debug target.", null); //$NON-NLS-1$
@@ -632,7 +642,20 @@ public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurati
 				throw new DebugException(Status.OK_STATUS);
 			}
 		}
-		return super.checkBinaryDetails(config);
+		return super.checkBinaryDetails(resolvedConfig);
+	}
+
+	/**
+	 * Fills empty attributes on a working copy, including C/C++ Application → {@code ${default_app}}. Mutates an
+	 * existing working copy in place so the Launch and CDT's program check share the same values.
+	 */
+	private ILaunchConfiguration applyLaunchDefaults(ILaunchConfiguration config) throws CoreException
+	{
+		ILaunchConfigurationWorkingCopy wc = config instanceof ILaunchConfigurationWorkingCopy workingCopy
+				? workingCopy
+				: config.getWorkingCopy();
+		LaunchDefaults.apply(wc);
+		return wc;
 	}
 
 	/**

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/DefaultPreferences.java
@@ -83,6 +83,9 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	public static final boolean DO_CONTINUE_DEFAULT = true;
 
+	public static final boolean DO_FLASH_BEFORE_START_DEFAULT = true;
+	public static final boolean ENABLE_VERBOSE_OUTPUT_DEFAULT = false;
+
 	// ------------------------------------------------------------------------
 
 	// Debugger commands

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/OpenOCDDefaultsInjector.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/OpenOCDDefaultsInjector.java
@@ -1,0 +1,127 @@
+package com.espressif.idf.debug.gdbjtag.openocd.preferences;
+
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
+import org.eclipse.cdt.debug.gdbjtag.core.IGDBJtagConstants;
+import org.eclipse.cdt.dsf.gdb.IGDBLaunchConfigurationConstants;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.variables.VariablesPlugin;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.ILaunchDefaultsContributor;
+import com.espressif.idf.debug.gdbjtag.openocd.Activator;
+import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
+import com.espressif.idf.debug.gdbjtag.openocd.IIDFGDBJtagConstants;
+
+public class OpenOCDDefaultsInjector implements ILaunchDefaultsContributor
+{
+
+	private static final String ESP_SVD_PATH = "esp_svd_path"; //$NON-NLS-1$
+
+	@Override
+	public void applyDefaults(ILaunchConfigurationWorkingCopy configuration)
+	{
+
+		PersistentPreferences persistentPrefs = Activator.getInstance().getPersistentPreferences();
+
+		try
+		{
+			if (configuration.hasAttribute(ConfigurationAttributes.DO_START_GDB_SERVER))
+			{
+				return;
+			}
+		}
+		catch (CoreException e)
+		{
+			Logger.log("Failed to check OpenOCD defaults guard", e);
+		}
+
+		configuration.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+				DefaultPreferences.PROGRAM_APP_DEFAULT);
+		// --- 1. JTAG Device Setup ---
+		configuration.setAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID, ConfigurationAttributes.JTAG_DEVICE);
+
+		// --- 2. OpenOCD GDB Server Setup ---
+		configuration.setAttribute(ConfigurationAttributes.DO_START_GDB_SERVER, persistentPrefs.getGdbServerDoStart());
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
+				persistentPrefs.getGdbServerExecutable());
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_CONNECTION_ADDRESS,
+				DefaultPreferences.GDB_SERVER_CONNECTION_ADDRESS_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
+				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
+				DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+				DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_LOG, DefaultPreferences.GDB_SERVER_LOG_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_CONSOLE,
+				DefaultPreferences.DO_GDB_SERVER_ALLOCATE_CONSOLE_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE,
+				DefaultPreferences.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_OTHER,
+				DefaultPreferences.GDB_SERVER_OTHER_DEFAULT);
+
+		// --- 3. GDB Client Setup ---
+		configuration.setAttribute(IGDBJtagConstants.ATTR_USE_REMOTE_TARGET,
+				DefaultPreferences.USE_REMOTE_TARGET_DEFAULT);
+		configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
+				DefaultPreferences.GDB_CLIENT_EXECUTABLE_DYNAMIC_DEFAULT);
+		configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
+				persistentPrefs.getGdbClientOtherOptions());
+		configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
+				persistentPrefs.getGdbClientCommands());
+
+		// --- 4. Thread List Setup ---
+		configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUGGER_UPDATE_THREADLIST_ON_SUSPEND,
+				DefaultPreferences.UPDATE_THREAD_LIST_DEFAULT);
+
+		// --- 5. SVD Target Setup ---
+		// Using the embedcdt ConfigurationAttributes explicitly to avoid namespace collision
+		configuration.setAttribute(org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes.SVD_PATH,
+				VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(ESP_SVD_PATH, null));
+		
+		// --- 6. Initialisation Commands (from TabStartup) ---
+        configuration.setAttribute(ConfigurationAttributes.DO_FIRST_RESET, persistentPrefs.getOpenOCDDoInitialReset());
+        configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, persistentPrefs.getOpenOCDInitialResetType());
+        configuration.setAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, persistentPrefs.getOpenOCDEnableSemihosting());
+        configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, persistentPrefs.getOpenOCDInitOther());
+
+        // --- 7. Load Image & Symbols (from TabStartup) ---
+        configuration.setAttribute(IGDBJtagConstants.ATTR_LOAD_IMAGE, IIDFGDBJtagConstants.DEFAULT_LOAD_IMAGE);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_IMAGE, IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_IMAGE);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_IMAGE, IGDBJtagConstants.DEFAULT_USE_FILE_FOR_IMAGE);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_FILE_NAME, IGDBJtagConstants.DEFAULT_IMAGE_FILE_NAME);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_OFFSET, IGDBJtagConstants.DEFAULT_IMAGE_OFFSET);
+        
+        configuration.setAttribute(IGDBJtagConstants.ATTR_LOAD_SYMBOLS, IGDBJtagConstants.DEFAULT_LOAD_SYMBOLS);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_SYMBOLS, IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_SYMBOLS);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_SYMBOLS, IGDBJtagConstants.DEFAULT_USE_FILE_FOR_SYMBOLS);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME, IGDBJtagConstants.DEFAULT_SYMBOLS_FILE_NAME);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_OFFSET, IGDBJtagConstants.DEFAULT_SYMBOLS_OFFSET);
+
+        // --- 8. Runtime Options & Run Commands (from TabStartup) ---
+        configuration.setAttribute(ConfigurationAttributes.DO_DEBUG_IN_RAM, persistentPrefs.getOpenOCDDebugInRam());
+        configuration.setAttribute(ConfigurationAttributes.DO_SECOND_RESET, persistentPrefs.getOpenOCDDoPreRunReset());
+        configuration.setAttribute(ConfigurationAttributes.SECOND_RESET_TYPE, persistentPrefs.getOpenOCDPreRunResetType());
+        configuration.setAttribute(ConfigurationAttributes.OTHER_RUN_COMMANDS, persistentPrefs.getOpenOCDPreRunOther());
+
+        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_PC_REGISTER, IGDBJtagConstants.DEFAULT_SET_PC_REGISTER);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_PC_REGISTER, IGDBJtagConstants.DEFAULT_PC_REGISTER);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_STOP_AT, DefaultPreferences.DO_STOP_AT_DEFAULT);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_STOP_AT, DefaultPreferences.STOP_AT_NAME_DEFAULT);
+        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_RESUME, IGDBJtagConstants.DEFAULT_SET_RESUME);
+        configuration.setAttribute(ConfigurationAttributes.DO_CONTINUE, DefaultPreferences.DO_CONTINUE_DEFAULT);
+
+
+		configuration.setAttribute(ConfigurationAttributes.DO_START_GDB_CLIENT,
+				DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);
+
+		configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
+
+		configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
+				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
+
+		configuration.setAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, true);
+		configuration.setAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, false);
+	}
+}

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/OpenOCDDefaultsInjector.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/preferences/OpenOCDDefaultsInjector.java
@@ -9,6 +9,7 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.ILaunchDefaultsContributor;
+import com.espressif.idf.core.util.LaunchAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.IIDFGDBJtagConstants;
@@ -21,107 +22,123 @@ public class OpenOCDDefaultsInjector implements ILaunchDefaultsContributor
 	@Override
 	public void applyDefaults(ILaunchConfigurationWorkingCopy configuration)
 	{
-
 		PersistentPreferences persistentPrefs = Activator.getInstance().getPersistentPreferences();
 
 		try
 		{
-			if (configuration.hasAttribute(ConfigurationAttributes.DO_START_GDB_SERVER))
-			{
-				return;
-			}
+			LaunchAttributes.setStringIfEmpty(configuration, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+					DefaultPreferences.PROGRAM_APP_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_JTAG_DEVICE_ID,
+					ConfigurationAttributes.JTAG_DEVICE);
+
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_START_GDB_SERVER,
+					persistentPrefs.getGdbServerDoStart());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
+					persistentPrefs.getGdbServerExecutable());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_SERVER_CONNECTION_ADDRESS,
+					DefaultPreferences.GDB_SERVER_CONNECTION_ADDRESS_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
+					DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
+					DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+					DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_SERVER_LOG,
+					DefaultPreferences.GDB_SERVER_LOG_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_CONSOLE,
+					DefaultPreferences.DO_GDB_SERVER_ALLOCATE_CONSOLE_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE,
+					DefaultPreferences.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_SERVER_OTHER,
+					DefaultPreferences.GDB_SERVER_OTHER_DEFAULT);
+
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_USE_REMOTE_TARGET,
+					DefaultPreferences.USE_REMOTE_TARGET_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
+					DefaultPreferences.GDB_CLIENT_EXECUTABLE_DYNAMIC_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
+					persistentPrefs.getGdbClientOtherOptions());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
+					persistentPrefs.getGdbClientCommands());
+
+			LaunchAttributes.setIfAbsent(configuration,
+					IGDBLaunchConfigurationConstants.ATTR_DEBUGGER_UPDATE_THREADLIST_ON_SUSPEND,
+					DefaultPreferences.UPDATE_THREAD_LIST_DEFAULT);
+
+			LaunchAttributes.setStringIfEmpty(configuration,
+					org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes.SVD_PATH,
+					VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(ESP_SVD_PATH,
+							null));
+
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_FIRST_RESET,
+					persistentPrefs.getOpenOCDDoInitialReset());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.FIRST_RESET_TYPE,
+					persistentPrefs.getOpenOCDInitialResetType());
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.ENABLE_SEMIHOSTING,
+					persistentPrefs.getOpenOCDEnableSemihosting());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.OTHER_INIT_COMMANDS,
+					persistentPrefs.getOpenOCDInitOther());
+
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_LOAD_IMAGE,
+					IIDFGDBJtagConstants.DEFAULT_LOAD_IMAGE);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_IMAGE,
+					IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_IMAGE);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_USE_FILE_FOR_IMAGE,
+					IGDBJtagConstants.DEFAULT_USE_FILE_FOR_IMAGE);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_IMAGE_FILE_NAME,
+					IGDBJtagConstants.DEFAULT_IMAGE_FILE_NAME);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_IMAGE_OFFSET,
+					IGDBJtagConstants.DEFAULT_IMAGE_OFFSET);
+
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_LOAD_SYMBOLS,
+					IGDBJtagConstants.DEFAULT_LOAD_SYMBOLS);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_SYMBOLS,
+					IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_SYMBOLS);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_USE_FILE_FOR_SYMBOLS,
+					IGDBJtagConstants.DEFAULT_USE_FILE_FOR_SYMBOLS);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME,
+					IGDBJtagConstants.DEFAULT_SYMBOLS_FILE_NAME);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_SYMBOLS_OFFSET,
+					IGDBJtagConstants.DEFAULT_SYMBOLS_OFFSET);
+
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_DEBUG_IN_RAM,
+					persistentPrefs.getOpenOCDDebugInRam());
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_SECOND_RESET,
+					persistentPrefs.getOpenOCDDoPreRunReset());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.SECOND_RESET_TYPE,
+					persistentPrefs.getOpenOCDPreRunResetType());
+			LaunchAttributes.setStringIfEmpty(configuration, ConfigurationAttributes.OTHER_RUN_COMMANDS,
+					persistentPrefs.getOpenOCDPreRunOther());
+
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_SET_PC_REGISTER,
+					IGDBJtagConstants.DEFAULT_SET_PC_REGISTER);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_PC_REGISTER,
+					IGDBJtagConstants.DEFAULT_PC_REGISTER);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_SET_STOP_AT,
+					DefaultPreferences.DO_STOP_AT_DEFAULT);
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_STOP_AT,
+					DefaultPreferences.STOP_AT_NAME_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_SET_RESUME,
+					IGDBJtagConstants.DEFAULT_SET_RESUME);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_CONTINUE,
+					DefaultPreferences.DO_CONTINUE_DEFAULT);
+
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_START_GDB_CLIENT,
+					DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);
+
+			LaunchAttributes.setStringIfEmpty(configuration, IGDBJtagConstants.ATTR_IP_ADDRESS,
+					DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, IGDBJtagConstants.ATTR_PORT_NUMBER,
+					DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
+
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.DO_FLASH_BEFORE_START,
+					DefaultPreferences.DO_FLASH_BEFORE_START_DEFAULT);
+			LaunchAttributes.setIfAbsent(configuration, ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT,
+					DefaultPreferences.ENABLE_VERBOSE_OUTPUT_DEFAULT);
 		}
 		catch (CoreException e)
 		{
-			Logger.log("Failed to check OpenOCD defaults guard", e);
+			Logger.log(e);
 		}
-
-		configuration.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-				DefaultPreferences.PROGRAM_APP_DEFAULT);
-		// --- 1. JTAG Device Setup ---
-		configuration.setAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID, ConfigurationAttributes.JTAG_DEVICE);
-
-		// --- 2. OpenOCD GDB Server Setup ---
-		configuration.setAttribute(ConfigurationAttributes.DO_START_GDB_SERVER, persistentPrefs.getGdbServerDoStart());
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
-				persistentPrefs.getGdbServerExecutable());
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_CONNECTION_ADDRESS,
-				DefaultPreferences.GDB_SERVER_CONNECTION_ADDRESS_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
-				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
-				DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
-				DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_LOG, DefaultPreferences.GDB_SERVER_LOG_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_CONSOLE,
-				DefaultPreferences.DO_GDB_SERVER_ALLOCATE_CONSOLE_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE,
-				DefaultPreferences.DO_GDB_SERVER_ALLOCATE_TELNET_CONSOLE_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_OTHER,
-				DefaultPreferences.GDB_SERVER_OTHER_DEFAULT);
-
-		// --- 3. GDB Client Setup ---
-		configuration.setAttribute(IGDBJtagConstants.ATTR_USE_REMOTE_TARGET,
-				DefaultPreferences.USE_REMOTE_TARGET_DEFAULT);
-		configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
-				DefaultPreferences.GDB_CLIENT_EXECUTABLE_DYNAMIC_DEFAULT);
-		configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
-				persistentPrefs.getGdbClientOtherOptions());
-		configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
-				persistentPrefs.getGdbClientCommands());
-
-		// --- 4. Thread List Setup ---
-		configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUGGER_UPDATE_THREADLIST_ON_SUSPEND,
-				DefaultPreferences.UPDATE_THREAD_LIST_DEFAULT);
-
-		// --- 5. SVD Target Setup ---
-		// Using the embedcdt ConfigurationAttributes explicitly to avoid namespace collision
-		configuration.setAttribute(org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes.SVD_PATH,
-				VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(ESP_SVD_PATH, null));
-		
-		// --- 6. Initialisation Commands (from TabStartup) ---
-        configuration.setAttribute(ConfigurationAttributes.DO_FIRST_RESET, persistentPrefs.getOpenOCDDoInitialReset());
-        configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, persistentPrefs.getOpenOCDInitialResetType());
-        configuration.setAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, persistentPrefs.getOpenOCDEnableSemihosting());
-        configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, persistentPrefs.getOpenOCDInitOther());
-
-        // --- 7. Load Image & Symbols (from TabStartup) ---
-        configuration.setAttribute(IGDBJtagConstants.ATTR_LOAD_IMAGE, IIDFGDBJtagConstants.DEFAULT_LOAD_IMAGE);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_IMAGE, IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_IMAGE);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_IMAGE, IGDBJtagConstants.DEFAULT_USE_FILE_FOR_IMAGE);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_FILE_NAME, IGDBJtagConstants.DEFAULT_IMAGE_FILE_NAME);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_OFFSET, IGDBJtagConstants.DEFAULT_IMAGE_OFFSET);
-        
-        configuration.setAttribute(IGDBJtagConstants.ATTR_LOAD_SYMBOLS, IGDBJtagConstants.DEFAULT_LOAD_SYMBOLS);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_SYMBOLS, IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_SYMBOLS);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_SYMBOLS, IGDBJtagConstants.DEFAULT_USE_FILE_FOR_SYMBOLS);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME, IGDBJtagConstants.DEFAULT_SYMBOLS_FILE_NAME);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_OFFSET, IGDBJtagConstants.DEFAULT_SYMBOLS_OFFSET);
-
-        // --- 8. Runtime Options & Run Commands (from TabStartup) ---
-        configuration.setAttribute(ConfigurationAttributes.DO_DEBUG_IN_RAM, persistentPrefs.getOpenOCDDebugInRam());
-        configuration.setAttribute(ConfigurationAttributes.DO_SECOND_RESET, persistentPrefs.getOpenOCDDoPreRunReset());
-        configuration.setAttribute(ConfigurationAttributes.SECOND_RESET_TYPE, persistentPrefs.getOpenOCDPreRunResetType());
-        configuration.setAttribute(ConfigurationAttributes.OTHER_RUN_COMMANDS, persistentPrefs.getOpenOCDPreRunOther());
-
-        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_PC_REGISTER, IGDBJtagConstants.DEFAULT_SET_PC_REGISTER);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_PC_REGISTER, IGDBJtagConstants.DEFAULT_PC_REGISTER);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_STOP_AT, DefaultPreferences.DO_STOP_AT_DEFAULT);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_STOP_AT, DefaultPreferences.STOP_AT_NAME_DEFAULT);
-        configuration.setAttribute(IGDBJtagConstants.ATTR_SET_RESUME, IGDBJtagConstants.DEFAULT_SET_RESUME);
-        configuration.setAttribute(ConfigurationAttributes.DO_CONTINUE, DefaultPreferences.DO_CONTINUE_DEFAULT);
-
-
-		configuration.setAttribute(ConfigurationAttributes.DO_START_GDB_CLIENT,
-				DefaultPreferences.DO_START_GDB_CLIENT_DEFAULT);
-
-		configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
-
-		configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
-				DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT);
-
-		configuration.setAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, true);
-		configuration.setAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, false);
 	}
 }

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabDebugger.java
@@ -62,6 +62,8 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.LaunchAttributes;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.Configuration;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
@@ -70,6 +72,7 @@ import com.espressif.idf.debug.gdbjtag.openocd.preferences.PersistentPreferences
 import com.espressif.idf.debug.gdbjtag.openocd.ui.preferences.GlobalMcuPage;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.preferences.WorkspaceMcuPage;
 import com.espressif.idf.debug.gdbjtag.openocd.ui.properties.ProjectMcuPage;
+import com.espressif.idf.swt.custom.LaunchTabControls;
 import com.espressif.idf.swt.custom.StyledInfoText;
 import com.espressif.idf.swt.custom.TextWithButton;
 
@@ -183,18 +186,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 		fUpdateThreadlistOnSuspend
 				.setToolTipText(Messages.getString("DebuggerTab.update_thread_list_on_suspend_ToolTipText")); //$NON-NLS-1$
 
-		Link restoreDefaults;
-		{
-			restoreDefaults = new Link(comp, SWT.NONE);
-			restoreDefaults.setText(Messages.getString("DebuggerTab.restoreDefaults_Link")); //$NON-NLS-1$
-			restoreDefaults.setToolTipText(Messages.getString("DebuggerTab.restoreDefaults_ToolTipText")); //$NON-NLS-1$
-
-			GridData gd = new GridData();
-			gd.grabExcessHorizontalSpace = true;
-			gd.horizontalAlignment = SWT.RIGHT;
-			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns;
-			restoreDefaults.setLayoutData(gd);
-		}
+		LaunchTabControls.addRestoreDefaultsButton(comp, () -> {
+			initializeFromDefaults();
+			scheduleUpdateJob();
+		});
 
 		// --------------------------------------------------------------------
 
@@ -204,16 +199,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			public void widgetSelected(SelectionEvent e)
 			{
 				updateLaunchConfigurationDialog();
-			}
-		});
-
-		restoreDefaults.addSelectionListener(new SelectionAdapter()
-		{
-			@Override
-			public void widgetSelected(final SelectionEvent event)
-			{
-				initializeFromDefaults();
-				scheduleUpdateJob();
 			}
 		});
 	}
@@ -298,6 +283,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 				fGdbServerExecutable = new TextWithButton(local, SWT.SINGLE | SWT.BORDER);
 				gd = new GridData(GridData.FILL_HORIZONTAL);
 				fGdbServerExecutable.setLayoutData(gd);
+				LaunchTabControls.applyEmptyDefaultHint(fGdbServerExecutable);
 
 				fGdbServerBrowseButton = new Button(local, SWT.NONE);
 				fGdbServerBrowseButton.setText(Messages.getString("DebuggerTab.gdbServerExecutableBrowse")); //$NON-NLS-1$
@@ -341,6 +327,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			gd.widthHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbServerGdbPort.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fGdbServerGdbPort);
 		}
 
 		{
@@ -353,6 +340,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			gd.widthHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbServerTelnetPort.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fGdbServerTelnetPort);
 		}
 
 		{
@@ -365,6 +353,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			gd.widthHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbServerTclPort.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fGdbServerTclPort);
 		}
 
 		{
@@ -383,6 +372,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			{
 				fGdbServerOtherOptions = new TextWithButton(local, SWT.SINGLE | SWT.BORDER);
 				fGdbServerOtherOptions.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+				LaunchTabControls.applyEmptyDefaultHint(fGdbServerOtherOptions);
 
 				Button browseVariablesButton = new Button(local, SWT.NONE);
 				browseVariablesButton.setText(Messages.getString("DebuggerTab.gdbOtherOptionsBrowse")); //$NON-NLS-1$
@@ -620,6 +610,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 				fGdbClientExecutable = new TextWithButton(local, SWT.SINGLE | SWT.BORDER);
 				gd = new GridData(GridData.FILL_HORIZONTAL);
 				fGdbClientExecutable.setLayoutData(gd);
+				LaunchTabControls.applyEmptyDefaultHint(fGdbClientExecutable);
 
 				fGdbClientBrowseButton = new Button(local, SWT.NONE);
 				fGdbClientBrowseButton.setText(Messages.getString("DebuggerTab.gdbCommandBrowse")); //$NON-NLS-1$
@@ -655,6 +646,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			gd.heightHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbClientOtherCommands.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fGdbClientOtherCommands);
 		}
 
 		// ----- Actions ------------------------------------------------------
@@ -749,6 +741,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			GridData gd = new GridData();
 			gd.widthHint = 125;
 			fTargetIpAddress.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fTargetIpAddress);
 
 			label = new Label(comp, SWT.NONE);
 			label.setText(Messages.getString("DebuggerTab.portNumberLabel")); //$NON-NLS-1$
@@ -757,6 +750,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 			gd = new GridData();
 			gd.widthHint = 125;
 			fTargetPortNumber.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fTargetPortNumber);
 		}
 
 		// ---- Actions -------------------------------------------------------
@@ -872,7 +866,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 		try
 		{
 			Boolean booleanDefault;
-			String stringDefault;
 
 			// OpenOCD GDB server
 			{
@@ -884,23 +877,20 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 						configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_SERVER, booleanDefault));
 
 				// Executable
-				stringDefault = fPersistentPreferences.getGdbServerExecutable();
 				fGdbServerExecutable.setText(
-						configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_EXECUTABLE, stringDefault));
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.GDB_SERVER_EXECUTABLE));
 
 				// Ports
-				fGdbServerGdbPort.setText(
-						Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
-								DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT)));
-				fGdbServerTelnetPort.setText(Integer
-						.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
-								DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT)));
-				fGdbServerTclPort.setText(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
-						DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT));
+				fGdbServerGdbPort.setText(LaunchAttributes.getStoredIntText(configuration,
+						ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER));
+				fGdbServerTelnetPort.setText(LaunchAttributes.getStoredIntText(configuration,
+						ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER));
+				fGdbServerTclPort.setText(LaunchAttributes.getStoredString(configuration,
+						ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER));
 
 				// Other options
-				fGdbServerOtherOptions.setText(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_OTHER,
-						fGdbServerOtherOptions.getText()));
+				fGdbServerOtherOptions.setText(
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.GDB_SERVER_OTHER));
 
 				// Allocate server console
 				if (EclipseUtils.isWindows())
@@ -927,38 +917,22 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 				fDoStartGdbClient.setSelection(
 						configuration.getAttribute(ConfigurationAttributes.DO_START_GDB_CLIENT, booleanDefault));
 
-				// Executable
-				String gdbCommandAttr = configuration.getAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
-						fGdbClientExecutable.getText());
-				fGdbClientExecutable.setText(gdbCommandAttr);
+				fGdbClientExecutable.setText(LaunchAttributes.getStoredString(configuration,
+						IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME));
 
-				// Other options
-				stringDefault = fPersistentPreferences.getGdbClientOtherOptions();
-				fGdbClientOtherOptions.setText(
-						configuration.getAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS, stringDefault));
+				fGdbClientOtherOptions.setText(LaunchAttributes.getStoredString(configuration,
+						ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS));
 
-				stringDefault = fPersistentPreferences.getGdbClientCommands();
-				fGdbClientOtherCommands.setText(
-						configuration.getAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS, stringDefault));
+				fGdbClientOtherCommands.setText(LaunchAttributes.getStoredString(configuration,
+						ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS));
 			}
 
 			// Remote target
 			{
-				fTargetIpAddress.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS,
-						DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT)); // $NON-NLS-1$
-
-				int storedPort = 0;
-				storedPort = configuration.getAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, 0); // Default
-																								// 0
-
-				// 0 means undefined, use default
-				if ((storedPort <= 0) || (65535 < storedPort))
-				{
-					storedPort = DefaultPreferences.REMOTE_PORT_NUMBER_DEFAULT;
-				}
-
-				String portString = Integer.toString(storedPort); // $NON-NLS-1$
-				fTargetPortNumber.setText(portString);
+				fTargetIpAddress.setText(
+						LaunchAttributes.getStoredString(configuration, IGDBJtagConstants.ATTR_IP_ADDRESS));
+				fTargetPortNumber.setText(
+						LaunchAttributes.getStoredIntText(configuration, IGDBJtagConstants.ATTR_PORT_NUMBER));
 			}
 
 			doStartGdbServerChanged();
@@ -1093,48 +1067,29 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 		if (fDoStartGdbServer != null && fDoStartGdbServer.getSelection())
 		{
-
 			hasContent = true;
-			if (fGdbServerExecutable != null && fGdbServerExecutable.getText().trim().isEmpty())
-			{
-				setErrorMessage(Messages.TabDebugger_noGdbServerExe);
-				result = false;
-			}
-
-			if (fGdbServerGdbPort != null && fGdbServerGdbPort.getText().trim().isEmpty())
+			if (!isEmptyOrValidPort(fGdbServerGdbPort))
 			{
 				setErrorMessage(Messages.TabDebugger_noGdbPort);
 				result = false;
 			}
 
-			if (fGdbServerTelnetPort != null && fGdbServerTelnetPort.getText().trim().isEmpty())
+			if (!isEmptyOrValidPort(fGdbServerTelnetPort))
 			{
 				setErrorMessage(Messages.TabDebugger_noTelnetPort);
-				result = false;
-			}
-
-			if (fGdbServerTclPort != null && fGdbServerTclPort.getText().trim().isEmpty())
-			{
-				setErrorMessage(Messages.TabDebugger_noTclPort);
 				result = false;
 			}
 		}
 
 		if (fDoStartGdbClient != null && fDoStartGdbClient.getSelection())
 		{
-
 			hasContent = true;
-			if (fGdbClientExecutable != null && fGdbClientExecutable.getText().trim().isEmpty())
-			{
-				result = false;
-				setErrorMessage(Messages.TabDebugger_noGdbClientExe);
-			}
 		}
 
-		if (fGdbServerOtherOptions != null && fGdbServerOtherOptions.getText().trim().isEmpty())
+		if (fTargetPortNumber != null && !isEmptyOrValidPort(fTargetPortNumber))
 		{
+			setErrorMessage(Messages.TabDebugger_noGdbPort);
 			result = false;
-			setErrorMessage(Messages.TabDebugger_noConfigOptions);
 		}
 
 		if (Activator.getInstance().isDebugging())
@@ -1144,24 +1099,31 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 		return hasContent && result;
 	}
 
+	private static boolean isEmptyOrValidPort(Text text)
+	{
+		if (text == null || StringUtil.isEmpty(text.getText()))
+		{
+			return true;
+		}
+		try
+		{
+			int port = Integer.parseInt(text.getText().trim());
+			return port >= 0 && port <= 65535;
+		}
+		catch (NumberFormatException e)
+		{
+			return false;
+		}
+	}
+
 	@Override
 	public boolean canSave()
 	{
-		if (fDoStartGdbServer != null && fDoStartGdbServer.getSelection())
+		if (!isEmptyOrValidPort(fGdbServerGdbPort) || !isEmptyOrValidPort(fGdbServerTelnetPort)
+				|| !isEmptyOrValidPort(fTargetPortNumber))
 		{
-			if (fGdbServerExecutable != null && fGdbServerExecutable.getText().trim().isEmpty())
-				return false;
-
-			if (fGdbServerGdbPort != null && fGdbServerGdbPort.getText().trim().isEmpty())
-				return false;
-
-			if (fGdbServerTelnetPort != null && fGdbServerTelnetPort.getText().trim().isEmpty())
-				return false;
-			if (fGdbServerTclPort != null && fGdbServerTclPort.getText().trim().isEmpty())
-				return false;
+			return false;
 		}
-
-		// Now, if any of server or client is enabled, return true
 		if (fDoStartGdbServer != null && fDoStartGdbServer.getSelection())
 		{
 			return true;
@@ -1201,42 +1163,21 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 
 			// Executable
 			stringValue = fGdbServerExecutable.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_EXECUTABLE, stringValue);
-			fPersistentPreferences.putGdbServerExecutable(stringValue);
-
-			// Ports
-			int port;
-			if (!fGdbServerGdbPort.getText().trim().isEmpty())
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.GDB_SERVER_EXECUTABLE,
+					stringValue);
+			if (!StringUtil.isEmpty(stringValue))
 			{
-				port = Integer.parseInt(fGdbServerGdbPort.getText().trim());
-				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER, port);
-			}
-			else
-			{
-				Activator.log("empty fGdbServerGdbPort"); //$NON-NLS-1$
-			}
-			if (!fGdbServerTelnetPort.getText().trim().isEmpty())
-			{
-				port = Integer.parseInt(fGdbServerTelnetPort.getText().trim());
-				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER, port);
-			}
-			else
-			{
-				Activator.log("empty fGdbServerTelnetPort"); //$NON-NLS-1$
-			}
-			if (!fGdbServerTclPort.getText().trim().isEmpty())
-			{
-				// Not integer, since it can be 'disabled'
-				String str = fGdbServerTclPort.getText().trim();
-				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER, str);
-			}
-			else
-			{
-				Activator.log("empty fGdbServerTclPort"); //$NON-NLS-1$
+				fPersistentPreferences.putGdbServerExecutable(stringValue);
 			}
 
-			// Other options
-			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_OTHER,
+			LaunchAttributes.setOrClearInt(configuration, ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
+					fGdbServerGdbPort.getText());
+			LaunchAttributes.setOrClearInt(configuration, ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
+					fGdbServerTelnetPort.getText());
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+					fGdbServerTclPort.getText());
+
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.GDB_SERVER_OTHER,
 					fGdbServerOtherOptions.getText().trim());
 
 			// Allocate server console
@@ -1260,55 +1201,39 @@ public class TabDebugger extends AbstractLaunchConfigurationTab
 					DefaultPreferences.USE_REMOTE_TARGET_DEFAULT);
 
 			stringValue = fGdbClientExecutable.getText().trim();
-			configuration.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME, stringValue); // DSF
+			LaunchAttributes.setOrClearString(configuration, IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME,
+					stringValue); // DSF
 
 			stringValue = fGdbClientOtherOptions.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS, stringValue);
-			fPersistentPreferences.putGdbClientOtherOptions(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.GDB_CLIENT_OTHER_OPTIONS,
+					stringValue);
+			if (!StringUtil.isEmpty(stringValue))
+			{
+				fPersistentPreferences.putGdbClientOtherOptions(stringValue);
+			}
 
 			stringValue = fGdbClientOtherCommands.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS, stringValue);
-			fPersistentPreferences.putGdbClientCommands(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.GDB_CLIENT_OTHER_COMMANDS,
+					stringValue);
+			if (!StringUtil.isEmpty(stringValue))
+			{
+				fPersistentPreferences.putGdbClientCommands(stringValue);
+			}
 		}
 
 		{
 			if (fDoStartGdbServer.getSelection())
 			{
 				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost"); //$NON-NLS-1$
-
-				String str = fGdbServerGdbPort.getText().trim();
-				if (!str.isEmpty())
-				{
-					try
-					{
-						int port;
-						port = Integer.parseInt(str);
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					}
-					catch (NumberFormatException e)
-					{
-						Activator.log(e);
-					}
-				}
+				LaunchAttributes.setOrClearInt(configuration, IGDBJtagConstants.ATTR_PORT_NUMBER,
+						fGdbServerGdbPort.getText());
 			}
 			else
 			{
-				String ip = fTargetIpAddress.getText().trim();
-				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, ip);
-
-				String str = fTargetPortNumber.getText().trim();
-				if (!str.isEmpty())
-				{
-					try
-					{
-						int port = Integer.valueOf(str).intValue();
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					}
-					catch (NumberFormatException e)
-					{
-						Activator.log(e);
-					}
-				}
+				LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_IP_ADDRESS,
+						fTargetIpAddress.getText().trim());
+				LaunchAttributes.setOrClearInt(configuration, IGDBJtagConstants.ATTR_PORT_NUMBER,
+						fTargetPortNumber.getText());
 			}
 		}
 

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -44,8 +44,10 @@ import org.eclipse.swt.widgets.Link;
 import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.LaunchAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
+import com.espressif.idf.swt.custom.LaunchTabControls;
 import com.espressif.idf.ui.EclipseUtil;
 
 public class TabMain extends CMainTab2
@@ -58,6 +60,23 @@ public class TabMain extends CMainTab2
 	{
 		super((Activator.getInstance().getDefaultPreferences().getTabMainCheckProgram() ? 0
 				: CMainTab2.DONT_CHECK_PROGRAM) | CMainTab2.INCLUDE_BUILD_SETTINGS);
+	}
+
+	@Override
+	public void createControl(Composite parent)
+	{
+		super.createControl(parent);
+		LaunchTabControls.applyEmptyDefaultHint(fProgText);
+		LaunchTabControls.addRestoreDefaultsButtonToTab(getControl(), this::restoreDefaults);
+	}
+
+	private void restoreDefaults()
+	{
+		if (fProgText != null)
+		{
+			fProgText.setText(DefaultPreferences.PROGRAM_APP_DEFAULT);
+		}
+		scheduleUpdateJob();
 	}
 
 	/**
@@ -137,9 +156,7 @@ public class TabMain extends CMainTab2
 			String programName = EMPTY_STRING;
 			try
 			{
-				programName = config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-						DefaultPreferences.PROGRAM_APP_DEFAULT);
-				programName = programName.isBlank() ? DefaultPreferences.PROGRAM_APP_DEFAULT : programName;
+				programName = LaunchAttributes.getStoredString(config, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME);
 			}
 			catch (CoreException ce)
 			{
@@ -285,8 +302,8 @@ public class TabMain extends CMainTab2
 		}
 
 		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText());
-		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-				fProgText.getText().isBlank() ? DefaultPreferences.PROGRAM_APP_DEFAULT : fProgText.getText());
+		LaunchAttributes.setOrClearString(config, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+				fProgText.getText());
 		if (fCoreText != null)
 		{
 			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_COREFILE_PATH, fCoreText.getText());

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabMain.java
@@ -45,7 +45,7 @@ import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LaunchAttributes;
-import com.espressif.idf.debug.gdbjtag.openocd.Activator;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.swt.custom.LaunchTabControls;
 import com.espressif.idf.ui.EclipseUtil;
@@ -53,13 +53,11 @@ import com.espressif.idf.ui.EclipseUtil;
 public class TabMain extends CMainTab2
 {
 	/**
-	 * If the preference is set to true, check program and disable Debug button if not found. The default GDB Hardware
-	 * Debug plug-in behaviour is to do not check program, to allow project-less debug sessions.
+	 * Empty C/C++ Application means {@code ${default_app}}, so never treat a blank field as an error.
 	 */
 	public TabMain()
 	{
-		super((Activator.getInstance().getDefaultPreferences().getTabMainCheckProgram() ? 0
-				: CMainTab2.DONT_CHECK_PROGRAM) | CMainTab2.INCLUDE_BUILD_SETTINGS);
+		super(CMainTab2.DONT_CHECK_PROGRAM | CMainTab2.INCLUDE_BUILD_SETTINGS);
 	}
 
 	@Override
@@ -163,6 +161,10 @@ public class TabMain extends CMainTab2
 				Logger.log(ce);
 			}
 
+			if (DefaultPreferences.PROGRAM_APP_DEFAULT.equals(programName.trim()))
+			{
+				programName = EMPTY_STRING;
+			}
 			fProgText.setText(programName);
 		}
 	}
@@ -262,6 +264,15 @@ public class TabMain extends CMainTab2
 	{
 		Optional<IProject> selectedProject = EclipseUtil.getDefaultIDFProject();
 		selectedProject.ifPresent(project -> initializeDefaultProject(project, configuration));
+		try
+		{
+			LaunchAttributes.setStringIfEmpty(configuration, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+					DefaultPreferences.PROGRAM_APP_DEFAULT);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
 	}
 
 	private void initializeDefaultProject(IProject project, ILaunchConfigurationWorkingCopy configuration)
@@ -302,8 +313,13 @@ public class TabMain extends CMainTab2
 		}
 
 		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText());
-		LaunchAttributes.setOrClearString(config, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-				fProgText.getText());
+		// CDT rejects a missing program name. An empty editor field means ${default_app}.
+		String programName = fProgText.getText();
+		if (StringUtil.isEmpty(programName))
+		{
+			programName = DefaultPreferences.PROGRAM_APP_DEFAULT;
+		}
+		LaunchAttributes.setOrClearString(config, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, programName);
 		if (fCoreText != null)
 		{
 			config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_COREFILE_PATH, fCoreText.getText());

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabStartup.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabStartup.java
@@ -51,19 +51,21 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 import org.eclipse.ui.views.navigator.ResourceComparator;
 
+import com.espressif.idf.core.util.LaunchAttributes;
+import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.debug.gdbjtag.openocd.Activator;
 import com.espressif.idf.debug.gdbjtag.openocd.ConfigurationAttributes;
 import com.espressif.idf.debug.gdbjtag.openocd.IIDFGDBJtagConstants;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.DefaultPreferences;
 import com.espressif.idf.debug.gdbjtag.openocd.preferences.PersistentPreferences;
 import com.espressif.idf.launch.serial.util.ESPFlashUtil;
+import com.espressif.idf.swt.custom.LaunchTabControls;
 
 public class TabStartup extends AbstractLaunchConfigurationTab {
 
@@ -185,27 +187,9 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		createRunOptionGroup(comp);
 		createRunGroup(comp);
 
-		Link restoreDefaults;
-		{
-			restoreDefaults = new Link(comp, SWT.NONE);
-			restoreDefaults.setText(Messages.getString("DebuggerTab.restoreDefaults_Link"));
-			restoreDefaults.setToolTipText(Messages.getString("DebuggerTab.restoreDefaults_ToolTipText"));
-
-			GridData gd = new GridData();
-			gd.grabExcessHorizontalSpace = true;
-			gd.horizontalAlignment = SWT.RIGHT;
-			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns;
-			restoreDefaults.setLayoutData(gd);
-		}
-
-		// --------------------------------------------------------------------
-
-		restoreDefaults.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(final SelectionEvent event) {
-				initializeFromDefaults();
-				scheduleUpdateJob();
-			}
+		LaunchTabControls.addRestoreDefaultsButton(comp, () -> {
+			initializeFromDefaults();
+			scheduleUpdateJob();
 		});
 		
 	}
@@ -311,6 +295,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			GridData gd = new GridData();
 			gd.widthHint = 30;
 			fFirstResetType.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fFirstResetType);
 		}
 
 		{
@@ -319,6 +304,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			GridData gd = new GridData(GridData.FILL_BOTH);
 			gd.heightHint = 60;
 			fInitCommands.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fInitCommands);
 		}
 
 		{
@@ -720,6 +706,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			GridData gd = new GridData();
 			gd.widthHint = 30;
 			fSecondResetType.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fSecondResetType);
 
 			fSecondResetWarning = new Label(comp, SWT.NONE);
 			fSecondResetWarning.setText(Messages.getString("StartupTab.secondResetWarning_Text"));
@@ -735,6 +722,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			gd.heightHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns;
 			fRunCommands.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fRunCommands);
 		}
 
 		{
@@ -748,6 +736,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			gd.widthHint = 100;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fPcRegister.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fPcRegister);
 		}
 
 		{
@@ -760,6 +749,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			gd.widthHint = 100;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fStopAt.setLayoutData(gd);
+			LaunchTabControls.applyEmptyDefaultHint(fStopAt);
 		}
 
 		{
@@ -898,21 +888,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			setErrorMessage(null);
 		}
 
-		if (fSetPcRegister.getSelection()) {
-			if (fPcRegister.getText().trim().length() == 0) {
-				setErrorMessage(Messages.getString("StartupTab.pcRegister_not_specified"));
-				return false;
-			}
-		} else {
-			setErrorMessage(null);
-		}
-		if (fSetStopAt.getSelection()) {
-			if (fStopAt.getText().trim().length() == 0) {
-				setErrorMessage(Messages.getString("StartupTab.stopAt_not_specified"));
-			}
-		} else {
-			setErrorMessage(null);
-		}
 		return true;
 	}
 
@@ -930,16 +905,17 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		}
 
 		try {
-			String stringDefault;
 			boolean booleanDefault;
 
 			// OpenOCD Commands
 			{
 				if (fDoFlashBeforeStart != null) {
 					fDoFlashBeforeStart
-					.setSelection(configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START, true));
+					.setSelection(configuration.getAttribute(ConfigurationAttributes.DO_FLASH_BEFORE_START,
+							DefaultPreferences.DO_FLASH_BEFORE_START_DEFAULT));
 				}
-				fEnableVerboseOutput.setSelection(configuration.getAttribute(ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, false));
+				fEnableVerboseOutput.setSelection(configuration.getAttribute(
+						ConfigurationAttributes.ENABLE_VERBOSE_OUTPUT, DefaultPreferences.ENABLE_VERBOSE_OUTPUT_DEFAULT));
 			}
 
 			// Initialisation Commands
@@ -950,9 +926,8 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 						configuration.getAttribute(ConfigurationAttributes.DO_FIRST_RESET, booleanDefault));
 
 				// Reset type
-				stringDefault = fPersistentPreferences.getOpenOCDInitialResetType();
-				fFirstResetType
-						.setText(configuration.getAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, stringDefault));
+				fFirstResetType.setText(
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.FIRST_RESET_TYPE));
 
 				// Enable semihosting
 				booleanDefault = fPersistentPreferences.getOpenOCDEnableSemihosting();
@@ -960,9 +935,8 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 						configuration.getAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, booleanDefault));
 
 				// Other commands
-				stringDefault = fPersistentPreferences.getOpenOCDInitOther();
 				fInitCommands.setText(
-						configuration.getAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, stringDefault));
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.OTHER_INIT_COMMANDS));
 			}
 
 			// Load Symbols & Image
@@ -974,10 +948,10 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 								IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_SYMBOLS));
 				fUseFileForSymbols.setSelection(configuration.getAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_SYMBOLS,
 						IGDBJtagConstants.DEFAULT_USE_FILE_FOR_SYMBOLS));
-				fSymbolsFileName.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME,
-						IGDBJtagConstants.DEFAULT_SYMBOLS_FILE_NAME));
-				fSymbolsOffset.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_SYMBOLS_OFFSET,
-						IGDBJtagConstants.DEFAULT_SYMBOLS_OFFSET));
+				fSymbolsFileName.setText(LaunchAttributes.getStoredString(configuration,
+						IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME));
+				fSymbolsOffset.setText(LaunchAttributes.getStoredString(configuration,
+						IGDBJtagConstants.ATTR_SYMBOLS_OFFSET));
 
 				fLoadExecutable.setSelection(configuration.getAttribute(IGDBJtagConstants.ATTR_LOAD_IMAGE,
 						IIDFGDBJtagConstants.DEFAULT_LOAD_IMAGE));
@@ -986,10 +960,10 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 								IGDBJtagConstants.DEFAULT_USE_PROJ_BINARY_FOR_IMAGE));
 				fUseFileForImage.setSelection(configuration.getAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_IMAGE,
 						IGDBJtagConstants.DEFAULT_USE_FILE_FOR_IMAGE));
-				fImageFileName.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_IMAGE_FILE_NAME,
-						IGDBJtagConstants.DEFAULT_IMAGE_FILE_NAME));
-				fImageOffset.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_IMAGE_OFFSET,
-						IGDBJtagConstants.DEFAULT_IMAGE_OFFSET));
+				fImageFileName.setText(LaunchAttributes.getStoredString(configuration,
+						IGDBJtagConstants.ATTR_IMAGE_FILE_NAME));
+				fImageOffset.setText(LaunchAttributes.getStoredString(configuration,
+						IGDBJtagConstants.ATTR_IMAGE_OFFSET));
 
 				String programName = CDebugUtils.getProgramName(configuration);
 				if (programName != null) {
@@ -1022,24 +996,21 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 						configuration.getAttribute(ConfigurationAttributes.DO_SECOND_RESET, booleanDefault));
 
 				// Pre-run reset type
-				stringDefault = fPersistentPreferences.getOpenOCDPreRunResetType();
-				fSecondResetType
-						.setText(configuration.getAttribute(ConfigurationAttributes.SECOND_RESET_TYPE, stringDefault));
+				fSecondResetType.setText(
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.SECOND_RESET_TYPE));
 
 				// Other commands
-				stringDefault = fPersistentPreferences.getOpenOCDPreRunOther();
-				fRunCommands
-						.setText(configuration.getAttribute(ConfigurationAttributes.OTHER_RUN_COMMANDS, stringDefault));
+				fRunCommands.setText(
+						LaunchAttributes.getStoredString(configuration, ConfigurationAttributes.OTHER_RUN_COMMANDS));
 
 				fSetPcRegister.setSelection(configuration.getAttribute(IGDBJtagConstants.ATTR_SET_PC_REGISTER,
 						IGDBJtagConstants.DEFAULT_SET_PC_REGISTER));
-				fPcRegister.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_PC_REGISTER,
-						IGDBJtagConstants.DEFAULT_PC_REGISTER));
+				fPcRegister.setText(
+						LaunchAttributes.getStoredString(configuration, IGDBJtagConstants.ATTR_PC_REGISTER));
 
 				fSetStopAt.setSelection(configuration.getAttribute(IGDBJtagConstants.ATTR_SET_STOP_AT,
 						DefaultPreferences.DO_STOP_AT_DEFAULT));
-				fStopAt.setText(configuration.getAttribute(IGDBJtagConstants.ATTR_STOP_AT,
-						DefaultPreferences.STOP_AT_NAME_DEFAULT));
+				fStopAt.setText(LaunchAttributes.getStoredString(configuration, IGDBJtagConstants.ATTR_STOP_AT));
 
 				// Do continue
 				fDoContinue.setSelection(configuration.getAttribute(ConfigurationAttributes.DO_CONTINUE,
@@ -1071,6 +1042,11 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		if (Activator.getInstance().isDebugging()) {
 			System.out.println("openocd.TabStartup.initializeFromDefaults()");
 		}
+
+		if (fDoFlashBeforeStart != null) {
+			fDoFlashBeforeStart.setSelection(DefaultPreferences.DO_FLASH_BEFORE_START_DEFAULT);
+		}
+		fEnableVerboseOutput.setSelection(DefaultPreferences.ENABLE_VERBOSE_OUTPUT_DEFAULT);
 
 		// Initialisation Commands
 		{
@@ -1189,13 +1165,17 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 			// First reset type
 			stringValue = fFirstResetType.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, stringValue);
-			fPersistentPreferences.putOpenOCDInitialResetType(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.FIRST_RESET_TYPE, stringValue);
+			if (!StringUtil.isEmpty(stringValue)) {
+				fPersistentPreferences.putOpenOCDInitialResetType(stringValue);
+			}
 
 			// Other commands
 			stringValue = fInitCommands.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, stringValue);
-			fPersistentPreferences.putOpenOCDInitOther(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.OTHER_INIT_COMMANDS, stringValue);
+			if (!StringUtil.isEmpty(stringValue)) {
+				fPersistentPreferences.putOpenOCDInitOther(stringValue);
+			}
 
 			// Enable semihosting
 			booleanValue = fEnableSemihosting.getSelection();
@@ -1209,17 +1189,21 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_SYMBOLS,
 					fUseProjectBinaryForSymbols.getSelection());
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_SYMBOLS, fUseFileForSymbols.getSelection());
-			configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME, fSymbolsFileName.getText().trim());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_SYMBOLS_FILE_NAME,
+					fSymbolsFileName.getText().trim());
 
-			configuration.setAttribute(IGDBJtagConstants.ATTR_SYMBOLS_OFFSET, fSymbolsOffset.getText());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_SYMBOLS_OFFSET,
+					fSymbolsOffset.getText());
 
 			configuration.setAttribute(IGDBJtagConstants.ATTR_LOAD_IMAGE, fLoadExecutable.getSelection());
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_PROJ_BINARY_FOR_IMAGE,
 					fUseProjectBinaryForImage.getSelection());
 			configuration.setAttribute(IGDBJtagConstants.ATTR_USE_FILE_FOR_IMAGE, fUseFileForImage.getSelection());
-			configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_FILE_NAME, fImageFileName.getText().trim());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_IMAGE_FILE_NAME,
+					fImageFileName.getText().trim());
 
-			configuration.setAttribute(IGDBJtagConstants.ATTR_IMAGE_OFFSET, fImageOffset.getText());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_IMAGE_OFFSET,
+					fImageOffset.getText());
 		}
 
 		// Runtime Options
@@ -1238,18 +1222,22 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 			// reset type
 			stringValue = fSecondResetType.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.SECOND_RESET_TYPE, stringValue);
-			fPersistentPreferences.putOpenOCDPreRunResetType(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.SECOND_RESET_TYPE, stringValue);
+			if (!StringUtil.isEmpty(stringValue)) {
+				fPersistentPreferences.putOpenOCDPreRunResetType(stringValue);
+			}
 
 			// Other commands
 			stringValue = fRunCommands.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.OTHER_RUN_COMMANDS, stringValue);
-			fPersistentPreferences.putOpenOCDPreRunOther(stringValue);
+			LaunchAttributes.setOrClearString(configuration, ConfigurationAttributes.OTHER_RUN_COMMANDS, stringValue);
+			if (!StringUtil.isEmpty(stringValue)) {
+				fPersistentPreferences.putOpenOCDPreRunOther(stringValue);
+			}
 
 			configuration.setAttribute(IGDBJtagConstants.ATTR_SET_PC_REGISTER, fSetPcRegister.getSelection());
-			configuration.setAttribute(IGDBJtagConstants.ATTR_PC_REGISTER, fPcRegister.getText());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_PC_REGISTER, fPcRegister.getText());
 			configuration.setAttribute(IGDBJtagConstants.ATTR_SET_STOP_AT, fSetStopAt.getSelection());
-			configuration.setAttribute(IGDBJtagConstants.ATTR_STOP_AT, fStopAt.getText());
+			LaunchAttributes.setOrClearString(configuration, IGDBJtagConstants.ATTR_STOP_AT, fStopAt.getText());
 
 			// Continue
 			configuration.setAttribute(ConfigurationAttributes.DO_CONTINUE, fDoContinue.getSelection());

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabSvdTarget.java
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/src/com/espressif/idf/debug/gdbjtag/openocd/ui/TabSvdTarget.java
@@ -4,10 +4,16 @@
  *******************************************************************************/
 package com.espressif.idf.debug.gdbjtag.openocd.ui;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.variables.VariablesPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.embedcdt.debug.gdbjtag.core.ConfigurationAttributes;
 import org.eclipse.embedcdt.debug.gdbjtag.ui.TabSvd;
+import org.eclipse.swt.widgets.Composite;
+
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.swt.custom.LaunchTabControls;
 
 /**
  * Svd target class for loading the svd files from the plugin directly
@@ -19,12 +25,49 @@ public class TabSvdTarget extends TabSvd
 {
 	private static final String ESP_SVD_PATH = "esp_svd_path"; //$NON-NLS-1$
 
+	private ILaunchConfiguration configuration;
+
+	@Override
+	public void createControl(Composite parent)
+	{
+		super.createControl(parent);
+		LaunchTabControls.addRestoreDefaultsButtonToTab(getControl(), this::restoreDefaults);
+	}
+
+	@Override
+	public void initializeFrom(ILaunchConfiguration configuration)
+	{
+		this.configuration = configuration;
+		super.initializeFrom(configuration);
+	}
+
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
 	{
 		configuration.setAttribute(ConfigurationAttributes.SVD_PATH,
 				VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(ESP_SVD_PATH, null));
 		super.setDefaults(configuration);
+	}
+
+	private void restoreDefaults()
+	{
+		if (configuration == null)
+		{
+			return;
+		}
+		try
+		{
+			ILaunchConfigurationWorkingCopy workingCopy = configuration instanceof ILaunchConfigurationWorkingCopy wc
+					? wc
+					: configuration.getWorkingCopy();
+			setDefaults(workingCopy);
+			initializeFrom(workingCopy);
+			scheduleUpdateJob();
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
 	}
 
 }

--- a/bundles/com.espressif.idf.launch.serial.core/plugin.xml
+++ b/bundles/com.espressif.idf.launch.serial.core/plugin.xml
@@ -35,7 +35,7 @@
       <launchDelegate
             delegate="com.espressif.idf.launch.serial.internal.SerialFlashLaunchConfigDelegate"
             id="com.espressif.idf.launch.serial.core.launchDelegate2"
-            modes="run,debug"
+            modes="run"
             name="%launchDelegate.name"
             type="com.espressif.idf.launch.serial.launchConfigurationType">
       </launchDelegate>

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -8,6 +8,8 @@ import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -15,7 +17,9 @@ import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
+import com.espressif.idf.core.util.ILaunchDefaultsContributor;
 import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
@@ -50,8 +54,50 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 
 		// Set the project
 		IProject project = descriptor.getAdapter(IProject.class);
-		workingCopy.setMappedResources(new IResource[] { project });
-		workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
+		if (project != null && project.exists())
+		{
+			workingCopy.setMappedResources(new IResource[] { project });
+			workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
+
+			org.eclipse.cdt.core.model.ICProject cProject = org.eclipse.cdt.core.CCorePlugin.getDefault().getCoreModel()
+					.create(project);
+			if (cProject != null && cProject.exists())
+			{
+				org.eclipse.cdt.core.settings.model.ICProjectDescription projDes = org.eclipse.cdt.core.CCorePlugin
+						.getDefault().getProjectDescription(cProject.getProject());
+
+				if (projDes != null && projDes.getActiveConfiguration() != null)
+				{
+					String buildConfigID = projDes.getActiveConfiguration().getId();
+					workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_BUILD_CONFIG_ID,
+							buildConfigID);
+				}
+			}
+
+			// 3. Ensure Build Before Launch is enabled
+			workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_BUILD_BEFORE_LAUNCH,
+					ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING);
+		}
+
+		IConfigurationElement[] elements = Platform.getExtensionRegistry()
+				.getConfigurationElementsFor("com.espressif.idf.core.launchDefaultsContributor"); //$NON-NLS-1$
+
+		for (IConfigurationElement element : elements)
+		{
+			try
+			{
+				Object obj = element.createExecutableExtension("class"); //$NON-NLS-1$
+				if (obj instanceof ILaunchDefaultsContributor launchDefaultsContributor)
+				{
+					launchDefaultsContributor.applyDefaults(workingCopy);
+				}
+			}
+			catch (CoreException e)
+			{
+				Logger.log(e);
+			}
+		}
+
 		workingCopy.doSave();
 	}
 

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -8,8 +8,6 @@ import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -17,9 +15,8 @@ import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.IDFUtil;
-import com.espressif.idf.core.util.ILaunchDefaultsContributor;
+import com.espressif.idf.core.util.LaunchDefaults;
 import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
@@ -79,24 +76,7 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 					ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING);
 		}
 
-		IConfigurationElement[] elements = Platform.getExtensionRegistry()
-				.getConfigurationElementsFor("com.espressif.idf.core.launchDefaultsContributor"); //$NON-NLS-1$
-
-		for (IConfigurationElement element : elements)
-		{
-			try
-			{
-				Object obj = element.createExecutableExtension("class"); //$NON-NLS-1$
-				if (obj instanceof ILaunchDefaultsContributor launchDefaultsContributor)
-				{
-					launchDefaultsContributor.applyDefaults(workingCopy);
-				}
-			}
-			catch (CoreException e)
-			{
-				Logger.log(e);
-			}
-		}
+		LaunchDefaults.apply(workingCopy);
 
 		workingCopy.doSave();
 	}

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -1,47 +1,20 @@
 package com.espressif.idf.launch.serial.core;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
-import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LaunchDefaults;
-import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
 {
-
-	private Map<IProject, Map<String, ILaunchConfiguration>> configs = new HashMap<>();
-
-	@Override
-	public ILaunchConfiguration getLaunchConfiguration(ILaunchDescriptor descriptor, ILaunchTarget target)
-			throws CoreException
-	{
-		IProject project = descriptor.getAdapter(IProject.class);
-		if (project == null)
-			return null;
-
-		String targetConfig = descriptor.getName();
-		Map<String, ILaunchConfiguration> projectConfigs = configs.computeIfAbsent(project, key -> new HashMap<>());
-		ILaunchConfiguration configuration = projectConfigs.get(targetConfig);
-		configuration = configuration == null ? new LaunchUtil(DebugPlugin.getDefault().getLaunchManager())
-				.findAppropriateLaunchConfig(descriptor, IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE) : configuration;
-		configuration = configuration == null ? createLaunchConfiguration(descriptor, target) : configuration;
-		projectConfigs.put(configuration.getName(), configuration);
-
-		return configuration;
-	}
 
 	@Override
 	protected void populateLaunchConfiguration(ILaunchDescriptor descriptor, ILaunchTarget target,
@@ -77,28 +50,6 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		}
 
 		LaunchDefaults.apply(workingCopy);
-
-		workingCopy.doSave();
-	}
-
-	@Override
-	public boolean launchConfigurationAdded(ILaunchConfiguration configuration) throws CoreException
-	{
-		if (configuration.getMappedResources() == null)
-		{
-			return false;
-		}
-		IProject project = configuration.getMappedResources()[0].getProject();
-		if (project != null && !project.isOpen())
-		{
-			return true;
-		}
-		if (configuration.exists())
-		{
-			configs.computeIfAbsent(project, key -> new HashMap<>()).put(configuration.getName(), configuration);
-		}
-
-		return ownsLaunchConfiguration(configuration);
 	}
 
 	@Override
@@ -107,27 +58,5 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 		IDFUtil.updateProjectBuildFolder(configuration.getWorkingCopy());
 
 		return false;
-	}
-
-	@Override
-	public void launchDescriptorRemoved(ILaunchDescriptor descriptor) throws CoreException
-	{
-		IProject project = descriptor.getAdapter(IProject.class);
-		if (project == null)
-		{
-			return;
-		}
-		Map<String, ILaunchConfiguration> projectConfigs = configs.get(project);
-		if (projectConfigs != null)
-		{
-			projectConfigs.remove(descriptor.getName());
-		}
-
-	}
-
-	@Override
-	public void launchTargetRemoved(ILaunchTarget target) throws CoreException
-	{
-		// Nothing to do
 	}
 }

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFCoreLaunchConfigProvider.java
@@ -1,20 +1,47 @@
 package com.espressif.idf.launch.serial.core;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.debug.core.launch.CoreBuildGenericLaunchConfigProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 
+import com.espressif.idf.core.build.IDFLaunchConstants;
 import com.espressif.idf.core.util.IDFUtil;
 import com.espressif.idf.core.util.LaunchDefaults;
+import com.espressif.idf.core.util.LaunchUtil;
 
 public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigProvider
 {
+
+	private Map<IProject, Map<String, ILaunchConfiguration>> configs = new HashMap<>();
+
+	@Override
+	public ILaunchConfiguration getLaunchConfiguration(ILaunchDescriptor descriptor, ILaunchTarget target)
+			throws CoreException
+	{
+		IProject project = descriptor.getAdapter(IProject.class);
+		if (project == null)
+			return null;
+
+		String targetConfig = descriptor.getName();
+		Map<String, ILaunchConfiguration> projectConfigs = configs.computeIfAbsent(project, key -> new HashMap<>());
+		ILaunchConfiguration configuration = projectConfigs.get(targetConfig);
+		configuration = configuration == null ? new LaunchUtil(DebugPlugin.getDefault().getLaunchManager())
+				.findAppropriateLaunchConfig(descriptor, IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE) : configuration;
+		configuration = configuration == null ? createLaunchConfiguration(descriptor, target) : configuration;
+		projectConfigs.put(configuration.getName(), configuration);
+
+		return configuration;
+	}
 
 	@Override
 	protected void populateLaunchConfiguration(ILaunchDescriptor descriptor, ILaunchTarget target,
@@ -53,10 +80,52 @@ public class IDFCoreLaunchConfigProvider extends CoreBuildGenericLaunchConfigPro
 	}
 
 	@Override
+	public boolean launchConfigurationAdded(ILaunchConfiguration configuration) throws CoreException
+	{
+		if (configuration.getMappedResources() == null)
+		{
+			return false;
+		}
+		IProject project = configuration.getMappedResources()[0].getProject();
+		if (project != null && !project.isOpen())
+		{
+			return true;
+		}
+		if (configuration.exists())
+		{
+			configs.computeIfAbsent(project, key -> new HashMap<>()).put(configuration.getName(), configuration);
+		}
+
+		return ownsLaunchConfiguration(configuration);
+	}
+
+	@Override
 	public boolean launchConfigurationChanged(ILaunchConfiguration configuration) throws CoreException
 	{
 		IDFUtil.updateProjectBuildFolder(configuration.getWorkingCopy());
 
 		return false;
+	}
+
+	@Override
+	public void launchDescriptorRemoved(ILaunchDescriptor descriptor) throws CoreException
+	{
+		IProject project = descriptor.getAdapter(IProject.class);
+		if (project == null)
+		{
+			return;
+		}
+		Map<String, ILaunchConfiguration> projectConfigs = configs.get(project);
+		if (projectConfigs != null)
+		{
+			projectConfigs.remove(descriptor.getName());
+		}
+
+	}
+
+	@Override
+	public void launchTargetRemoved(ILaunchTarget target) throws CoreException
+	{
+		// Nothing to do
 	}
 }

--- a/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFLaunchDescriptorType.java
+++ b/bundles/com.espressif.idf.launch.serial.core/src/com/espressif/idf/launch/serial/core/IDFLaunchDescriptorType.java
@@ -4,22 +4,20 @@
  *******************************************************************************/
 package com.espressif.idf.launch.serial.core;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.ILaunchDescriptorType;
-import org.eclipse.swt.widgets.Display;
 
 import com.espressif.idf.core.IDFProjectNature;
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
-import com.espressif.idf.ui.EclipseUtil;
 
 /**
  * @author Kondal Kolipaka <kondal.kolipaka@espressif.com>
@@ -27,8 +25,7 @@ import com.espressif.idf.ui.EclipseUtil;
  */
 public class IDFLaunchDescriptorType implements ILaunchDescriptorType
 {
-
-	private Map<ILaunchConfiguration, ILaunchDescriptor> descriptors = new HashMap<>();
+	private final Map<ILaunchConfiguration, ILaunchDescriptor> descriptors = new HashMap<>();
 
 	@Override
 	public ILaunchDescriptor getDescriptor(Object launchObject) throws CoreException
@@ -36,61 +33,43 @@ public class IDFLaunchDescriptorType implements ILaunchDescriptorType
 		if (launchObject instanceof IProject)
 		{
 			IProject project = (IProject) launchObject;
-			if (launchObject instanceof IProject && IDFProjectNature.hasNature((IProject) launchObject))
+			if (IDFProjectNature.hasNature(project))
 			{
 				return new IDFProjectLaunchDescriptor(this, project, null);
 			}
 		}
 		else if (launchObject instanceof ILaunchConfiguration)
 		{
-			ILaunchConfiguration config = (ILaunchConfiguration) launchObject;
-			String identifier = config.getType().getIdentifier();
-			if (identifier.equals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE))
+			ILaunchConfiguration configuration = (ILaunchConfiguration) launchObject;
+			if (IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE.equals(configuration.getType().getIdentifier()))
 			{
-				return null;
-			}
-			IProject project = getProject();
-			if (project == null && config.getMappedResources() == null)
-			{
-				return null;
-			}
-			project = project != null ? project : config.getMappedResources()[0].getProject();
-			try
-			{
-				if (IDFProjectNature.hasNature(project))
+				IProject project = getProject(configuration);
+				if (project != null && project.isAccessible() && IDFProjectNature.hasNature(project))
 				{
-					ILaunchDescriptor descriptor = descriptors.get(config);
-					if (descriptor == null)
-					{
-						descriptor = new IDFProjectLaunchDescriptor(this, project, (ILaunchConfiguration) launchObject);
-						descriptors.put(config, descriptor);
-					}
-					return descriptor;
+					return descriptors.computeIfAbsent(configuration,
+							config -> new IDFProjectLaunchDescriptor(this, project, config));
 				}
-			}
-			catch (CoreException ce)
-			{
-				Logger.log(ce);
 			}
 		}
 		return null;
 	}
 
-	protected IProject getProject()
+	private IProject getProject(ILaunchConfiguration configuration) throws CoreException
 	{
-		List<IProject> projectList = new ArrayList<>(1);
-		Display.getDefault().syncExec(new Runnable()
+		IResource[] mappedResources = configuration.getMappedResources();
+		if (mappedResources != null)
 		{
-
-			@Override
-			public void run()
+			for (IResource resource : mappedResources)
 			{
-				IProject project = EclipseUtil.getSelectedProjectInExplorer();
-				projectList.add(project);
+				if (resource != null)
+				{
+					return resource.getProject();
+				}
 			}
-		});
-		IProject project = projectList.get(0);
-		return project;
+		}
+
+		String projectName = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+		return projectName.isEmpty() ? null : ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 	}
 
 }

--- a/bundles/com.espressif.idf.launch.serial.ui/plugin.xml
+++ b/bundles/com.espressif.idf.launch.serial.ui/plugin.xml
@@ -60,41 +60,47 @@
             resolver="com.espressif.idf.launch.serial.ui.BuildFolderVariableResolver">
       </variable>
    </extension>
-   <extension
-         point="org.eclipse.debug.ui.launchConfigurationTabs">
-      <tab
-            class="org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab"
-            group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
-            id="org.eclipse.cdt.cdi.launch.buildSettingsTab"
-            name="Core Build Tab">
-      </tab>
-      <tab
-            class="com.espressif.idf.launch.serial.ui.internal.CMakeMainTab2"
-            group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
-            id="com.espressif.idf.launch.serial.ui.mainTab"
-            name="Main Tab">
-         <placement
-               after="org.eclipse.cdt.cdi.launch.buildSettingsTab">
-         </placement>
-      </tab>
-      <tab
-            class="org.eclipse.debug.ui.EnvironmentTab"
-            group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
-            id="org.eclipse.debug.ui.environmentTab"
-            name="Environment Tab">
-         <placement
-               after="com.espressif.idf.launch.serial.ui.mainTab">
-         </placement>
-      </tab>
-      <tab
-            class="org.eclipse.debug.ui.CommonTab"
-            group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
-            id="org.eclipse.debug.ui.commonTab"
-            name="Common Tab">
-         <placement
-               after="org.eclipse.debug.ui.environmentTab">
-         </placement>
-      </tab>
-   </extension>
+   <extension point="org.eclipse.debug.ui.launchConfigurationTabs">
+	    <!-- 1. Core Build Tab -->
+	    <tab
+	        class="org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab"
+	        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+	        id="org.eclipse.cdt.cdi.launch.buildSettingsTab"
+	        name="Core Build Tab">
+	        <associatedDelegate delegate="com.espressif.idf.launch.serial.core.launchDelegate2" />
+	    </tab>
+	
+	    <!-- 2. Main Tab -->
+	    <tab
+	        class="com.espressif.idf.launch.serial.ui.internal.CMakeMainTab2"
+	        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+	        id="com.espressif.idf.launch.serial.ui.mainTab"
+	        name="Main Tab">
+	        <placement after="org.eclipse.cdt.cdi.launch.buildSettingsTab" />
+	        <associatedDelegate delegate="com.espressif.idf.launch.serial.core.launchDelegate2" />
+	    </tab>
+	
+	    <!-- 3. Environment Tab -->
+	    <tab
+	        class="org.eclipse.debug.ui.EnvironmentTab"
+	        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+	        id="org.eclipse.debug.ui.environmentTab"
+	        name="Environment Tab">
+	        <placement after="com.espressif.idf.launch.serial.ui.mainTab" />
+	        <associatedDelegate delegate="com.espressif.idf.launch.serial.core.launchDelegate2" />
+	    </tab>
+	
+	    <!-- 4. Common Tab -->
+	    <tab
+	        class="org.eclipse.debug.ui.CommonTab"
+	        group="com.espressif.idf.launch.serial.ui.launchConfigurationTabGroup"
+	        id="org.eclipse.debug.ui.commonTab"
+	        name="Common Tab">
+	        <placement after="org.eclipse.debug.ui.environmentTab" />
+         <associatedDelegate
+               delegate="com.espressif.idf.launch.serial.core.launchDelegate2">
+         </associatedDelegate>
+	    </tab>
+	</extension>
 
 </plugin>

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/CMakeMainTab2.java
@@ -74,6 +74,7 @@ import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.core.variable.JtagDynamicVariable;
 import com.espressif.idf.core.variable.OpenocdDynamicVariable;
 import com.espressif.idf.launch.serial.util.ESPFlashUtil;
+import com.espressif.idf.swt.custom.LaunchTabControls;
 import com.espressif.idf.swt.custom.StyledInfoText;
 import com.espressif.idf.swt.custom.TextWithButton;
 import com.espressif.idf.ui.EclipseUtil;
@@ -134,6 +135,11 @@ public class CMakeMainTab2 extends GenericMainTab
 		createUartComposite(mainComposite);
 		createJtagflashComposite(mainComposite);
 		createDfuArgumentField(mainComposite);
+
+		LaunchTabControls.addRestoreDefaultsButton(mainComposite, () -> {
+			initializeFromDefaults();
+			scheduleUpdateJob();
+		});
 
 		argumentField = new Text(parent, SWT.MULTI | SWT.WRAP | SWT.BORDER | SWT.V_SCROLL);
 		argumentField.setVisible(false);

--- a/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
+++ b/bundles/com.espressif.idf.launch.serial.ui/src/com/espressif/idf/launch/serial/ui/internal/SerialFlashLaunchConfigTabGroup.java
@@ -18,10 +18,12 @@ package com.espressif.idf.launch.serial.ui.internal;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 
 import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.core.util.LaunchDefaults;
 
 public class SerialFlashLaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup
 {
@@ -30,6 +32,17 @@ public class SerialFlashLaunchConfigTabGroup extends AbstractLaunchConfiguration
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode)
 	{
 		setTabs();
+	}
+
+	@Override
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration)
+	{
+		// This configuration type is shared by run and debug, but the dialog only visits the tabs associated with the
+		// mode the configuration is created in. Seed the contributed defaults for both modes here so the attributes of
+		// the other mode are present instead of showing up empty the first time it is edited.
+		LaunchDefaults.apply(configuration);
+
+		super.setDefaults(configuration);
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/LaunchTabControls.java
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/LaunchTabControls.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.swt.custom;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+
+import com.espressif.idf.swt.messages.Messages;
+
+public final class LaunchTabControls
+{
+	private LaunchTabControls()
+	{
+	}
+
+	public static void applyEmptyDefaultHint(Text text)
+	{
+		if (text != null)
+		{
+			text.setMessage(Messages.keepEmptyForDefault);
+		}
+	}
+
+	public static void applyEmptyDefaultHint(TextWithButton field)
+	{
+		if (field != null)
+		{
+			field.setMessage(Messages.keepEmptyForDefault);
+		}
+	}
+
+	public static Button addRestoreDefaultsButton(Composite parent, Runnable restoreAction)
+	{
+		Button button = new Button(parent, SWT.PUSH);
+		button.setText(Messages.styledTextRestoreDefaultsLinkMsg);
+		button.setToolTipText(Messages.restoreDefaultsButtonToolTip);
+		GridData gd = new GridData(SWT.RIGHT, SWT.CENTER, true, false);
+		if (parent.getLayout() instanceof GridLayout gridLayout)
+		{
+			gd.horizontalSpan = Math.max(1, gridLayout.numColumns);
+		}
+		button.setLayoutData(gd);
+		button.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				restoreAction.run();
+			}
+		});
+		return button;
+	}
+
+	public static Button addRestoreDefaultsButtonToTab(Control tabControl, Runnable restoreAction)
+	{
+		Composite parent = findButtonParent(tabControl);
+		if (parent == null)
+		{
+			return null;
+		}
+		return addRestoreDefaultsButton(parent, restoreAction);
+	}
+
+	private static Composite findButtonParent(Control control)
+	{
+		if (control instanceof ScrolledComposite scrolled && scrolled.getContent() instanceof Composite content)
+		{
+			return content;
+		}
+		if (control instanceof Composite composite)
+		{
+			return composite;
+		}
+		return null;
+	}
+}

--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/TextWithButton.java
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/custom/TextWithButton.java
@@ -140,6 +140,11 @@ public class TextWithButton
 
 	}
 
+	public void setMessage(String message)
+	{
+		text.setMessage(message);
+	}
+
 	public void setEnabled(boolean enabled)
 	{
 		text.setEnabled(enabled);

--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/Messages.java
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/Messages.java
@@ -7,6 +7,8 @@ public class Messages extends NLS
 	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
 	public static String styledTextInfoDefaultMsg;
 	public static String styledTextRestoreDefaultsLinkMsg;
+	public static String keepEmptyForDefault;
+	public static String restoreDefaultsButtonToolTip;
 
 	static
 	{

--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/messages.properties
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/messages.properties
@@ -1,2 +1,4 @@
 styledTextInfoDefaultMsg=%1$s Text fields with an icon %1$s use dynamic variables. Click %1$s to see actual values. If the configuration is from an older version, click %2$s to populate fields with dynamic variables.
 styledTextRestoreDefaultsLinkMsg=Restore defaults
+keepEmptyForDefault=(keep empty for default)
+restoreDefaultsButtonToolTip=Restore all fields to their default values.\nCurrent values will be lost.

--- a/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/messages_zh.properties
+++ b/bundles/com.espressif.idf.swt.custom/src/com/espressif/idf/swt/messages/messages_zh.properties
@@ -1,0 +1,4 @@
+styledTextInfoDefaultMsg=%1$s 带图标 %1$s 的文本字段使用动态变量。点击 %1$s 可查看实际值。如果配置来自旧版本，请点击 %2$s 以动态变量填充字段。
+styledTextRestoreDefaultsLinkMsg=\u6062\u590d\u9ed8\u8ba4\u503c
+keepEmptyForDefault=(\u7559\u7a7a\u5219\u4f7f\u7528\u9ed8\u8ba4\u503c)
+restoreDefaultsButtonToolTip=\u5c06\u6240\u6709\u5b57\u6bb5\u6062\u590d\u5230\u5176\u9ed8\u8ba4\u503c\u3002\n\u5f53\u524d\u914d\u7f6e\u5c06\u4e22\u5931\u3002

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/LaunchBarListener.java
@@ -6,8 +6,6 @@ package com.espressif.idf.ui;
 
 import java.io.File;
 import java.text.MessageFormat;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
@@ -20,8 +18,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.launchbar.core.ILaunchBarListener;
 import org.eclipse.launchbar.core.ILaunchBarManager;
@@ -59,19 +55,6 @@ public class LaunchBarListener implements ILaunchBarListener
 
 			if (activeLaunchConfiguration != null && activeLaunchConfiguration.getType() != null)
 			{
-				String configTypeIdentifier = activeLaunchConfiguration.getType().getIdentifier();
-				if (IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE.equals(configTypeIdentifier))
-				{
-					// Set debug mode first to ensure a mode change, triggering listeners.
-					setMode(launchBarManager, ILaunchManager.DEBUG_MODE);
-					setMode(launchBarManager, ILaunchManager.RUN_MODE);
-				}
-				else if (IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE.equals(configTypeIdentifier))
-				{
-					// Set run mode first to ensure a mode change, triggering listeners.
-					setMode(launchBarManager, ILaunchManager.RUN_MODE);
-					setMode(launchBarManager, ILaunchManager.DEBUG_MODE);
-				}
 				updateProjectBuildFolderBasedOnActiveConfig(activeLaunchConfiguration);
 			}
 		}
@@ -225,24 +208,6 @@ public class LaunchBarListener implements ILaunchBarListener
 				// attempting one more time!
 				sdkconfig.renameTo(sdkconfigOld);
 			}
-		}
-	}
-
-	private void setMode(ILaunchBarManager launchBarManager, String mode)
-	{
-		try
-		{
-			Optional<ILaunchMode> runMode = Stream.of(launchBarManager.getLaunchModes())
-					.filter(m -> m.getIdentifier().equals(mode)).findFirst();
-			if (runMode.isPresent())
-			{
-				launchBarManager.setActiveLaunchMode(runMode.get());
-			}
-
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
 		}
 	}
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/handlers/RunActionHandler.java
@@ -4,38 +4,23 @@
  *******************************************************************************/
 package com.espressif.idf.ui.handlers;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.window.Window;
-import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.ui.ILaunchBarUIManager;
-import org.eclipse.launchbar.ui.NewLaunchConfigWizard;
-import org.eclipse.launchbar.ui.NewLaunchConfigWizardDialog;
 import org.eclipse.launchbar.ui.internal.commands.LaunchActiveCommandHandler;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 
 import com.espressif.idf.core.build.IDFLaunchConstants;
-import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.StringUtil;
 import com.espressif.idf.ui.UIPlugin;
-import com.espressif.idf.ui.dialogs.SelectDebugConfigDialog;
 
 @SuppressWarnings("restriction")
 public class RunActionHandler extends LaunchActiveCommandHandler
@@ -54,13 +39,10 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 			{
 				return Status.OK_STATUS;
 			}
-
-			boolean isEspLaunchConfig = config.getType().getIdentifier()
+			boolean isUnifiedEspConfig = config.getType().getIdentifier()
 					.contentEquals(IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
-			boolean isEspDebugConfig = config.getType().getIdentifier()
-					.contentEquals(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
 
-			if (!isEspLaunchConfig && !isEspDebugConfig)
+			if (!isUnifiedEspConfig)
 			{
 				return super.execute(event);
 			}
@@ -70,7 +52,7 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 			{
 				return Status.OK_STATUS;
 			}
-			int returnCode = Window.OK;
+
 			String projectName = config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME,
 					StringUtil.EMPTY);
 			if (projectName.isBlank())
@@ -85,29 +67,10 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 				}
 				return Status.CANCEL_STATUS;
 			}
-			if (launchMode.getIdentifier().equals(ILaunchManager.DEBUG_MODE) && isEspLaunchConfig)
-			{
-				List<String> suitableDescNames = findSuitableDescNames(projectName,
-						IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
-				if (suitableDescNames.isEmpty())
-				{
-					showMessage(Messages.DebugConfigurationNotFoundMsg);
-					return Status.CANCEL_STATUS;
-				}
-				returnCode = runActionBasedOnDescCount(launchBarManager, suitableDescNames);
-			}
-			else if (launchMode.getIdentifier().equals(ILaunchManager.RUN_MODE) && isEspDebugConfig)
-			{
-				List<String> suitableDescNames = findSuitableDescNames(projectName,
-						IDFLaunchConstants.RUN_LAUNCH_CONFIG_TYPE);
-				returnCode = runActionBasedOnDescCount(launchBarManager, suitableDescNames);
-			}
-			if (returnCode == Window.OK)
-			{
-				launchBarManager.setActiveLaunchMode(launchMode);
-				config = launchBarManager.getActiveLaunchConfiguration();
-				DebugUITools.launch(config, launchMode.getIdentifier());
-			}
+
+			launchBarManager.setActiveLaunchMode(launchMode);
+			config = launchBarManager.getActiveLaunchConfiguration();
+			DebugUITools.launch(config, launchMode.getIdentifier());
 
 			return Status.OK_STATUS;
 		}
@@ -115,82 +78,5 @@ public class RunActionHandler extends LaunchActiveCommandHandler
 		{
 			return e.getStatus();
 		}
-	}
-
-	private int runActionBasedOnDescCount(ILaunchBarManager launchBarManager, List<String> suitableDescNames)
-			throws CoreException
-	{
-		return suitableDescNames.size() == 1
-				? setLaunchBarWithFirstAppropriateDescriptor(launchBarManager, suitableDescNames)
-				: new SelectDebugConfigDialog(Display.getDefault().getActiveShell(), suitableDescNames).open();
-	}
-
-	private int setLaunchBarWithFirstAppropriateDescriptor(ILaunchBarManager launchBarManager,
-			List<String> suitableDescNames) throws CoreException
-	{
-		Stream.of(launchBarManager.getLaunchDescriptors())
-				.filter(desc -> desc.getName().equals(suitableDescNames.get(0))).findFirst().ifPresent(desc -> {
-					try
-					{
-						launchBarManager.setActiveLaunchDescriptor(desc);
-					}
-					catch (CoreException e)
-					{
-						Logger.log(e);
-					}
-				});
-		return IStatus.OK;
-	}
-
-	private List<String> findSuitableDescNames(String projectName, String configType)
-	{
-		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-		List<ILaunchConfiguration> configList = new ArrayList<>();
-		try
-		{
-			configList = Arrays.asList(
-					launchManager.getLaunchConfigurations(launchManager.getLaunchConfigurationType(configType)));
-
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
-		}
-		return configList.stream().filter(config -> {
-			try
-			{
-				return config.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, StringUtil.EMPTY)
-						.contentEquals(projectName);
-			}
-			catch (CoreException e)
-			{
-				Logger.log(e);
-			}
-			return false;
-		}).map(config -> config.getName()).toList();
-	}
-
-	private void showMessage(final String message)
-	{
-		Display.getDefault().asyncExec(() -> {
-
-			Shell activeShell = Display.getDefault().getActiveShell();
-			boolean isYes = MessageDialog.openQuestion(activeShell, Messages.MissingDebugConfigurationTitle, message);
-			if (isYes)
-			{
-
-				NewLaunchConfigWizard wizard = new NewLaunchConfigWizard();
-				WizardDialog dialog = new NewLaunchConfigWizardDialog(activeShell, wizard);
-				dialog.open();
-				try
-				{
-					wizard.getWorkingCopy().doSave();
-				}
-				catch (CoreException e)
-				{
-					Logger.log(e);
-				}
-			}
-		});
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -17,21 +17,14 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.jface.dialogs.IDialogSettings;
-import org.eclipse.jface.dialogs.PageChangingEvent;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
-import org.eclipse.launchbar.ui.NewLaunchConfigWizard;
-import org.eclipse.launchbar.ui.NewLaunchConfigWizardDialog;
-import org.eclipse.launchbar.ui.internal.dialogs.NewLaunchConfigEditPage;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.tools.templates.core.IGenerator;
 import org.eclipse.tools.templates.ui.TemplateWizard;
 import org.eclipse.ui.IViewPart;
@@ -150,8 +143,6 @@ public class NewIDFProjectWizard extends TemplateWizard
 
 					// this ensures that the configuration exists
 					launchBarManager.getActiveLaunchConfiguration();
-
-					createDefaultDebugConfig();
 					launchBarManager.setActiveLaunchDescriptor(desc);
 				}
 			}
@@ -203,38 +194,6 @@ public class NewIDFProjectWizard extends TemplateWizard
 		{
 			Logger.log(e);
 		}
-	}
-
-	private void createDefaultDebugConfig()
-	{
-		Shell activeShell = Display.getDefault().getActiveShell();
-
-		NewLaunchConfigWizard wizard = new NewLaunchConfigWizard();
-		WizardDialog dialog = new NewLaunchConfigWizardDialog(activeShell, wizard);
-		dialog.create();
-
-		NewLaunchConfigEditPage editPage = (NewLaunchConfigEditPage) wizard.getPage(NEW_LAUNCH_CONFIG_EDIT_PAGE);
-		ILaunchConfigurationType debugLaunchConfigType = DebugPlugin.getDefault().getLaunchManager()
-				.getLaunchConfigurationType(IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE);
-		editPage.setLaunchConfigType(debugLaunchConfigType);
-
-		PageChangingEvent pageChangingEvent = new PageChangingEvent(wizard, wizard.getStartingPage(), editPage);
-		editPage.handlePageChanging(pageChangingEvent);
-		wizard.performFinish();
-
-		try
-		{
-			String originalName = wizard.getWorkingCopy().getName();
-			int configPartIndex = originalName.lastIndexOf("Configuration"); //$NON-NLS-1$
-			String debugConfigName = configPartIndex != -1 ? originalName.substring(0, configPartIndex) + "Debug" //$NON-NLS-1$
-					: originalName;
-			wizard.getWorkingCopy().copy(debugConfigName).doSave();
-		}
-		catch (CoreException e)
-		{
-			Logger.log(e);
-		}
-		wizard.dispose();
 	}
 
 	@Override

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/NewIDFProjectWizard.java
@@ -6,7 +6,6 @@ package com.espressif.idf.ui.wizard;
 
 import java.io.File;
 
-import org.eclipse.cdt.debug.internal.core.InternalDebugCoreMessages;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -14,17 +13,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.launchbar.core.ILaunchBarManager;
-import org.eclipse.launchbar.core.ILaunchDescriptor;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.tools.templates.core.IGenerator;
 import org.eclipse.tools.templates.ui.TemplateWizard;
 import org.eclipse.ui.IViewPart;
@@ -32,14 +27,13 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 
 import com.espressif.idf.core.IDFConstants;
-import com.espressif.idf.core.LaunchBarTargetConstants;
-import com.espressif.idf.core.build.IDFLaunchConstants;
+import com.espressif.idf.core.build.IDFBuildConfigurationSetup;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.util.ClangFormatFileHandler;
 import com.espressif.idf.core.util.ClangdConfigFileHandler;
 import com.espressif.idf.core.util.ConsoleManager;
 import com.espressif.idf.core.util.IdfCommandExecutor;
-import com.espressif.idf.core.util.LaunchUtil;
+import com.espressif.idf.core.util.LaunchTargetHelper;
 import com.espressif.idf.ui.UIPlugin;
 import com.espressif.idf.ui.handlers.EclipseHandler;
 import com.espressif.idf.ui.handlers.NewProjectHandlerUtil;
@@ -57,10 +51,9 @@ import com.espressif.idf.ui.tools.ManageEspIdfVersionsHandler;
 @SuppressWarnings("restriction")
 public class NewIDFProjectWizard extends TemplateWizard
 {
-	private static final String NEW_LAUNCH_CONFIG_EDIT_PAGE = "NewLaunchConfigEditPage"; //$NON-NLS-1$
-	public static final String TARGET_SWITCH_JOB = "TARGET SWITCH JOB"; //$NON-NLS-1$
 	private NewProjectCreationWizardPage projectCreationWizardPage;
 	private IProject project;
+
 	public NewIDFProjectWizard()
 	{
 		IDialogSettings workbenchSettings = IDEWorkbenchPlugin.getDefault().getDialogSettings();
@@ -117,13 +110,13 @@ public class NewIDFProjectWizard extends TemplateWizard
 		boolean performFinish = super.performFinish();
 		if (performFinish)
 		{
+			project = ResourcesPlugin.getWorkspace().getRoot()
+					.getProject(projectCreationWizardPage.getProjectName());
 			IWorkbenchPage page = EclipseHandler.getActiveWorkbenchWindow().getActivePage();
 			IViewPart viewPart = page.findView("org.eclipse.ui.navigator.ProjectExplorer"); //$NON-NLS-1$
 			if (viewPart != null)
 			{
 				ISelectionProvider selProvider = viewPart.getSite().getSelectionProvider();
-				String projectName = projectCreationWizardPage.getProjectName();
-				project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 				selProvider.setSelection(new StructuredSelection(project));
 				updateClangFiles(project);
 			}
@@ -131,32 +124,40 @@ public class NewIDFProjectWizard extends TemplateWizard
 
 		final String target = projectCreationWizardPage.getSelectedTarget();
 		this.getShell().addDisposeListener(event -> {
-			ILaunchBarManager launchBarManager = UIPlugin.getService(ILaunchBarManager.class);
-			TargetSwitchJob targetSwtichJob = new TargetSwitchJob(target);
-			targetSwtichJob.schedule();
-			try
-			{
-				ILaunchDescriptor desc = launchBarManager.getActiveLaunchDescriptor();
-				if (new LaunchUtil(DebugPlugin.getDefault().getLaunchManager()).findAppropriateLaunchConfig(desc,
-						IDFLaunchConstants.DEBUG_LAUNCH_CONFIG_TYPE) == null)
-				{
-
-					// this ensures that the configuration exists
-					launchBarManager.getActiveLaunchConfiguration();
-					launchBarManager.setActiveLaunchDescriptor(desc);
-				}
-			}
-			catch (CoreException e)
-			{
-				Logger.log(e);
-			}
+			IDFBuildConfigurationSetup.schedule(project, activateLaunchTarget(target));
 			if (projectCreationWizardPage.isRunIdfReconfigureEnabled())
 			{
 				runIdfReconfigureCommandJob(target);
-
 			}
 		});
 		return performFinish;
+	}
+
+	/**
+	 * Selects the chip chosen in the wizard in the Launch Bar. The Launch Bar keeps the target of the previously active
+	 * project when a new descriptor has no remembered target of its own, so the choice has to be applied explicitly.
+	 *
+	 * @param idfTargetName ESP-IDF target selected in the wizard
+	 * @return the matching launch target, or {@code null} when none is registered for that chip
+	 */
+	private ILaunchTarget activateLaunchTarget(String idfTargetName)
+	{
+		ILaunchTargetManager launchTargetManager = UIPlugin.getService(ILaunchTargetManager.class);
+		ILaunchTarget launchTarget = LaunchTargetHelper.findLaunchTargetByName(launchTargetManager, idfTargetName);
+		if (launchTarget == null)
+		{
+			return null;
+		}
+
+		try
+		{
+			UIPlugin.getService(ILaunchBarManager.class).setActiveLaunchTarget(launchTarget);
+		}
+		catch (CoreException e)
+		{
+			Logger.log(e);
+		}
+		return launchTarget;
 	}
 
 	private void runIdfReconfigureCommandJob(final String target)
@@ -216,81 +217,5 @@ public class NewIDFProjectWizard extends TemplateWizard
 			generator.setLocationURI(projectCreationWizardPage.getLocationURI());
 		}
 		return generator;
-	}
-
-	private class TargetSwitchJob extends Job
-	{
-		private ILaunchBarManager launchBarManager;
-		private String target;
-
-		public TargetSwitchJob(String target)
-		{
-			super(TARGET_SWITCH_JOB);
-			this.target = target;
-			launchBarManager = UIPlugin.getService(ILaunchBarManager.class);
-		}
-
-		private Job findInternalJob()
-		{
-			for (Job job : Job.getJobManager().find(null))
-			{
-				if (job.getName().equals(InternalDebugCoreMessages.CoreBuildLaunchBarTracker_Job))
-				{
-					return job;
-				}
-			}
-
-			return null;
-		}
-
-		@Override
-		protected IStatus run(IProgressMonitor monitor)
-		{
-			Job job = findInternalJob();
-			if (job != null)
-			{
-				try
-				{
-					job.join();
-				}
-				catch (InterruptedException e1)
-				{
-					Logger.log(e1);
-				}
-			}
-
-			Display.getDefault().syncExec(() -> {
-				ILaunchTarget launchTarget = findSuitableTargetForSelectedTargetString();
-				try
-				{
-					launchBarManager.setActiveLaunchTarget(launchTarget);
-				}
-				catch (CoreException e)
-				{
-					Logger.log(e);
-				}
-			});
-
-			return Status.OK_STATUS;
-
-		}
-
-		private ILaunchTarget findSuitableTargetForSelectedTargetString()
-		{
-			ILaunchTargetManager launchTargetManager = UIPlugin.getService(ILaunchTargetManager.class);
-			ILaunchTarget[] targets = launchTargetManager
-					.getLaunchTargetsOfType(IDFLaunchConstants.ESP_LAUNCH_TARGET_TYPE);
-
-			for (ILaunchTarget iLaunchTarget : targets)
-			{
-				String idfTarget = iLaunchTarget.getAttribute(LaunchBarTargetConstants.TARGET, null);
-				if (idfTarget.contentEquals(target))
-				{
-					return iLaunchTarget;
-				}
-			}
-
-			return null;
-		}
 	}
 }

--- a/docs/en/openocddebugging.rst
+++ b/docs/en/openocddebugging.rst
@@ -19,7 +19,7 @@ Please navigate through each tab and configure project specific settings.
 
 .. note::
 
-    Most of the settings are auto-configured by the plugin.
+    Most of the settings are auto-configured by the plugin. You can leave a text field empty to use that default; empty fields show ``(keep empty for default)``. Each **Main**, **Debugger**, **Startup**, and **SVD** tab (and the Run **Main** tab) has a **Restore defaults** button that fills that tab with the built-in values.
 
 .. image:: ../../media/OpenOCDDebug_4.png
 
@@ -38,7 +38,7 @@ Main Tab
 
 1. Enter the ``Name`` of this configuration, the default name is "{project_name} Configuration".
 2. On the ``Main`` tab below, under ``Project:``, press ``Browse`` button and select the project if it's not selected or you want to change it.
-3. In the next line, ``C/C++ Application:`` should be a relative path to the elf file, for example, ``build/hello_world.elf`` for ``hello_world`` project. If the elf file is not there, then likely this project has not been build yet. After building the project, the elf file will appear there. However, you can change it by pressing ``Browse`` button.
+3. In the next line, ``C/C++ Application:`` should be a relative path to the elf file, for example, ``build/hello_world.elf`` for ``hello_world`` project. If the elf file is not there, then likely this project has not been build yet. After building the project, the elf file will appear there. However, you can change it by pressing ``Browse`` button. You can also leave this field empty to use the default application (``${default_app}``).
 
 The last section on the ``Main`` tab is ``Build (if required) before launching``. If you don't want to build the project each time you click the ``Debug`` button, then select ``Disable auto build``.
 
@@ -49,7 +49,7 @@ Points 1–3 are shown below.
 Debugger Tab
 ------------
 
-In the ``Debugger`` tab, all parameters are automatically configured to start debugging, you just need to check if the ``Config options`` line is appropriate for your board. It automatically adjusts based on ``Flash voltage`` and ``Board`` options. If you expand the list of boards, only those that match the selected ``Target`` will appear. So, for example, if the selected target is ``esp32``, you will not see ``ESP32-S2-KALUGA-1`` in the list. To make it appear, you need to change the target to ``esp32s2`` first. The second option in the Debugger tab is ``GDB executable``, which also depends on the selected target and is automatically configured based on it.
+In the ``Debugger`` tab, all parameters are automatically configured to start debugging, you just need to check if the ``Config options`` line is appropriate for your board. It automatically adjusts based on ``Flash voltage`` and ``Board`` options. If you expand the list of boards, only those that match the selected ``Target`` will appear. So, for example, if the selected target is ``esp32``, you will not see ``ESP32-S2-KALUGA-1`` in the list. To make it appear, you need to change the target to ``esp32s2`` first. The second option in the Debugger tab is ``GDB executable``, which also depends on the selected target and is automatically configured based on it. You can leave OpenOCD path, ports, config options, and GDB fields empty to keep the plugin defaults.
 
 Let's take a look at some other options, that you need to check if they auto-configured correctly for you:
 

--- a/docs/zh_CN/openocddebugging.rst
+++ b/docs/zh_CN/openocddebugging.rst
@@ -19,7 +19,7 @@ ESP-IDF GDB OpenOCD 调试
 
 .. note::
 
-    插件能自动配置大多数设置。
+    插件能自动配置大多数设置。文本字段可以留空以使用默认值；留空时会显示 ``(keep empty for default)``（留空则使用默认值）。**Main**、**Debugger**、**Startup** 和 **SVD** 标签页（以及运行配置的 **Main** 标签页）均提供 **Restore defaults** 按钮，用于将该标签页恢复为内置默认值。
 
 .. image:: ../../media/OpenOCDDebug_4.png
 
@@ -38,7 +38,7 @@ Main 标签页
 
 1. 输入此配置的 ``Name``，默认名称为 "{project_name} Configuration"。
 2. 在 ``Main`` 标签页中，找到 ``Project:`` 一栏，点击 ``Browse`` 按钮来选择或更改当前项目。
-3. 下一行的 ``C/C++ Application:`` 是指向 elf 文件的相对路径，例如 ``build/hello_world.elf``，对应 ``hello_world`` 项目。若不存在 elf 文件，则此项目可能尚未构建。构建项目后，该 elf 文件会出现，也可以点击 ``Browse`` 按钮进行更改。
+3. 下一行的 ``C/C++ Application:`` 是指向 elf 文件的相对路径，例如 ``build/hello_world.elf``，对应 ``hello_world`` 项目。若不存在 elf 文件，则此项目可能尚未构建。构建项目后，该 elf 文件会出现，也可以点击 ``Browse`` 按钮进行更改。也可以将该字段留空，以使用默认应用程序（``${default_app}``）。
 
 ``Main`` 标签页中的最后一栏是 ``Build (if required) before launching``。如果不想在每次点击 ``Debug`` 按钮时都构建项目，则选择 ``Disable auto build`` 选项。
 
@@ -49,7 +49,7 @@ Main 标签页
 Debugger 标签页
 ---------------
 
-在 ``Debugger`` 标签页中，所有参数都会自动配置以开始调试，你只需检查 ``Config options`` 是否适用于你的开发板即可。该选项会根据 ``Flash voltage`` 和 ``Board`` 选项自动调整。展开开发板列表时，只会显示与所选 ``Target`` 相匹配的条目。举例来说，如果所选目标芯片是 ``esp32``，列表中不会显示 ``ESP32-S2-KALUGA-1``。若希望显示该开发版，需要先将目标芯片改为 ``esp32s2``。``Debugger`` 标签页中的第二个选项是 ``GDB executable``，该选项同样依赖于所选目标芯片，并会根据目标自动进行配置
+在 ``Debugger`` 标签页中，所有参数都会自动配置以开始调试，你只需检查 ``Config options`` 是否适用于你的开发板即可。该选项会根据 ``Flash voltage`` 和 ``Board`` 选项自动调整。展开开发板列表时，只会显示与所选 ``Target`` 相匹配的条目。举例来说，如果所选目标芯片是 ``esp32``，列表中不会显示 ``ESP32-S2-KALUGA-1``。若希望显示该开发版，需要先将目标芯片改为 ``esp32s2``。``Debugger`` 标签页中的第二个选项是 ``GDB executable``，该选项同样依赖于所选目标芯片，并会根据目标自动进行配置。OpenOCD 路径、端口、配置选项和 GDB 相关字段均可留空，以使用插件默认值。
 
 还有一些其他选项，建议检查这些选项是否已自动正确配置：
 

--- a/docs/zh_CN/openocddebugging.rst
+++ b/docs/zh_CN/openocddebugging.rst
@@ -19,7 +19,7 @@ ESP-IDF GDB OpenOCD 调试
 
 .. note::
 
-    插件能自动配置大多数设置。文本字段可以留空以使用默认值；留空时会显示 ``(keep empty for default)``（留空则使用默认值）。**Main**、**Debugger**、**Startup** 和 **SVD** 标签页（以及运行配置的 **Main** 标签页）均提供 **Restore defaults** 按钮，用于将该标签页恢复为内置默认值。
+    插件能自动配置大多数设置。文本字段可以留空以使用默认值；留空时会显示 ``(keep empty for default)``\ （留空则使用默认值）。**Main**、**Debugger**、**Startup** 和 **SVD** 标签页（以及运行配置的 **Main** 标签页）均提供 **Restore defaults** 按钮，用于将该标签页恢复为内置默认值。
 
 .. image:: ../../media/OpenOCDDebug_4.png
 

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchAttributesTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/util/test/LaunchAttributesTest.java
@@ -1,0 +1,199 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.util.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.espressif.idf.core.util.LaunchAttributes;
+import com.espressif.idf.core.util.StringUtil;
+
+class LaunchAttributesTest
+{
+	private static final String KEY = "test.key"; //$NON-NLS-1$
+	private static final String DEFAULT_VALUE = "default"; //$NON-NLS-1$
+	private static final String USER_VALUE = "user"; //$NON-NLS-1$
+
+	private ILaunchConfiguration configuration;
+	private ILaunchConfigurationWorkingCopy workingCopy;
+
+	@BeforeEach
+	void setUp()
+	{
+		configuration = Mockito.mock(ILaunchConfiguration.class);
+		workingCopy = Mockito.mock(ILaunchConfigurationWorkingCopy.class);
+	}
+
+	@Test
+	void getString_returnsStoredValueWhenPresent() throws CoreException
+	{
+		when(configuration.getAttribute(KEY, DEFAULT_VALUE)).thenReturn(USER_VALUE);
+
+		assertEquals(USER_VALUE, LaunchAttributes.getString(configuration, KEY, DEFAULT_VALUE));
+	}
+
+	@Test
+	void getString_returnsDefaultWhenValueIsBlank() throws CoreException
+	{
+		when(configuration.getAttribute(KEY, DEFAULT_VALUE)).thenReturn("  "); //$NON-NLS-1$
+
+		assertEquals(DEFAULT_VALUE, LaunchAttributes.getString(configuration, KEY, DEFAULT_VALUE));
+	}
+
+	@Test
+	void getString_returnsDefaultWhenValueIsEmpty() throws CoreException
+	{
+		when(configuration.getAttribute(KEY, DEFAULT_VALUE)).thenReturn(StringUtil.EMPTY);
+
+		assertEquals(DEFAULT_VALUE, LaunchAttributes.getString(configuration, KEY, DEFAULT_VALUE));
+	}
+
+	@Test
+	void setStringIfEmpty_writesWhenAttributeIsMissing() throws CoreException
+	{
+		when(workingCopy.getAttribute(KEY, StringUtil.EMPTY)).thenReturn(StringUtil.EMPTY);
+
+		LaunchAttributes.setStringIfEmpty(workingCopy, KEY, DEFAULT_VALUE);
+
+		verify(workingCopy).setAttribute(KEY, DEFAULT_VALUE);
+	}
+
+	@Test
+	void setStringIfEmpty_writesWhenAttributeIsBlank() throws CoreException
+	{
+		when(workingCopy.getAttribute(KEY, StringUtil.EMPTY)).thenReturn(" "); //$NON-NLS-1$
+
+		LaunchAttributes.setStringIfEmpty(workingCopy, KEY, DEFAULT_VALUE);
+
+		verify(workingCopy).setAttribute(KEY, DEFAULT_VALUE);
+	}
+
+	@Test
+	void setStringIfEmpty_doesNotOverwriteUserValue() throws CoreException
+	{
+		when(workingCopy.getAttribute(KEY, StringUtil.EMPTY)).thenReturn(USER_VALUE);
+
+		LaunchAttributes.setStringIfEmpty(workingCopy, KEY, DEFAULT_VALUE);
+
+		verify(workingCopy, never()).setAttribute(eq(KEY), anyString());
+	}
+
+	@Test
+	void setIfAbsent_writesBooleanWhenMissing() throws CoreException
+	{
+		when(workingCopy.hasAttribute(KEY)).thenReturn(false);
+
+		LaunchAttributes.setIfAbsent(workingCopy, KEY, true);
+
+		verify(workingCopy).setAttribute(KEY, true);
+	}
+
+	@Test
+	void setIfAbsent_keepsStoredFalse() throws CoreException
+	{
+		when(workingCopy.hasAttribute(KEY)).thenReturn(true);
+
+		LaunchAttributes.setIfAbsent(workingCopy, KEY, true);
+
+		verify(workingCopy, never()).setAttribute(eq(KEY), eq(true));
+	}
+
+	@Test
+	void setIfAbsent_writesIntWhenMissing() throws CoreException
+	{
+		when(workingCopy.hasAttribute(KEY)).thenReturn(false);
+
+		LaunchAttributes.setIfAbsent(workingCopy, KEY, 3333);
+
+		verify(workingCopy).setAttribute(KEY, 3333);
+	}
+
+	@Test
+	void setIfAbsent_keepsStoredZero() throws CoreException
+	{
+		when(workingCopy.hasAttribute(KEY)).thenReturn(true);
+
+		LaunchAttributes.setIfAbsent(workingCopy, KEY, 3333);
+
+		verify(workingCopy, never()).setAttribute(eq(KEY), eq(3333));
+	}
+
+	@Test
+	void getStoredString_returnsEmptyWhenAttributeIsMissing() throws CoreException
+	{
+		when(configuration.hasAttribute(KEY)).thenReturn(false);
+
+		assertEquals(StringUtil.EMPTY, LaunchAttributes.getStoredString(configuration, KEY));
+	}
+
+	@Test
+	void getStoredString_returnsStoredValue() throws CoreException
+	{
+		when(configuration.hasAttribute(KEY)).thenReturn(true);
+		when(configuration.getAttribute(KEY, StringUtil.EMPTY)).thenReturn(USER_VALUE);
+
+		assertEquals(USER_VALUE, LaunchAttributes.getStoredString(configuration, KEY));
+	}
+
+	@Test
+	void getStoredIntText_returnsEmptyWhenAttributeIsMissing() throws CoreException
+	{
+		when(configuration.hasAttribute(KEY)).thenReturn(false);
+
+		assertEquals(StringUtil.EMPTY, LaunchAttributes.getStoredIntText(configuration, KEY));
+	}
+
+	@Test
+	void getStoredIntText_returnsStoredValue() throws CoreException
+	{
+		when(configuration.hasAttribute(KEY)).thenReturn(true);
+		when(configuration.getAttribute(KEY, 0)).thenReturn(3333);
+
+		assertEquals("3333", LaunchAttributes.getStoredIntText(configuration, KEY)); //$NON-NLS-1$
+	}
+
+	@Test
+	void setOrClearString_removesBlankValue()
+	{
+		LaunchAttributes.setOrClearString(workingCopy, KEY, "  "); //$NON-NLS-1$
+
+		verify(workingCopy).setAttribute(KEY, (String) null);
+	}
+
+	@Test
+	void setOrClearString_writesNonEmptyValue()
+	{
+		LaunchAttributes.setOrClearString(workingCopy, KEY, USER_VALUE);
+
+		verify(workingCopy).setAttribute(KEY, USER_VALUE);
+	}
+
+	@Test
+	void setOrClearInt_removesBlankValue()
+	{
+		LaunchAttributes.setOrClearInt(workingCopy, KEY, StringUtil.EMPTY);
+
+		verify(workingCopy).setAttribute(KEY, (String) null);
+	}
+
+	@Test
+	void setOrClearInt_writesParsedValue()
+	{
+		LaunchAttributes.setOrClearInt(workingCopy, KEY, "3333"); //$NON-NLS-1$
+
+		verify(workingCopy).setAttribute(KEY, 3333);
+	}
+}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/IDFProjectBuildConfigurationTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/IDFProjectBuildConfigurationTest.java
@@ -9,9 +9,7 @@ import static org.junit.Assert.assertNotEquals;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
@@ -20,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
 import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
@@ -48,6 +45,9 @@ public class IDFProjectBuildConfigurationTest
 	@AfterClass
 	public static void tearDown()
 	{
+		// The active mode is shared by the whole workbench, so it has to go back to the default before the next test
+		// class runs. Otherwise every later test edits and launches the ESP-IDF Application configuration in Debug.
+		ProjectTestOperations.selectLaunchMode(ILaunchManager.RUN_MODE, bot);
 		TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
 		ProjectTestOperations.closeAllProjects(bot);
 		ProjectTestOperations.deleteAllProjects(bot);
@@ -88,16 +88,7 @@ public class IDFProjectBuildConfigurationTest
 
 		private static void whenLaunchModeIsSelected(String launchMode)
 		{
-			ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
-			try
-			{
-				launchBarManager
-						.setActiveLaunchMode(DebugPlugin.getDefault().getLaunchManager().getLaunchMode(launchMode));
-			}
-			catch (Exception e)
-			{
-				throw new AssertionError("Unable to select the " + launchMode + " launch mode", e); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			ProjectTestOperations.selectLaunchMode(launchMode, bot);
 		}
 
 		private static String thenCoreBuildConfigurationIsAssigned(String launchMode)

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/IDFProjectBuildConfigurationTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/IDFProjectBuildConfigurationTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD. All rights reserved.
+ * Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.ui.test.executable.cases.project;
+
+import static org.junit.Assert.assertNotEquals;
+
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.launchbar.core.ILaunchBarManager;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.espressif.idf.core.IDFCorePlugin;
+import com.espressif.idf.core.build.IDFBuildConfigurationProvider;
+import com.espressif.idf.ui.test.common.WorkBenchSWTBot;
+import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
+import com.espressif.idf.ui.test.operations.EnvSetupOperations;
+import com.espressif.idf.ui.test.operations.ProjectTestOperations;
+
+/**
+ * Verifies the CDT Core Build configuration lifecycle of IDF projects.
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class IDFProjectBuildConfigurationTest
+{
+	private static final String PROJECT_NAME = "RecreatedProject"; //$NON-NLS-1$
+	private static final String CONFIG_NAME_PREFIX = IDFBuildConfigurationProvider.ID + "/idf."; //$NON-NLS-1$
+
+	private static SWTWorkbenchBot bot;
+
+	@BeforeClass
+	public static void beforeTestClass() throws Exception
+	{
+		bot = WorkBenchSWTBot.getBot();
+		EnvSetupOperations.setupEspressifEnv(bot);
+	}
+
+	@AfterClass
+	public static void tearDown()
+	{
+		TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+		ProjectTestOperations.closeAllProjects(bot);
+		ProjectTestOperations.deleteAllProjects(bot);
+	}
+
+	/**
+	 * Verifies that CDT assigns mode-specific configurations and that recreating a project under a name the tracker
+	 * handled before still produces a usable configuration.
+	 */
+	@Test
+	public void givenProjectWhenModeChangesAndProjectIsRecreatedThenModeSpecificConfigurationIsAssigned()
+	{
+		Fixture.givenProjectIsCreated();
+		String runModeConfig = Fixture.thenCoreBuildConfigurationIsAssigned(ILaunchManager.RUN_MODE);
+
+		Fixture.whenLaunchModeIsSelected(ILaunchManager.DEBUG_MODE);
+		String debugModeConfig = Fixture.thenCoreBuildConfigurationIsAssigned(ILaunchManager.DEBUG_MODE);
+		assertNotEquals("Run and Debug must have separate CDT Core Build configurations", runModeConfig, //$NON-NLS-1$
+				debugModeConfig);
+
+		Fixture.whenProjectIsDeletedAndCreatedAgain();
+
+		Fixture.thenCoreBuildConfigurationIsAssigned(ILaunchManager.DEBUG_MODE);
+	}
+
+	private static class Fixture
+	{
+		private static void givenProjectIsCreated()
+		{
+			ProjectTestOperations.setupProject(PROJECT_NAME, "EspressIf", "Espressif IDF Project", bot); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		private static void whenProjectIsDeletedAndCreatedAgain()
+		{
+			ProjectTestOperations.deleteAllProjects(bot);
+			givenProjectIsCreated();
+		}
+
+		private static void whenLaunchModeIsSelected(String launchMode)
+		{
+			ILaunchBarManager launchBarManager = IDFCorePlugin.getService(ILaunchBarManager.class);
+			try
+			{
+				launchBarManager
+						.setActiveLaunchMode(DebugPlugin.getDefault().getLaunchManager().getLaunchMode(launchMode));
+			}
+			catch (Exception e)
+			{
+				throw new AssertionError("Unable to select the " + launchMode + " launch mode", e); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+
+		private static String thenCoreBuildConfigurationIsAssigned(String launchMode)
+		{
+			bot.waitUntil(new DefaultCondition()
+			{
+				@Override
+				public boolean test() throws Exception
+				{
+					return activeConfigName().startsWith(CONFIG_NAME_PREFIX + launchMode + '.');
+				}
+
+				@Override
+				public String getFailureMessage()
+				{
+					return "No " + launchMode + " IDF Core Build configuration was assigned to " + PROJECT_NAME; //$NON-NLS-1$ //$NON-NLS-2$
+				}
+			}, 30000, 500);
+
+			return activeConfigName();
+		}
+
+		private static String activeConfigName()
+		{
+			IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+			if (!project.isAccessible())
+			{
+				return IBuildConfiguration.DEFAULT_CONFIG_NAME;
+			}
+
+			try
+			{
+				return project.getActiveBuildConfig().getName();
+			}
+			catch (Exception e)
+			{
+				return IBuildConfiguration.DEFAULT_CONFIG_NAME;
+			}
+		}
+	}
+}

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectFlashProcessTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectFlashProcessTest.java
@@ -19,6 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
@@ -66,6 +67,7 @@ public class NewEspressifIDFProjectFlashProcessTest
 	{
 //		assumeTrue("Linux only", SystemUtils.IS_OS_LINUX);
 
+		Fixture.givenRunLaunchModeIsSelected();
 		Fixture.givenNewEspressifIDFProjectIsSelected("EspressIf", "Espressif IDF Project");
 		Fixture.givenProjectNameIs("NewProjectFlashTest");
 		Fixture.whenNewProjectIsSelected();
@@ -218,6 +220,15 @@ public class NewEspressifIDFProjectFlashProcessTest
 			EnvSetupOperations.setupEspressifEnv(bot);
 			bot.sleep(1000);
 			ProjectTestOperations.deleteAllProjects(bot);
+		}
+
+		/**
+		 * Flashing over UART is a Run mode activity: the Main tab holding the serial options is only contributed to
+		 * the ESP-IDF Application configuration in Run mode, and in Debug mode the OpenOCD tabs take its place.
+		 */
+		private static void givenRunLaunchModeIsSelected()
+		{
+			ProjectTestOperations.selectLaunchMode(ILaunchManager.RUN_MODE, bot);
 		}
 
 		private static void givenNewEspressifIDFProjectIsSelected(String category, String subCategory)

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/EnvSetupOperations.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.ui.PlatformUI;
 
@@ -45,6 +46,21 @@ public class EnvSetupOperations
 		}
 		
 		SWTBotEditor espIdfManagerView = bot.editorByTitle("ESP-IDF Manager");
+		// The manager fills its table from an asynchronous refresh job, so it can still be empty here
+		espIdfManagerView.bot().waitUntil(new DefaultCondition()
+		{
+			@Override
+			public boolean test() throws Exception
+			{
+				return espIdfManagerView.bot().table().rowCount() > 0;
+			}
+
+			@Override
+			public String getFailureMessage()
+			{
+				return "No ESP-IDF installation was listed in the ESP-IDF Manager";
+			}
+		}, 300000, 1000);
 		espIdfManagerView.bot().table().doubleClick(0, 0);
 		
 		SWTBotView consoleView = bot.viewById("org.eclipse.ui.console.ConsoleView");

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -67,6 +67,7 @@ public class ProjectTestOperations
 	 */
 	public static void buildProjectUsingContextMenu(String projectName, SWTWorkbenchBot bot)
 	{
+		TestWidgetWaitUtility.waitForOperationsInProgressToFinishSync(bot);
 		SWTBotTreeItem projectItem = fetchProjectFromProjectExplorer(projectName, bot);
 		if (projectItem != null)
 		{

--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/operations/ProjectTestOperations.java
@@ -17,6 +17,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchMode;
+import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
@@ -37,6 +40,7 @@ import org.eclipse.ui.IPageLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.espressif.idf.core.IDFCorePlugin;
 import com.espressif.idf.ui.test.common.configs.DefaultPropertyFetcher;
 import com.espressif.idf.ui.test.common.utility.TestWidgetWaitUtility;
 import com.espressif.idf.ui.test.common.utility.WaitUtils;
@@ -58,6 +62,37 @@ public class ProjectTestOperations
 	private static final Logger logger = LoggerFactory.getLogger(ProjectTestOperations.class);
 
 	private static final int DELETE_PROJECT_TIMEOUT = 240000;
+
+	/**
+	 * Selects the launch mode in the Launch Bar.
+	 * <p>
+	 * The active mode is workbench state shared by every test class in the run, and the ESP-IDF Application launch
+	 * configuration exposes different tabs per mode. A test that depends on a mode has to select it, and a test that
+	 * changes it has to restore it.
+	 * </p>
+	 *
+	 * @param launchMode launch mode identifier, as defined in {@link org.eclipse.debug.core.ILaunchManager}
+	 * @param bot        current SWT bot reference
+	 */
+	public static void selectLaunchMode(String launchMode, SWTWorkbenchBot bot)
+	{
+		ILaunchMode mode = DebugPlugin.getDefault().getLaunchManager().getLaunchMode(launchMode);
+		if (mode == null)
+		{
+			throw new AssertionError("Unknown launch mode: " + launchMode);
+		}
+
+		try
+		{
+			IDFCorePlugin.getService(ILaunchBarManager.class).setActiveLaunchMode(mode);
+		}
+		catch (CoreException e)
+		{
+			throw new AssertionError("Unable to select the " + launchMode + " launch mode", e);
+		}
+
+		TestWidgetWaitUtility.waitForOperationsInProgressToFinishAsync(bot);
+	}
 
 	/**
 	 * Build a project using the context menu by right clicking on the project


### PR DESCRIPTION
## Description

Run and Debug now share a single launch configuration.

If you are coming from an older Espressif-IDE version that had two configs — one for Run (flash) and one for Debug — you can keep using the old Run config as-is. Select it in the launch bar, switch the mode to Debug, and start debugging. You do not have to open the configuration editor first, and you do not have to click Restore defaults. Any debug settings that were never stored on that Run config are filled in at launch with the plugin defaults.

In the editor, empty debug fields are allowed (they show “keep empty for default”). Each Espressif tab also has a Restore defaults button if you want to write the defaults into the file.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How has this been tested?

- `LaunchAttributesTest` (JUnit)
- Manual: take an old Run config (from before unification), switch the launch bar to Debug, and start a session without opening the editor or clicking Restore defaults
- Manual: open the editor, leave debug fields empty, save, and debug — plugin defaults are used
- Manual: Restore defaults on Main, Debugger, Startup, SVD, and Run Main
- Debug session: breakpoints, step, halt/resume, OpenOCD console
- Heap tracing (start/stop from breakpoint, dump file appears)
- Heap dump analysis
- Application-level tracing
- Flash before debug / skip flash, verbose OpenOCD output
- JTAG flash and serial monitor after flash (Run mode on the same config)

**Test Configuration**:
* ESP-IDF Version: v5.4
* OS (Windows,Linux and macOS): Windows

## Dependent components impacted by this PR:

- `com.espressif.idf.core`
- `com.espressif.idf.debug.gdbjtag.openocd`
- `com.espressif.idf.launch.serial.ui`
- `com.espressif.idf.swt.custom`

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launch configurations now apply appropriate defaults automatically.
  * Added **Restore defaults** controls to relevant launch tabs.
  * Empty fields can use plugin-provided defaults, with clearer guidance.
  * OpenOCD/JTAG debugging receives recommended configuration values.

* **Changes**
  * Improved launch configuration setup for projects and build settings.
  * Simplified run and debug workflows.
  * Updated serial launch behavior and tab associations.
  * Preserved user-specified values when applying defaults.
  * Removed automatic creation of separate default debug configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->