### PR TITLE
IEP-1778 Running activation script could cause eim_idf.json modification

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/SetupToolsInIde.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/SetupToolsInIde.java
@@ -8,9 +8,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,12 +22,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.ui.console.MessageConsoleStream;
 
 import com.espressif.idf.core.IDFConstants;
@@ -78,7 +71,11 @@ public class SetupToolsInIde extends Job
 	public void rollback()
 	{
 		IDFEnvironmentVariables idfEnvironmentVariables = new IDFEnvironmentVariables();
-		
+		if (existingEnvVarsInIdeForRollback == null)
+		{
+			Logger.log("Attempt to rollback failed because existing env vars are null"); //$NON-NLS-1$
+			return;
+		}
 		for (Entry<String, String> entry : existingEnvVarsInIdeForRollback.entrySet())
 		{
 			idfEnvironmentVariables.addEnvVariable(entry.getKey(), entry.getValue());
@@ -98,10 +95,9 @@ public class SetupToolsInIde extends Job
 	{
 		monitor.beginTask("Setting up tools in IDE", 7); //$NON-NLS-1$
 		monitor.worked(1);
-		List<String> arguemnts = new ArrayList<>();
 		Map<String, String> env = new HashMap<>(System.getenv());
 		addGitToEnvironment(env, eimJson.getGitPath());
-		arguemnts = ToolsUtility.getExportScriptCommand(idfInstalled.getActivationScript());
+		List<String> arguemnts = ToolsUtility.getExportScriptCommand(idfInstalled.getActivationScript());
 		final ProcessBuilderFactory processBuilderFactory = new ProcessBuilderFactory();
 		try
 		{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonStateChecker.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonStateChecker.java
@@ -4,7 +4,10 @@
  *******************************************************************************/
 package com.espressif.idf.core.tools.watcher;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Base64;
 
 import org.osgi.service.prefs.Preferences;
 
@@ -12,15 +15,14 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.tools.EimIdfJsonPathResolver;
 
 /**
- * Checks if eim_idf.json was changed while Eclipse was not running. Stores and compares last seen timestamp to file
- * system's last modified.
- * 
- * @author Ali Azam Rana <ali.azamrana@espressif.com>
+ * Checks if eim_idf.json was changed while Eclipse was not running. Stores and compares last seen size and hash to
+ * determine if actual content has changed. * @author Ali Azam Rana <ali.azamrana@espressif.com>
  *
  */
 public class EimJsonStateChecker
 {
-	private static final String LAST_MODIFIED_PREF_KEY = "lastEimJsonModified"; //$NON-NLS-1$
+	private static final String PREF_LAST_SEEN_SIZE = "lastEimJsonSize"; //$NON-NLS-1$
+	private static final String PREF_LAST_SEEN_HASH = "lastEimJsonHash"; //$NON-NLS-1$
 
 	private final Preferences preferences;
 
@@ -31,36 +33,70 @@ public class EimJsonStateChecker
 
 	public boolean wasModifiedSinceLastRun()
 	{
-		File jsonFile = new File(getEimJsonPath());
-		if (!jsonFile.exists())
+		Path jsonPath = new EimIdfJsonPathResolver().resolveEimIdfJsonFile();
+		if (!Files.exists(jsonPath))
 		{
 			return false;
 		}
 
-		long lastModified = jsonFile.lastModified();
-		long lastSeen = preferences.getLong(LAST_MODIFIED_PREF_KEY, 0L);
-
-		if (lastSeen == 0L)
+		try
 		{
-			// First run ever, don't treat as changed
-			Logger.log("eim_idf.json detected, but no last seen timestamp — assuming first run."); //$NON-NLS-1$
+			long lastSeenSize = preferences.getLong(PREF_LAST_SEEN_SIZE, -1L);
+			String lastSeenHash = preferences.get(PREF_LAST_SEEN_HASH, ""); //$NON-NLS-1$
+
+			if (lastSeenSize == -1L || lastSeenHash.isEmpty())
+			{
+				// First run ever, don't treat as changed
+				Logger.log("eim_idf.json detected, but no last seen state — assuming first run."); //$NON-NLS-1$
+				return false;
+			}
+
+			// 1. Fast-fail check: If size is different, it was definitely modified
+			long currentSize = Files.size(jsonPath);
+			if (currentSize != lastSeenSize)
+			{
+				return true;
+			}
+
+			// 2. Deep check: If size is the same, verify the hash
+			String currentHash = computeHashBase64(jsonPath);
+			return !currentHash.equals(lastSeenHash);
+		}
+		catch (Exception e)
+		{
+			Logger.log("Failed to check if eim_idf.json was modified since last run"); //$NON-NLS-1$
+			Logger.log(e);
+			// Default to false on error to prevent unwanted popups/refreshes
 			return false;
 		}
-
-		return lastModified > lastSeen;
 	}
 
-	public void updateLastSeenTimestamp()
+	public void updateLastSeenState()
 	{
-		File jsonFile = new File(getEimJsonPath());
-		if (jsonFile.exists())
+		Path jsonPath = new EimIdfJsonPathResolver().resolveEimIdfJsonFile();
+		if (Files.exists(jsonPath))
 		{
-			preferences.putLong(LAST_MODIFIED_PREF_KEY, jsonFile.lastModified());
+			try
+			{
+				long size = Files.size(jsonPath);
+				String hash = computeHashBase64(jsonPath);
+
+				preferences.putLong(PREF_LAST_SEEN_SIZE, size);
+				preferences.put(PREF_LAST_SEEN_HASH, hash);
+			}
+			catch (Exception e)
+			{
+				Logger.log("Failed to update last seen state for eim_idf.json"); //$NON-NLS-1$
+				Logger.log(e);
+			}
 		}
 	}
 
-	private String getEimJsonPath()
+	private String computeHashBase64(Path filePath) throws Exception
 	{
-		return new EimIdfJsonPathResolver().resolveEimIdfJsonFile().toString();
+		MessageDigest digest = MessageDigest.getInstance("SHA-256"); //$NON-NLS-1$
+		byte[] fileBytes = Files.readAllBytes(filePath);
+		byte[] hash = digest.digest(fileBytes);
+		return Base64.getEncoder().encodeToString(hash);
 	}
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonStateChecker.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonStateChecker.java
@@ -83,6 +83,8 @@ public class EimJsonStateChecker
 
 				preferences.putLong(PREF_LAST_SEEN_SIZE, size);
 				preferences.put(PREF_LAST_SEEN_HASH, hash);
+
+				preferences.flush();
 			}
 			catch (Exception e)
 			{

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
@@ -65,6 +65,21 @@ public class EimJsonWatchService extends Thread
 		watchDirectoryPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
 				StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
 
+		Path fullPath = watchDirectoryPath.resolve(EimConstants.EIM_JSON);
+		if (Files.exists(fullPath))
+		{
+			try
+			{
+				lastFileSize = Files.size(fullPath);
+				lastFileHash = computeHash(fullPath);
+			}
+			catch (Exception e)
+			{
+				Logger.log("Could not establish initial baseline for eim_idf.json watcher"); //$NON-NLS-1$
+				Logger.log(e);
+			}
+		}
+
 		Logger.log("Watcher added to the directory: " + watchDirectoryPath); //$NON-NLS-1$
 		setName("EimJsonWatchService"); //$NON-NLS-1$
 		setDaemon(true);

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
@@ -13,8 +13,8 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -37,7 +37,8 @@ public class EimJsonWatchService extends Thread
 	private final List<EimJsonChangeListener> eimJsonChangeListeners = new CopyOnWriteArrayList<>();
 	private volatile boolean running = true;
 	private volatile boolean paused = false;
-	private volatile Instant lastModifiedTime;
+	private volatile long lastFileSize = -1;
+	private volatile byte[] lastFileHash = null;
 
 	private EimJsonWatchService() throws IOException
 	{
@@ -225,19 +226,34 @@ public class EimJsonWatchService extends Thread
 					Path fullPath = watchDirectoryPath.resolve(path);
 					try
 					{
-						Instant currentModified = Files.getLastModifiedTime(fullPath).toInstant()
-								.truncatedTo(ChronoUnit.SECONDS);
+						long currentSize = Files.size(fullPath);
+						boolean sizeChanged = (lastFileSize != currentSize);
 
-						if (lastModifiedTime != null && currentModified.compareTo(lastModifiedTime) <= 0)
+						boolean contentChanged = false;
+
+						if (sizeChanged)
 						{
-							continue; // skip duplicate or same-second event
+							contentChanged = true;
+							lastFileHash = computeHash(fullPath);
+						}
+						else
+						{
+							byte[] currentHash = computeHash(fullPath);
+							if (lastFileHash == null || !MessageDigest.isEqual(lastFileHash, currentHash))
+							{
+								contentChanged = true;
+								lastFileHash = currentHash;
+							}
 						}
 
-						lastModifiedTime = currentModified;
+						lastFileSize = currentSize;
 
-						for (EimJsonChangeListener listener : eimJsonChangeListeners)
+						if (contentChanged)
 						{
-							listener.onJsonFileChanged(fullPath, paused);
+							for (EimJsonChangeListener listener : eimJsonChangeListeners)
+							{
+								listener.onJsonFileChanged(fullPath, paused);
+							}
 						}
 					}
 					catch (IOException e)
@@ -278,5 +294,19 @@ public class EimJsonWatchService extends Thread
 	{
 		running = false;
 		interrupt();
+	}
+
+	private byte[] computeHash(Path filePath) throws IOException
+	{
+		try
+		{
+			MessageDigest digest = MessageDigest.getInstance("SHA-256"); //$NON-NLS-1$
+			byte[] fileBytes = Files.readAllBytes(filePath);
+			return digest.digest(fileBytes);
+		}
+		catch (NoSuchAlgorithmException e)
+		{
+			throw new RuntimeException("SHA-256 algorithm not available", e); //$NON-NLS-1$
+		}
 	}
 }

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
@@ -39,6 +39,7 @@ public class EimJsonWatchService extends Thread
 	private volatile boolean paused = false;
 	private volatile long lastFileSize = -1;
 	private volatile byte[] lastFileHash = null;
+	private final Object stateLock = new Object();
 
 	private EimJsonWatchService() throws IOException
 	{
@@ -197,14 +198,20 @@ public class EimJsonWatchService extends Thread
 
 	public void pauseListeners()
 	{
-		Logger.log("Listeners are paused"); //$NON-NLS-1$
-		paused = true;
+		synchronized (stateLock)
+		{
+			Logger.log("Listeners are paused"); //$NON-NLS-1$
+			paused = true;
+		}
 	}
 
 	public void unpauseListeners()
 	{
-		Logger.log("Listeners are resumed"); //$NON-NLS-1$
-		paused = false;
+		synchronized (stateLock)
+		{
+			Logger.log("Listeners are resumed"); //$NON-NLS-1$
+			paused = false;
+		}
 	}
 
 	@Override
@@ -267,7 +274,10 @@ public class EimJsonWatchService extends Thread
 						{
 							for (EimJsonChangeListener listener : eimJsonChangeListeners)
 							{
-								listener.onJsonFileChanged(fullPath, paused);
+								synchronized (stateLock)
+								{
+									listener.onJsonFileChanged(fullPath, paused);
+								}
 							}
 						}
 					}

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/tools/watcher/EimJsonWatchService.java
@@ -39,7 +39,6 @@ public class EimJsonWatchService extends Thread
 	private volatile boolean paused = false;
 	private volatile long lastFileSize = -1;
 	private volatile byte[] lastFileHash = null;
-	private final Object stateLock = new Object();
 
 	private EimJsonWatchService() throws IOException
 	{
@@ -198,20 +197,14 @@ public class EimJsonWatchService extends Thread
 
 	public void pauseListeners()
 	{
-		synchronized (stateLock)
-		{
-			Logger.log("Listeners are paused"); //$NON-NLS-1$
-			paused = true;
-		}
+		Logger.log("Listeners are paused"); //$NON-NLS-1$
+		paused = true;
 	}
 
 	public void unpauseListeners()
 	{
-		synchronized (stateLock)
-		{
-			Logger.log("Listeners are resumed"); //$NON-NLS-1$
-			paused = false;
-		}
+		Logger.log("Listeners are resumed"); //$NON-NLS-1$
+		paused = false;
 	}
 
 	@Override
@@ -274,10 +267,7 @@ public class EimJsonWatchService extends Thread
 						{
 							for (EimJsonChangeListener listener : eimJsonChangeListeners)
 							{
-								synchronized (stateLock)
-								{
-									listener.onJsonFileChanged(fullPath, paused);
-								}
+								listener.onJsonFileChanged(fullPath, paused);
 							}
 						}
 					}

--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFTerminalProcessConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFTerminalProcessConnector.java
@@ -52,9 +52,8 @@ public class IDFTerminalProcessConnector extends ProcessConnector {
 			// We delay unpausing the listeners for a generous 20-second buffer to safely bypass 
 			// these file changes while the terminal initializes.
 
-			CompletableFuture.runAsync(() -> {
-				watchService.unpauseListeners();
-			}, CompletableFuture.delayedExecutor(20, TimeUnit.SECONDS));
+			CompletableFuture.runAsync(watchService::unpauseListeners,
+					CompletableFuture.delayedExecutor(20, TimeUnit.SECONDS));
 		}
 	}
 

--- a/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFTerminalProcessConnector.java
+++ b/bundles/com.espressif.idf.terminal.connector/src/com/espressif/idf/terminal/connector/launcher/IDFTerminalProcessConnector.java
@@ -8,8 +8,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.terminal.connector.ITerminalControl;
@@ -18,6 +19,7 @@ import org.eclipse.terminal.connector.process.ProcessConnector;
 import com.espressif.idf.core.IDFEnvironmentVariables;
 import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.tools.EimIdfJsonPathResolver;
+import com.espressif.idf.core.tools.watcher.EimJsonWatchService;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
@@ -30,17 +32,30 @@ public class IDFTerminalProcessConnector extends ProcessConnector {
 
 	@Override
 	public void connect(ITerminalControl control) {
-		super.connect(control);
+		var watchService = EimJsonWatchService.getInstance();
 
-		var process = getProcess();
-		if (process == null) {
-			return;
+		if (watchService != null) {
+			watchService.pauseListeners();
 		}
 
-		getActivationScriptPath().ifPresentOrElse(
-				scriptPath -> sendCommand(process.getOutputStream(), buildActivationCommand(scriptPath)),
-				() -> sendCommand(process.getOutputStream(), "# Error: ESP-IDF activation script is missing.\r\n") //$NON-NLS-1$
-		);
+		super.connect(control);
+		var process = getProcess();
+
+		if (process != null) {
+			getActivationScriptPath().ifPresentOrElse(
+					scriptPath -> sendCommand(process.getOutputStream(), buildActivationCommand(scriptPath)),
+					() -> sendCommand(process.getOutputStream(), "# Error: ESP-IDF activation script is missing.\r\n")); //$NON-NLS-1$
+		}
+
+		if (watchService != null) {
+			// TODO: The activation script unexpectedly modifies eim_idf.json on startup. 
+			// We delay unpausing the listeners for a generous 20-second buffer to safely bypass 
+			// these file changes while the terminal initializes.
+
+			CompletableFuture.runAsync(() -> {
+				watchService.unpauseListeners();
+			}, CompletableFuture.delayedExecutor(20, TimeUnit.SECONDS));
+		}
 	}
 
 	private String buildActivationCommand(String scriptPath) {

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.launchbar.core.ILaunchBarManager;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -23,8 +25,10 @@ import com.espressif.idf.core.logging.Logger;
 import com.espressif.idf.core.resources.OpenDialogListenerSupport;
 import com.espressif.idf.core.resources.PopupDialog;
 import com.espressif.idf.core.resources.ResourceChangeListener;
+import com.espressif.idf.core.tools.watcher.EimJsonStateChecker;
 import com.espressif.idf.ui.dialogs.BuildView;
 import com.espressif.idf.ui.dialogs.MessageLinkDialog;
+import com.espressif.idf.ui.tools.watcher.EimJsonUiChangeHandler;
 
 /**
  * General Startup class for handling 
@@ -138,4 +142,20 @@ public class EspressifGeneralStartup implements IStartup
                             "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html?highlight=partitions%20csv#creating-custom-tables"));
         });
     }
+
+	private void checkEimJsonOfflineChanges()
+	{
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode("com.espressif.idf.core");
+
+		EimJsonStateChecker checker = new EimJsonStateChecker(prefs);
+
+		if (checker.wasModifiedSinceLastRun())
+		{
+			Logger.log("eim_idf.json was modified while Eclipse was offline. Prompting user..."); //$NON-NLS-1$
+
+			EimJsonUiChangeHandler uiHandler = new EimJsonUiChangeHandler(prefs);
+
+			Display.getDefault().asyncExec(uiHandler::displayMessageToUser);
+		}
+	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
@@ -146,7 +146,7 @@ public class EspressifGeneralStartup implements IStartup
 
 	private void checkEimJsonOfflineChanges()
 	{
-		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode("com.espressif.idf.core");
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(UIPlugin.PLUGIN_ID);
 
 		EimJsonStateChecker checker = new EimJsonStateChecker(prefs);
 

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/EspressifGeneralStartup.java
@@ -48,6 +48,7 @@ public class EspressifGeneralStartup implements IStartup
     {
         hookDialogListeners();
         hookLaunchBarListeners();
+		checkEimJsonOfflineChanges();
     }
 
     private void hookDialogListeners()

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EimGuiOrCliLauncher.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/EimGuiOrCliLauncher.java
@@ -40,7 +40,16 @@ public final class EimGuiOrCliLauncher
 			return;
 		}
 
-		if (toolInitializer.isEimGuiCapable(eimPath))
+		boolean isGuiCapable;
+		EimJsonWatchService.getInstance().pauseListeners();
+		try
+		{
+			isGuiCapable = toolInitializer.isEimGuiCapable(eimPath);
+		} finally
+		{
+			EimJsonWatchService.getInstance().unpauseListeners();
+		}
+		if (isGuiCapable)
 		{
 			Logger.log("EIM binary supports GUI mode, launching GUI"); //$NON-NLS-1$
 			LaunchResult launchResult = eimLoader.launchEimWithResult(eimPath, "gui"); //$NON-NLS-1$
@@ -48,8 +57,8 @@ public final class EimGuiOrCliLauncher
 			return;
 		}
 
-		Logger.log("EIM binary does not support GUI mode, launching CLI terminal"); //$NON-NLS-1$
 		EimJsonWatchService.getInstance().pauseListeners();
+		Logger.log("EIM binary does not support GUI mode, launching CLI terminal"); //$NON-NLS-1$
 		display.syncExec(() -> {
 			try
 			{

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/pages/ESPIDFMainTablePage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/manager/pages/ESPIDFMainTablePage.java
@@ -440,6 +440,7 @@ public class ESPIDFMainTablePage
 
 					if (newJson != null && newJson.getIdfInstalled() != null)
 					{
+						eimJson = newJson;
 						var gitPath = newJson.getGitPath();
 
 						monitor.subTask(Messages.ESPIDFMainTablePage_DetectingEspIdfSubTaskName);

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
@@ -51,6 +51,8 @@ public class EimJsonUiChangeHandler implements EimJsonChangeListener
 	@Override
 	public void onJsonFileChanged(Path file, boolean paused)
 	{
+		EimJsonStateChecker checker = new EimJsonStateChecker(preferences);
+		checker.updateLastSeenState();
 		if (paused)
 		{
 			Logger.log("Listener is paused");
@@ -108,9 +110,6 @@ public class EimJsonUiChangeHandler implements EimJsonChangeListener
 				Logger.log(e);
 			}
 		}
-
-		EimJsonStateChecker checker = new EimJsonStateChecker(preferences);
-		checker.updateLastSeenState();
 	}
 
 	private void loadEimJson() throws IOException, EimVersionMismatchException

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
@@ -110,6 +110,10 @@ public class EimJsonUiChangeHandler implements EimJsonChangeListener
 				Logger.log(e);
 			}
 		}
+
+		// TODO: remove duplicate of this call
+		EimJsonStateChecker checker = new EimJsonStateChecker(preferences);
+		checker.updateLastSeenState();
 	}
 
 	private void loadEimJson() throws IOException, EimVersionMismatchException

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/tools/watcher/EimJsonUiChangeHandler.java
@@ -110,7 +110,7 @@ public class EimJsonUiChangeHandler implements EimJsonChangeListener
 		}
 
 		EimJsonStateChecker checker = new EimJsonStateChecker(preferences);
-		checker.updateLastSeenTimestamp();
+		checker.updateLastSeenState();
 	}
 
 	private void loadEimJson() throws IOException, EimVersionMismatchException


### PR DESCRIPTION
## Description

Running the activation script (for example, when opening the ESP-IDF terminal) can cause modifications to eim_idf.json, which triggers a misleading notification in the IDE. To prevent this, in this PR we no longer rely solely on timestamps. Instead, we first check for file size changes and then compare the SHA hashes of the original and modified files.

Fixes # ([IEP-1778](https://jira.espressif.com:8443/browse/IEP-1778))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)



## How has this been tested?

Make sure eim is part of the PATH -> open the IDE -> open the esp-idf terminal in the IDE -> no notification about eim json update

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable change detection using content-based size+hash checks to eliminate false positives and duplicate notifications.
  * Avoids triggering refreshes or prompts on file-read/hash errors by failing safely.

* **New Features**
  * Startup/offline checking detects changes made while the IDE was closed and surfaces a single prompt to handle updates.

* **Improvements**
  * Suppresses change notifications during terminal startup to avoid prompts while activation scripts run.
  * UI now uses the newly scanned configuration after refresh.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/idf-eclipse-plugin/pull/1468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->