### PR TITLE
WIP: Reduce the size of update site and add repository reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
         name: com.espressif.idf.update-${{ env.VERSION }}
         path: releng/com.espressif.idf.update/target/repository
 
+    - name: Upload offline update site artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: com.espressif.idf.update.offline-${{ env.VERSION }}
+        path: releng/com.espressif.idf.update.offline/target/repository
+
     - name: Upload Windows x86_64 artifact
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -218,12 +218,19 @@ jobs:
            name: espressif-ide-macosx.cocoa.aarch64
            path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg
       
-      - name: Upload build artifacts
+      - name: Upload online update site
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: com.espressif.idf.update
           path: releng/com.espressif.idf.update/target/repository
+      
+      - name: Upload offline update site
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: com.espressif.idf.update.offline
+          path: releng/com.espressif.idf.update.offline/target/repository
               
       - name: Upload windows rcp
         if: ${{ !cancelled() }}
@@ -373,11 +380,17 @@ jobs:
         name: espressif-ide-macosx.cocoa.aarch64
         path: artifacts/macos_arm
 
-    - name: Download update site zip
+    - name: Download online update site zip
       uses: actions/download-artifact@v4
       with:
         name: com.espressif.idf.update
         path: artifacts/update
+
+    - name: Download offline update site
+      uses: actions/download-artifact@v4
+      with:
+        name: com.espressif.idf.update.offline
+        path: artifacts/update_offline
 
     - name: Extract version from tag and prepare folder
       id: get_version
