### PR TITLE
IEP-1777 EIM CLI Wizard terminal has been added to the Terminal list

### DIFF
--- a/bundles/com.espressif.idf.ui/plugin.xml
+++ b/bundles/com.espressif.idf.ui/plugin.xml
@@ -916,9 +916,10 @@
 	<extension
 		point="org.eclipse.terminal.view.ui.launcherDelegates">
 		<delegate
-			class="com.espressif.idf.ui.tools.eim.terminal.EimCliTerminalLauncherDelegate"
-			id="com.espressif.idf.ui.launcher.eimCliTerminal"
-			label="EIM CLI Wizard">
+        class="com.espressif.idf.ui.tools.eim.terminal.EimCliTerminalLauncherDelegate"
+        hidden="true"
+        id="com.espressif.idf.ui.launcher.eimCliTerminal"
+        label="EIM CLI Wizard">
 		</delegate>
 	</extension>
 </plugin>


### PR DESCRIPTION
## Description

The eim cli wizard is hidden now.

Fixes # ([IEP-1777](https://jira.espressif.com:8443/browse/IEP-1777))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Just verify that EIM CLI wizard not in the terminal selector's list

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * EIM CLI Wizard launcher is now hidden from the user interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/idf-eclipse-plugin/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->