### PR TITLE
ci: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         maven-version: 3.9.6
    
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: [self-hosted, eclipse, BrnoUBU0004]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -67,10 +67,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -87,28 +87,28 @@ jobs:
   
     - name: Upload build artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: com.espressif.idf.update-${{ env.VERSION }}
         path: releng/com.espressif.idf.update/target/repository
 
     - name: Upload Windows x86_64 artifact
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Espressif-IDE-${{ env.VERSION }}-win32
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-${{ env.VERSION }}-win32.win32.x86_64.zip
   
     - name: Upload Linux x86_64 artifact
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Espressif-IDE-${{ env.VERSION }}-linux.gtk.x86_64
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-${{ env.VERSION }}-linux.gtk.x86_64.tar.gz
   
     - name: Upload Linux ARM64 artifact
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Espressif-IDE-${{ env.VERSION }}-linux.gtk.aarch64
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-${{ env.VERSION }}-linux.gtk.aarch64.tar.gz
@@ -138,14 +138,14 @@ jobs:
 
     - name: Upload espressif-ide-macosx.cocoa.x86_64 dmg
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Espressif-IDE-${{ env.VERSION }}-macosx.cocoa.x86_64
         path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
 
     - name: Upload espressif-ide-macosx.cocoa.aarch64 dmg
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Espressif-IDE-${{ env.VERSION }}-macosx.cocoa.aarch64
         path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -20,10 +20,10 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -206,42 +206,42 @@ jobs:
         
       - name: Upload Espressif-IDE-macosx-cocoa-x86_64.dmg
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: espressif-ide-macosx-cocoa-x86_64
           path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
       
       - name: Upload Espressif-IDE-macosx-cocoa-aarch64.dmg
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
            name: espressif-ide-macosx.cocoa.aarch64
            path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg
       
       - name: Upload build artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: com.espressif.idf.update
           path: releng/com.espressif.idf.update/target/repository
               
       - name: Upload windows rcp
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: espressif-ide-win32
           path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip
       
       - name: Upload linux rcp
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: espressif-ide-linux
           path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz
       
       - name: Upload linux arm64 rcp
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: espressif-ide-linux-arm64
           path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.aarch64.tar.gz
@@ -253,10 +253,10 @@ jobs:
     env:
       ARTIFACTS_PATH: extracted/Espressif-IDE
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Download built artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: espressif-ide-win32
           path: artifacts
@@ -326,7 +326,7 @@ jobs:
 
       - name: Upload Signed Windows ZIP
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: espressif-ide-win32
           path: extracted/
@@ -341,40 +341,40 @@ jobs:
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
    steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Download built windows artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: espressif-ide-win32
         path: artifacts/win32
 
     - name: Download built linux artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: espressif-ide-linux
         path: artifacts/linux
 
     - name: Download built linux arm64 artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: espressif-ide-linux-arm64
         path: artifacts/linux_arm64
 
     - name: Download macOS x86_64 dmg
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: espressif-ide-macosx-cocoa-x86_64
         path: artifacts/macos_x86
 
     - name: Download macOS aarch64 dmg
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: espressif-ide-macosx.cocoa.aarch64
         path: artifacts/macos_arm
 
     - name: Download update site zip
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: com.espressif.idf.update
         path: artifacts/update

--- a/.github/workflows/ci_uploads.yml
+++ b/.github/workflows/ci_uploads.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upload file to S3
         env:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -25,10 +25,10 @@ jobs:
       - BrnoWIN0007
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Clone IDF Release From Github
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: espressif/esp-idf
         path: dependencies/idf-tools
@@ -36,7 +36,7 @@ jobs:
         ref: release/v5.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
           python-version: '3.11'
 

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -46,7 +46,7 @@ jobs:
         maven-version: 3.9.6
    
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -36,7 +36,7 @@ jobs:
         ref: release/v5.1
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
           python-version: '3.11'
 

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -26,7 +26,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: actions/setup-python@v5
@@ -44,7 +44,7 @@ jobs:
         PATH=/home/runner/.local/bin:$PATH pip3 install -r requirements.txt --prefer-binary
         PATH=/home/runner/.local/bin:$PATH SPHINXOPTS="-W" build-docs
     - name: Archive Docs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs
         path: docs

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         cache-dependency-path: docs/requirements.txt
         cache: 'pip'

--- a/.github/workflows/docs_production.yml
+++ b/.github/workflows/docs_production.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         cache-dependency-path: docs/requirements.txt
         cache: 'pip'

--- a/.github/workflows/docs_production.yml
+++ b/.github/workflows/docs_production.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: actions/setup-python@v5

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -12,7 +12,7 @@ jobs:
     name: Sync Issue Comments to Jira
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: Sync issue comments to JIRA
         uses: espressif/github-actions/sync_issues_to_jira@master
         env:

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sync issues to Jira
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: Sync GitHub issues to Jira project
         uses: espressif/github-actions/sync_issues_to_jira@master
         env:

--- a/.github/workflows/new_prs.yml
+++ b/.github/workflows/new_prs.yml
@@ -15,7 +15,7 @@ jobs:
     name: Sync PRs to Jira
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: Sync PRs to Jira project
         uses: espressif/github-actions/sync_issues_to_jira@master
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -168,35 +168,35 @@ jobs:
 
     - name: Upload Espressif-IDE-macosx-cocoa-x86_64.dmg
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: espressif-ide-macosx-cocoa-x86_64
         path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-x86_64.dmg
 
     - name: Upload Espressif-IDE-macosx-cocoa-aarch64.dmg
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: espressif-ide-macosx.cocoa.aarch64
         path: releng/ide-dmg-builder/Espressif-IDE-macosx-cocoa-aarch64.dmg
 
     - name: Upload build artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: com.espressif.idf.update
         path: releng/com.espressif.idf.update/target/repository
         
     - name: Upload windows rcp
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: espressif-ide-win32
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-win32.win32.x86_64.zip
 
     - name: Upload linux rcp
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: espressif-ide-linux
         path: releng/com.espressif.idf.product/target/products/Espressif-IDE-*-linux.gtk.x86_64.tar.gz

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9  
 

--- a/.github/workflows/update-site-test.yml
+++ b/.github/workflows/update-site-test.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Print trigger info
         run: |
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload Update Site Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eclipse-update-site-test-results
           path: releng/update-site-tests/out


### PR DESCRIPTION
## Description

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Bump official actions ahead of the Node 20 deprecation on GitHub runners (June 16, 2026)

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and automation workflows to use newer GitHub Action releases (checkout, setup-python, setup-java, github-script) and modernized artifact handling (upload/download) across builds, releases, docs, and auxiliary pipelines.
  * Consistent action version pinning and minor workflow formatting tweaks; no functional changes to build, deploy, upload, or job logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->