@@ -410,6 +423,7 @@ jobs:
       run: |
         VERSION="${{ env.VERSION }}"
         zip -r "com.espressif.idf.update-v$VERSION.zip" artifacts/update/*
+        zip -r "Espressif-IDE-Offline-Update-v$VERSION.zip" artifacts/update_offline/*
         zip -r "Espressif-IDE-$VERSION-win32.win32.x86_64.zip" artifacts/win32/*
 
     - name: Listing files for upload to verify and debug
@@ -441,6 +455,7 @@ jobs:
         aws s3 cp --acl=public-read ./releng/index.html "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/$UPLOAD_PATH/"
         
         aws s3 cp --acl=public-read "com.espressif.idf.update-v$VERSION.zip" "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/"
+        aws s3 cp --acl=public-read "Espressif-IDE-Offline-Update-v$VERSION.zip" "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/updates/"
         aws s3 cp --acl=public-read --recursive artifacts/linux/ "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/"
         aws s3 cp --acl=public-read --recursive artifacts/linux_arm64/ "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/"
         aws s3 cp --acl=public-read "artifacts/macos_x86/Espressif-IDE-macosx-cocoa-x86_64-v$VERSION.dmg" "s3://${{ secrets.DL_BUCKET }}/dl/idf-eclipse-plugin/ide/"

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -76,42 +76,47 @@ jobs:
             echo "Using certificate chain file"
           fi
           
-          REPO_DIR="releng/com.espressif.idf.update/target/repository"
+          REPO_DIRS=(
+            "releng/com.espressif.idf.update/target/repository"
+            "releng/com.espressif.idf.update.offline/target/repository"
+          )
           SIGFILE="ECLIPSE"
           
-          echo "Signing IDF plugin JARs in $REPO_DIR..."
-          echo "Only signing JARs matching com.espressif.* pattern..."
-          
-          find "$REPO_DIR" -type f -name "*.jar" | while read -r file; do
-            if [[ "$file" =~ (plugins|features)/com\.espressif\. ]]; then
-              echo "Signing IDF plugin/feature JAR: $file"
-              
-              jarsigner \
-                -J-cp -Jjsign-7.4.jar \
-                -J--add-modules -Jjava.sql \
-                -providerClass net.jsign.jca.JsignJcaProvider \
-                -providerArg "${{ secrets.AZURE_KEYVAULT_URI }}" \
-                -keystore NONE \
-                -storetype AZUREKEYVAULT \
-                -storepass "$AZURE_TOKEN" \
-                -sigfile "$SIGFILE" \
-                -digestalg SHA-256 \
-                -tsa http://timestamp.digicert.com \
-                $CERTCHAIN_ARG \
-                -certs \
-                -verbose \
-                "$file" \
-                "${{ secrets.AZURE_KEYVAULT_CERT_NAME }}"
-              
-              if [ $? -eq 0 ]; then
-                echo "Successfully signed: $file"
+          for REPO_DIR in "${REPO_DIRS[@]}"; do
+            echo "Signing IDF plugin JARs in $REPO_DIR..."
+            echo "Only signing JARs matching com.espressif.* pattern..."
+            
+            find "$REPO_DIR" -type f -name "*.jar" | while read -r file; do
+              if [[ "$file" =~ (plugins|features)/com\.espressif\. ]]; then
+                echo "Signing IDF plugin/feature JAR: $file"
+                
+                jarsigner \
+                  -J-cp -Jjsign-7.4.jar \
+                  -J--add-modules -Jjava.sql \
+                  -providerClass net.jsign.jca.JsignJcaProvider \
+                  -providerArg "${{ secrets.AZURE_KEYVAULT_URI }}" \
+                  -keystore NONE \
+                  -storetype AZUREKEYVAULT \
+                  -storepass "$AZURE_TOKEN" \
+                  -sigfile "$SIGFILE" \
+                  -digestalg SHA-256 \
+                  -tsa http://timestamp.digicert.com \
+                  $CERTCHAIN_ARG \
+                  -certs \
+                  -verbose \
+                  "$file" \
+                  "${{ secrets.AZURE_KEYVAULT_CERT_NAME }}"
+                
+                if [ $? -eq 0 ]; then
+                  echo "Successfully signed: $file"
+                else
+                  echo "Failed to sign: $file"
+                  exit 1
+                fi
               else
-                echo "Failed to sign: $file"
-                exit 1
+                echo "Skipping non-IDF JAR: $file"
               fi
-            else
-              echo "Skipping non-IDF JAR: $file"
-            fi
+            done
           done
           
           echo "JAR files signed!"
@@ -119,27 +124,36 @@ jobs:
       - name: Verify JAR signatures
         run: |
           echo "Verifying JAR signatures..."
-          find releng/com.espressif.idf.update/target/repository -type f -name "*.jar" | while read -r file; do
-            echo "Verifying: $file"
-            # Note: Certificate chain warnings are expected if CA is not in Java truststore
-            jarsigner -verify -verbose "$file" || true
+          for REPO_DIR in \
+            releng/com.espressif.idf.update/target/repository \
+            releng/com.espressif.idf.update.offline/target/repository; do
+            find "$REPO_DIR" -type f -name "*.jar" | while read -r file; do
+              echo "Verifying: $file"
+              # Note: Certificate chain warnings are expected if CA is not in Java truststore
+              jarsigner -verify -verbose "$file" || true
+            done
           done
 
       - name: Regenerate P2 metadata after signing
         env:
           MAVEN_OPTS: "-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.maxParameterEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0"
         run: |
-          REPO_DIR="releng/com.espressif.idf.update/target/repository"
-          
-          echo "Updating P2 metadata for signed JARs in $REPO_DIR..."
-          mvn -f releng/com.espressif.idf.update/pom.xml \
-            org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
-            -DrepositoryPath="$REPO_DIR" \
-            -DskipTests=true || \
-          mvn -f releng/com.espressif.idf.update/pom.xml \
-            org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
-            -DskipTests=true
-          
+          update_p2_metadata() {
+            local POM="$1"
+            local REPO_DIR="$2"
+            echo "Updating P2 metadata for signed JARs in $REPO_DIR..."
+            mvn -f "$POM" \
+              org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
+              -DrepositoryPath="$REPO_DIR" \
+              -DskipTests=true || \
+            mvn -f "$POM" \
+              org.eclipse.tycho:tycho-p2-repository-plugin:fix-artifacts-metadata \
+              -DskipTests=true
+          }
+
+          update_p2_metadata releng/com.espressif.idf.update/pom.xml releng/com.espressif.idf.update/target/repository
+          update_p2_metadata releng/com.espressif.idf.update.offline/pom.xml releng/com.espressif.idf.update.offline/target/repository
+
           echo "P2 metadata updated with correct hashes for signed JARs"
 
       - name: Cleanup

--- a/docs/en/marketplaceupdate.rst
+++ b/docs/en/marketplaceupdate.rst
@@ -11,6 +11,11 @@ The Espressif-IDE Eclipse Plugin can be installed using the following three meth
 - :ref:`install_idf_eclipse_plugin_marketplace`
 - :ref:`install_idf_eclipse_plugin_local_archive`
 
+Release builds publish two kinds of update sites:
+
+- **Online update site** — contains the ESP-IDF Eclipse Plugin feature only. Dependencies (Eclipse Platform, Embed CDT, LSP4E, and others) are resolved from referenced Eclipse update sites during installation. An internet connection is required.
+- **Offline update site** — bundles the ESP-IDF Eclipse Plugin and its dependencies for installation without network access. Use this archive in air-gapped or restricted environments.
+
 .. _installUpdateSiteURL:
 
 Installing IDF Plugin Using the Update Site URL
@@ -25,7 +30,11 @@ You can install the IDF Eclipse plugin into an existing Eclipse CDT/Espressif-ID
     * Enter ``Location`` of the repository. (`Stable release <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_)
     * Click ``Add``.
 
-3.  Select all items from the list and proceed with the installation.
+3.  Select ``ESP-IDF Eclipse Plugin`` from the list and proceed with the installation. p2 resolves required dependencies from the Eclipse release train and other referenced update sites.
+
+.. note::
+
+    The online update site requires an internet connection. Dependencies are not bundled in the site itself; they are fetched from Eclipse Platform, Nebula, and SWTChart repositories during installation.
 
 For adding beta and nightly builds, you can use the following update site URLs:
 
@@ -57,15 +66,24 @@ To install the ESP-IDF Eclipse Plugin from the Eclipse Marketplace, follow these
 Installing IDF Eclipse Plugin from Local Archive
 ------------------------------------------------
 
-To install the ESP-IDF Eclipse Plugin from a local archive, follow these steps:
+Download update site archives from `GitHub Releases <https://github.com/espressif/idf-eclipse-plugin/releases>`_ or from `dl.espressif.com <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/>`_.
 
-1. Download the latest update site archive for the IDF Eclipse Plugin from `here <https://github.com/espressif/idf-eclipse-plugin/releases>`_.
-2. In Eclipse, go to ``Help`` > ``Install New Software``.
-3. Click the ``Add`` button.
-4. In the ``Add Repository`` dialog, select ``Archive`` and choose the file ``com.espressif.idf.update-vxxxxxxx.zip``.
-5. Click ``Add``.
-6. Select ``Espressif IDF`` from the list and continue with the installation.
-7. After the installation is complete, restart Eclipse.
+Choose the archive that matches your environment:
+
+Online update site archive (``com.espressif.idf.update-vX.Y.Z.zip``)
+    Same content as the online update site URL. Requires an internet connection to resolve dependencies during installation.
+
+Offline update site archive (``Espressif-IDE-Offline-Update-vX.Y.Z.zip``)
+    Self-contained archive for environments without network access. Includes the ESP-IDF Eclipse Plugin and its bundled dependencies.
+
+To install from either archive:
+
+1. In Eclipse, go to ``Help`` > ``Install New Software``.
+2. Click the ``Add`` button.
+3. In the ``Add Repository`` dialog, select ``Archive`` and choose the downloaded ``.zip`` file.
+4. Click ``Add``.
+5. Select ``ESP-IDF Eclipse Plugin`` from the list and continue with the installation.
+6. After the installation is complete, restart Eclipse.
 
 .. _upgradePlugins:
 
@@ -76,7 +94,7 @@ If you are installing the IDF Eclipse Plugin for the first time, follow these st
 
 1. Go to ``Window`` > ``Preferences`` > ``Install/Update`` > ``Available Software Sites``.
 2. Click ``Add``.
-3. Enter the `URL <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_ of the new repository: .
+3. Enter the `URL <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_ of the new repository.
 4. Click ``Ok``.
 
 If you have already installed the IDF Eclipse Plugin using the update site URL, you can upgrade to the latest version with the following steps:
@@ -118,19 +136,26 @@ This ensures that the installer can update or replace any conflicting components
 Troubleshooting
 ---------------
 
-If you encounter the error ``Cannot complete the install because one or more required items could not be found.`` during installation, it usually means that the Eclipse Platform update site is not enabled.
+If you encounter the error ``Cannot complete the install because one or more required items could not be found.`` during installation, try the following:
 
-To resolve this issue:
+**Online update site URL or online archive (``com.espressif.idf.update-vX.Y.Z.zip``)**
 
-1.  Go to ``Help`` > ``Install New Software``.  
-2.  Click ``Manage``.  
-3.  Make sure the option for the ``Eclipse Platform - Latest Release Update Site`` is enabled.  
+This usually means that a required dependency update site is not enabled or the IDE cannot reach it over the network.
+
+1.  Confirm that the IDE has internet access.
+2.  Go to ``Help`` > ``Install New Software``.
+3.  Click ``Manage``.
+4.  Make sure the option for the ``Eclipse Platform - Latest Release Update Site`` is enabled.
 
     .. image:: ../../media/Resolve_update_error_2.png
 
-4.  Apply the changes and close the dialog.  
-5.  Then go to ``Help`` > ``Check for Updates`` and proceed with updating the IDE and its dependencies.  
+5.  Apply the changes and close the dialog.
+6.  Then go to ``Help`` > ``Check for Updates`` and proceed with updating the IDE and its dependencies.
 
 .. note::
 
-    Enabling the Eclipse Platform update site ensures that all required dependencies are properly resolved during installation or upgrade.
+    Enabling the Eclipse Platform update site ensures that all required dependencies are properly resolved during installation or upgrade from the online update site.
+
+**Offline archive (``Espressif-IDE-Offline-Update-vX.Y.Z.zip``)**
+
+If installation from the offline archive still fails, verify that you downloaded the matching offline archive for your Espressif-IDE or Eclipse version and that the archive was not corrupted during download.

--- a/docs/en/marketplaceupdate.rst
+++ b/docs/en/marketplaceupdate.rst
@@ -156,6 +156,6 @@ This usually means that a required dependency update site is not enabled or the 
 
     Enabling the Eclipse Platform update site ensures that all required dependencies are properly resolved during installation or upgrade from the online update site.
 
-**Offline archive (``Espressif-IDE-Offline-Update-vX.Y.Z.zip``)**
+**Offline archive** (``Espressif-IDE-Offline-Update-vX.Y.Z.zip``)
 
 If installation from the offline archive still fails, verify that you downloaded the matching offline archive for your Espressif-IDE or Eclipse version and that the archive was not corrupted during download.

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -34,7 +34,7 @@
 
 .. note::
 
-    在线更新站点需要互联网连接。依赖项不会包含在站点本身中，而是在安装过程中从 Eclipse Platform、Nebula 和 SWTChart 等仓库获取。
+    使用在线更新站点时需要连接网络。站点本身不包含依赖项，而是在安装过程中从 Eclipse Platform、Nebula 和 SWTChart 等仓库获取。
 
 若要添加测试版和每日构建版插件，可以使用以下的更新站点 URL：
 

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -138,7 +138,7 @@
 
 如果在安装过程中遇到错误提示 ``Cannot complete the install because one or more required items could not be found.``，请尝试以下方法：
 
-**在线更新站点 URL 或在线压缩包（``com.espressif.idf.update-vX.Y.Z.zip``）**
+**在线更新站点 URL 或在线压缩包** （``com.espressif.idf.update-vX.Y.Z.zip``）
 
 通常表示所需的依赖更新站点未启用，或 IDE 无法通过网络访问这些站点。
 

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -27,7 +27,7 @@
 2.  点击 ``Add``，在弹出窗口中：
 
     * 在 ``Name`` 一栏填写 ``Espressif IDF Plugin for Eclipse``。
-    * 在 ``Location`` 一栏，填写插件更新站点的 URL.（`稳定版 <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_）
+    * 在 ``Location`` 一栏，填写插件更新站点的 URL（`稳定版 <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_）。
     * 点击 ``Add``。
 
 3.  在列表中选择 ``ESP-IDF Eclipse Plugin``，然后继续安装。p2 会从 Eclipse 发布版本及其他引用的更新站点解析所需依赖项。

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -11,6 +11,11 @@
 - :ref:`install_idf_eclipse_plugin_marketplace`
 - :ref:`install_idf_eclipse_plugin_local_archive`
 
+正式发布版本提供两种更新站点：
+
+- **在线更新站点** — 仅包含 ESP-IDF Eclipse 插件特性（feature）。安装时，p2 会从引用的 Eclipse 更新站点解析依赖项（Eclipse Platform、Embed CDT、LSP4E 等）。需要互联网连接。
+- **离线更新站点** — 将 ESP-IDF Eclipse 插件及其依赖项一并打包，可在无网络环境中安装。适用于隔离网络或受限环境。
+
 .. _installUpdateSiteURL:
 
 使用更新站点 URL 安装 IDF 插件
@@ -25,7 +30,11 @@
     * 在 ``Location`` 一栏，填写插件更新站点的 URL.（`稳定版 <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/>`_）
     * 点击 ``Add``。
 
-3.  全选列表中的组件并继续安装。
+3.  在列表中选择 ``ESP-IDF Eclipse Plugin``，然后继续安装。p2 会从 Eclipse 发布版本及其他引用的更新站点解析所需依赖项。
+
+.. note::
+
+    在线更新站点需要互联网连接。依赖项不会包含在站点本身中，而是在安装过程中从 Eclipse Platform、Nebula 和 SWTChart 等仓库获取。
 
 若要添加测试版和每日构建版插件，可以使用以下的更新站点 URL：
 
@@ -57,15 +66,24 @@
 通过本地压缩包安装 IDF Eclipse 插件
 -----------------------------------
 
-要通过本地压缩包安装 ESP-IDF Eclipse 插件，请按以下步骤操作：
+从 `GitHub Releases <https://github.com/espressif/idf-eclipse-plugin/releases>`_ 或 `dl.espressif.com <https://dl.espressif.com/dl/idf-eclipse-plugin/updates/>`_ 下载更新站点压缩包。
 
-1. 点击 `此处 <https://github.com/espressif/idf-eclipse-plugin/releases>`_ 下载 IDF Eclipse 插件的最新更新站点压缩包。
-2. 在 Eclipse 中，进入 ``Help`` > ``Install New Software``。
-3. 点击 ``Add`` 按钮。
-4. 在 ``Add Repository`` 对话框中，选择 ``Archive`` 并选择文件 ``com.espressif.idf.update-vxxxxxxx.zip``。
-5. 点击 ``Add``。
-6. 在列表中选择 ``Espressif IDF``，然后继续安装。
-7. 完成安装后重启 Eclipse。
+根据使用环境选择合适的压缩包：
+
+在线更新站点压缩包（``com.espressif.idf.update-vX.Y.Z.zip``）
+    与在线更新站点 URL 内容相同。安装时需要互联网连接以解析依赖项。
+
+离线更新站点压缩包（``Espressif-IDE-Offline-Update-vX.Y.Z.zip``）
+    自包含压缩包，适用于无网络环境。包含 ESP-IDF Eclipse 插件及其打包的依赖项。
+
+通过任一压缩包安装的步骤：
+
+1. 在 Eclipse 中，进入 ``Help`` > ``Install New Software``。
+2. 点击 ``Add`` 按钮。
+3. 在 ``Add Repository`` 对话框中，选择 ``Archive`` 并选择已下载的 ``.zip`` 文件。
+4. 点击 ``Add``。
+5. 在列表中选择 ``ESP-IDF Eclipse Plugin``，然后继续安装。
+6. 完成安装后重启 Eclipse。
 
 .. _upgradePlugins:
 
@@ -118,19 +136,26 @@
 故障排查
 --------
 
-如果在安装过程中遇到错误提示 ``Cannot complete the install because one or more required items could not be found.``，通常是因为未启用 Eclipse 更新站点。
+如果在安装过程中遇到错误提示 ``Cannot complete the install because one or more required items could not be found.``，请尝试以下方法：
 
-解决方法：
+**在线更新站点 URL 或在线压缩包（``com.espressif.idf.update-vX.Y.Z.zip``）**
 
-1.  进入 ``Help`` > ``Install New Software``。  
-2.  点击 ``Manage``。  
-3.  确保已启用 ``Eclipse Platform - Latest Release Update Site`` 选项。
+通常表示所需的依赖更新站点未启用，或 IDE 无法通过网络访问这些站点。
+
+1.  确认 IDE 可以访问互联网。
+2.  进入 ``Help`` > ``Install New Software``。
+3.  点击 ``Manage``。
+4.  确保已启用 ``Eclipse Platform - Latest Release Update Site`` 选项。
 
     .. image:: ../../media/Resolve_update_error_2.png
 
-4.  应用更改并关闭对话框。
-5.  前往 ``Help`` > ``Check for Updates``，继续更新 IDE 及其依赖项。  
+5.  应用更改并关闭对话框。
+6.  前往 ``Help`` > ``Check for Updates``，继续更新 IDE 及其依赖项。
 
 .. note::
 
-    启用 Eclipse Platform 更新站点可确保在安装或升级过程中解析所有必要的依赖项。
+    启用 Eclipse Platform 更新站点可确保从在线更新站点安装或升级时正确解析所有必要的依赖项。
+
+**离线压缩包（``Espressif-IDE-Offline-Update-vX.Y.Z.zip``）**
+
+若从离线压缩包安装仍然失败，请确认已下载与 Espressif-IDE 或 Eclipse 版本匹配的离线压缩包，且下载过程中文件未损坏。

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -13,7 +13,7 @@
 
 正式发布版本提供两种更新站点：
 
-- **在线更新站点** — 仅包含 ESP-IDF Eclipse 插件特性（feature）。安装时，p2 会从引用的 Eclipse 更新站点解析依赖项（Eclipse Platform、Embed CDT、LSP4E 等）。需要互联网连接。
+- **在线更新站点** — 仅包含 ESP-IDF Eclipse 插件的 feature 包。所需依赖项（Eclipse Platform、Embed CDT、LSP4E 等）将从引用的 Eclipse 更新站点解析。需要互联网连接。
 - **离线更新站点** — 将 ESP-IDF Eclipse 插件及其依赖项一并打包，可在无网络环境中安装。适用于隔离网络或受限环境。
 
 .. _installUpdateSiteURL:

--- a/docs/zh_CN/marketplaceupdate.rst
+++ b/docs/zh_CN/marketplaceupdate.rst
@@ -14,7 +14,7 @@
 正式发布版本提供两种更新站点：
 
 - **在线更新站点** — 仅包含 ESP-IDF Eclipse 插件的 feature 包。所需依赖项（Eclipse Platform、Embed CDT、LSP4E 等）将从引用的 Eclipse 更新站点解析。需要互联网连接。
-- **离线更新站点** — 将 ESP-IDF Eclipse 插件及其依赖项一并打包，可在无网络环境中安装。适用于隔离网络或受限环境。
+- **离线更新站点** — 将 ESP-IDF Eclipse 插件及其依赖项一并打包，可在无网络环境中安装。适用于物理断网或网络受限的环境。
 
 .. _installUpdateSiteURL:
 

--- a/features/com.espressif.idf.feature/feature.xml
+++ b/features/com.espressif.idf.feature/feature.xml
@@ -103,6 +103,16 @@ You may add additional accurate notices of copyright ownership.
 
    <requires>
       <import plugin="org.eclipse.cdt"/>
+      <import feature="org.eclipse.tm4e.feature"/>
+      <import feature="org.eclipse.tm4e.language_pack.feature"/>
+      <import feature="org.eclipse.swtchart.feature"/>
+      <import plugin="org.eclipse.lsp4e"/>
+      <import feature="org.eclipse.cdt.lsp.feature" version="3.5.0.202603041744"/>
+      <import feature="org.eclipse.embedcdt" version="6.4.0.202307251916"/>
+      <import feature="org.eclipse.embedcdt.debug.gdbjtag" version="6.4.0.202307251916"/>
+      <import feature="org.eclipse.launchbar" version="12.4.0.202512101642"/>
+      <import feature="org.eclipse.nebula.widgets.xviewer.feature" version="1.1.0.202601240135"/>
+      <import feature="org.eclipse.terminal.feature" version="1.0.200.v20260226-0920"/>
    </requires>
 
    <plugin

--- a/features/com.espressif.idf.feature/p2.inf
+++ b/features/com.espressif.idf.feature/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2025-12/);\
-  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2025-12/);

--- a/features/com.espressif.idf.feature/p2.inf
+++ b/features/com.espressif.idf.feature/p2.inf
@@ -1,0 +1,3 @@
+instructions.configure=\
+  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2025-12/);\
+  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2025-12/);

--- a/releng/com.espressif.idf.update.offline/.gitignore
+++ b/releng/com.espressif.idf.update.offline/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/bin/

--- a/releng/com.espressif.idf.update.offline/.project
+++ b/releng/com.espressif.idf.update.offline/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.espressif.idf.update.offline</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1727074774359</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/releng/com.espressif.idf.update.offline/.settings/org.eclipse.core.resources.prefs
+++ b/releng/com.espressif.idf.update.offline/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/com.espressif.idf.update.offline/.settings/org.eclipse.m2e.core.prefs
+++ b/releng/com.espressif.idf.update.offline/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/releng/com.espressif.idf.update.offline/category.xml
+++ b/releng/com.espressif.idf.update.offline/category.xml
@@ -3,6 +3,9 @@
    <feature id="com.espressif.idf.feature">
       <category name="com.espressif.idf"/>
    </feature>
+   <feature id="com.cthing.cmakeed.feature">
+      <category name="com.espressif.idf"/>
+   </feature>
    
    <feature id="org.eclipse.rcp">
       <category name="com.espressif.idf.platform"/>

--- a/releng/com.espressif.idf.update.offline/category.xml
+++ b/releng/com.espressif.idf.update.offline/category.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature id="com.espressif.idf.feature">
+      <category name="com.espressif.idf"/>
+   </feature>
+   
+   <feature id="org.eclipse.rcp">
+      <category name="com.espressif.idf.platform"/>
+   </feature>
+   <feature id="org.eclipse.platform">
+      <category name="com.espressif.idf.platform"/>
+   </feature>
+   <feature id="org.eclipse.equinox.p2.user.ui">
+      <category name="com.espressif.idf.platform"/>
+   </feature>
+
+   <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin"/>
+   <category-def name="com.espressif.idf.platform" label="Eclipse Platform Core Updates"/>
+</site>

--- a/releng/com.espressif.idf.update.offline/pom.xml
+++ b/releng/com.espressif.idf.update.offline/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.espressif.idf</groupId>
+        <artifactId>com.espressif.idf.releng</artifactId>
+        <version>1.0.0-SNAPSHOT</version> </parent>
+
+    <artifactId>com.espressif.idf.update.offline</artifactId>
+    <version>${espressif-ide-release-version}-SNAPSHOT</version>
+    <packaging>eclipse-repository</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-repository-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <includeAllDependencies>true</includeAllDependencies>
+                    
+                    <createZipFile>true</createZipFile>
+                    <finalName>Espressif-IDE-Offline-Update-${project.version}</finalName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/releng/com.espressif.idf.update.offline/pom.xml
+++ b/releng/com.espressif.idf.update.offline/pom.xml
@@ -1,30 +1,29 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>com.espressif.idf.update.offline</artifactId>
+	<version>${espressif-ide-release-version}-SNAPSHOT</version>
+	<packaging>eclipse-repository</packaging>
 
-    <parent>
-        <groupId>com.espressif.idf</groupId>
-        <artifactId>com.espressif.idf.releng</artifactId>
-        <version>1.0.0-SNAPSHOT</version> </parent>
+	<parent>
+		<groupId>com.espressif.idf</groupId>
+		<artifactId>com.espressif.idf.releng</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>com.espressif.idf.update.offline</artifactId>
-    <version>${espressif-ide-release-version}-SNAPSHOT</version>
-    <packaging>eclipse-repository</packaging>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.tycho</groupId>
-                <artifactId>tycho-p2-repository-plugin</artifactId>
-                <version>${tycho-version}</version>
-                <configuration>
-                    <includeAllDependencies>true</includeAllDependencies>
-                    
-                    <createZipFile>true</createZipFile>
-                    <finalName>Espressif-IDE-Offline-Update-${project.version}</finalName>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<includeAllDependencies>true</includeAllDependencies>
+					<createZipFile>true</createZipFile>
+					<finalName>Espressif-IDE-Offline-Update-${project.version}</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -3,100 +3,13 @@
    <feature id="com.espressif.idf.feature">
       <category name="com.espressif.idf"/>
    </feature>
-   <feature id="com.cthing.cmakeed.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.nebula.widgets.xviewer.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.embedcdt">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.embedcdt.debug.gdbjtag">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.cdt.lsp.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.epp.mpc">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.tm4e.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.swtchart.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.tm4e.language_pack.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.terminal.feature">
-      <category name="com.espressif.idf.dependencies"/>
-   </feature>
-   <feature id="org.eclipse.launchbar">
-      <category name="com.espressif.idf.dependencies"/>
-   </feature>
-   <bundle id="org.eclipse.embedcdt.templates.core">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.embedcdt.packs.core">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4e">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.jcodings">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.joni">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.yaml.snakeyaml">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.gson">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.guava">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.guava.failureaccess">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4j">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4j.jsonrpc">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.apache.httpcomponents.httpclient">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.freemarker.freemarker">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.snakeyaml.engine">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.i18n">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.css">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.constants">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.util">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.commonmark">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
+   
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
-      <description>
-         ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications
-      </description>
+      <description>ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications</description>
    </category-def>
+   
    <category-def name="com.espressif.idf.dependencies" label="ESP-IDF Eclipse Plugin - Dependencies"/>
+
+   <repository-reference location="https://download.eclipse.org/releases/2026-03/" enabled="true" />
+
 </site>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -11,5 +11,7 @@
    <category-def name="com.espressif.idf.dependencies" label="ESP-IDF Eclipse Plugin - Dependencies"/>
 
    <repository-reference location="https://download.eclipse.org/releases/2026-03/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/swtchart/releases/1.0.0/repository/" enabled="true" />
+   <repository-reference location="http://download.eclipse.org/nebula/releases/latest" enabled="true" />
 
 </site>

--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -7,11 +7,9 @@
    <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
       <description>ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications</description>
    </category-def>
-   
-   <category-def name="com.espressif.idf.dependencies" label="ESP-IDF Eclipse Plugin - Dependencies"/>
 
    <repository-reference location="https://download.eclipse.org/releases/2026-03/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/swtchart/releases/1.0.0/repository/" enabled="true" />
-   <repository-reference location="http://download.eclipse.org/nebula/releases/latest" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/nebula/releases/latest" enabled="true" />
 
 </site>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -1,23 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.espressif.idf</groupId>
-	<artifactId>com.espressif.idf.releng</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
-
-	<parent>
-		<groupId>com.espressif.idf</groupId>
-		<artifactId>com.espressif.idf.root</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
-
-	<modules>
-		<module>com.espressif.idf.update</module>
-		<module>com.espressif.idf.target</module>
-		<module>com.espressif.idf.product</module>
-	</modules>
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.espressif.idf</groupId>
+  <artifactId>com.espressif.idf.releng</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <parent>
+    <groupId>com.espressif.idf</groupId>
+    <artifactId>com.espressif.idf.root</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <modules>
+    <module>com.espressif.idf.update</module>
+    <module>com.espressif.idf.target</module>
+    <module>com.espressif.idf.product</module>
+    <module>com.espressif.idf.update.offline</module>
+    <module>com.espressif.idf.update.offline1</module>
+  </modules>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -14,6 +14,5 @@
     <module>com.espressif.idf.target</module>
     <module>com.espressif.idf.product</module>
     <module>com.espressif.idf.update.offline</module>
-    <module>com.espressif.idf.update.offline1</module>
   </modules>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -1,18 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.espressif.idf</groupId>
-  <artifactId>com.espressif.idf.releng</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <parent>
-    <groupId>com.espressif.idf</groupId>
-    <artifactId>com.espressif.idf.root</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-  </parent>
-  <modules>
-    <module>com.espressif.idf.update</module>
-    <module>com.espressif.idf.target</module>
-    <module>com.espressif.idf.product</module>
-    <module>com.espressif.idf.update.offline</module>
-  </modules>
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.espressif.idf</groupId>
+	<artifactId>com.espressif.idf.releng</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>com.espressif.idf</groupId>
+		<artifactId>com.espressif.idf.root</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<modules>
+		<module>com.espressif.idf.update</module>
+		<module>com.espressif.idf.target</module>
+		<module>com.espressif.idf.product</module>
+		<module>com.espressif.idf.update.offline</module>
+	</modules>
 </project>


### PR DESCRIPTION
## Description

Split the monolithic p2 update site into separate **online** and **offline** repositories:

- **Online update site** (`com.espressif.idf.update`) — publishes only `com.espressif.idf.feature`. Dependencies are resolved at install time via `repository-reference` entries (Eclipse SimRel 2026-03, SWTChart, Nebula). Matches the existing update site URL and `com.espressif.idf.update-v*.zip` archive.
- **Offline update site** (`com.espressif.idf.update.offline`) — new Tycho module with `includeAllDependencies=true`, bundling the Espressif feature, platform features, CMakeEd, and transitive dependencies for air-gapped installs. Published as `Espressif-IDE-Offline-Update-v*.zip`.

Other changes:
- Move dependency declarations from `category.xml` into `feature.xml` `<requires>`.
- Extend CI/release workflows to build, sign, and publish both update sites.
- Update English and Chinese update-site installation docs.
- Polish: HTTPS Nebula URL, remove unused dependency category, restore `releng/pom.xml` formatting.

Fixes # ([IEP-1786](https://jira.espressif.com:8443/browse/IEP-1786))

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

> **Note:** `com.espressif.idf.update-v*.zip` is now the **online/slim** archive and requires network access during install. Users who previously relied on that zip for offline installs should use `Espressif-IDE-Offline-Update-v*.zip` instead.

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Online install from update site URL (`https://dl.espressif.com/dl/idf-eclipse-plugin/updates/latest/`) into Eclipse CDT 2026-03 with network enabled
- [ ] Online install from `com.espressif.idf.update-v*.zip` archive with network enabled
- [ ] Offline install from `Espressif-IDE-Offline-Update-v*.zip` with network disabled
- [ ] Release workflow: Espressif JARs signed in both online and offline repositories; p2 metadata regenerated

**Test Configuration**:
* ESP-IDF Version: 5.4 (CI default)
* OS (Windows, Linux and macOS): _To be verified_

## Dependent components impacted by this PR:

- p2 update site publishing (`releng/com.espressif.idf.update`, `releng/com.espressif.idf.update.offline`)
- GitHub Actions CI (`ci.yml`, `ci_release.yml`) — artifact upload, signing, S3 release
- Feature metadata (`features/com.espressif.idf.feature/feature.xml`)
- User documentation (`docs/en/marketplaceupdate.rst`, `docs/zh_CN/marketplaceupdate.rst`)
- Release downloads on `dl.espressif.com` — new offline zip artifact

## Checklist

- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows, Linux and macOS

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline update package so installers can be downloaded and applied without online access.

* **Chores**
  * Split online/offline update artifacts in CI and added packaging/upload for the offline update.
  * Broadened Eclipse tooling support (language packs, LSP/editor integrations, charting, terminal) to improve development workflows.
  * Consolidated and simplified update-site/category definitions and project metadata for packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->