### PR TITLE
test: stabilize sdkconfig partition offset UI test on Linux

### DIFF
--- a/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSDKconfigTest.java
+++ b/tests/com.espressif.idf.ui.test/src/com/espressif/idf/ui/test/executable/cases/project/NewEspressifIDFProjectSDKconfigTest.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package com.espressif.idf.ui.test.executable.cases.project;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -11,6 +12,8 @@ import java.io.IOException;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -159,27 +162,73 @@ public class NewEspressifIDFProjectSDKconfigTest
 			TestWidgetWaitUtility.waitForCTabToAppear(bot, "SDK Configuration (sdkconfig)", 10000);
 		}
 
-		private static void thenSDKconfigFileContentChecked() throws Exception
+		private static void openPartitionTableSettings() throws Exception
 		{
 			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
 			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
 			bot.tree(1).getTreeItem("Partition Table").click();
 			bot.sleep(1000);
-			assertTrue("'Offset of partition table (hex)' does not match '0x8000'",
-					bot.textWithLabel("Offset of partition table (hex)").getText().matches("0x8000"));
+		}
+
+		private static void setPartitionTableOffset(String hexValue)
+		{
+			SWTBotText offsetField = bot.textWithLabel("Offset of partition table (hex)");
+			offsetField.setFocus();
+			offsetField.selectAll();
+			offsetField.setText(hexValue);
+			bot.sleep(500);
+
+			if (!offsetField.getText().equalsIgnoreCase(hexValue))
+			{
+				offsetField.setFocus();
+				offsetField.selectAll();
+				offsetField.typeText(hexValue);
+				bot.sleep(500);
+			}
+		}
+
+		private static void waitForPartitionTableOffset(String hexValue) throws Exception
+		{
+			bot.waitUntil(new DefaultCondition()
+			{
+				@Override
+				public boolean test() throws Exception
+				{
+					return bot.textWithLabel("Offset of partition table (hex)").getText()
+							.equalsIgnoreCase(hexValue);
+				}
+
+				@Override
+				public String getFailureMessage()
+				{
+					return "Partition table offset did not become " + hexValue;
+				}
+			}, 15000, 500);
+		}
+
+		private static void assertPartitionTableOffset(String expectedHexValue)
+		{
+			String actual = bot.textWithLabel("Offset of partition table (hex)").getText();
+			assertEquals("'Offset of partition table (hex)' does not match '" + expectedHexValue + "'",
+					expectedHexValue.toLowerCase(), actual.toLowerCase());
+		}
+
+		private static void thenSDKconfigFileContentChecked() throws Exception
+		{
+			openPartitionTableSettings();
+			waitForPartitionTableOffset("0x8000");
+			assertPartitionTableOffset("0x8000");
 		}
 
 		private static void thenSDKconfigFileContentEdited() throws Exception
 		{
-			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
-			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
-			bot.tree(1).getTreeItem("Partition Table").click();
-			bot.sleep(1000);
-			bot.textWithLabel("Offset of partition table (hex)").setText("0x4000");
-			bot.sleep(1000);
+			openPartitionTableSettings();
+			setPartitionTableOffset("0x4000");
+			waitForPartitionTableOffset("0x4000");
 			bot.comboBoxWithLabel("Partition Table").setSelection("Custom partition table CSV");
 			bot.sleep(1000);
 			bot.checkBox("Generate an MD5 checksum for the partition table").click();
+			bot.sleep(500);
 		}
 
 		private static void thenSDKconfigShellClosed() throws IOException
@@ -193,16 +242,15 @@ public class NewEspressifIDFProjectSDKconfigTest
 			bot.cTabItem("*SDK Configuration (sdkconfig)").close();
 			TestWidgetWaitUtility.waitForDialogToAppear(bot, "Save Resource", 10000);
 			bot.shell("Save Resource").bot().button("Save").click();
+			TestWidgetWaitUtility.waitForOperationsInProgressToFinishSync(bot);
+			bot.sleep(1000);
 		}
 
 		private static void thenCheckChangesAreSaved() throws Exception
 		{
-			bot.cTabItem("SDK Configuration (sdkconfig)").activate();
-			TestWidgetWaitUtility.waitForTreeItem("Partition Table", bot.tree(1), bot);
-			bot.tree(1).getTreeItem("Partition Table").click();
-			bot.sleep(1000);
-			assertTrue("'Offset of partition table (hex)' does not match '0x4000'",
-					bot.textWithLabel("Offset of partition table (hex)").getText().matches("0x4000"));
+			openPartitionTableSettings();
+			waitForPartitionTableOffset("0x4000");
+			assertPartitionTableOffset("0x4000");
 			bot.sleep(1000);
 			assertTrue("'Partition Table' does not match 'Custom partition table CSV'",
 					bot.comboBoxWithLabel("Partition Table").selection().equals("Custom partition table CSV"));


### PR DESCRIPTION
Wait for sdkconfig save to complete and use reliable hex field input so partition table offset changes persist on the self-hosted Linux runner.

## Description

**What the test does**
NewEspressifIDFProjectSDKconfigTest ([failure at line 61](https://github.com/espressif/idf-eclipse-plugin/actions/runs/27190770202/job/80270182500?pr=1476) → thenCheckChangesAreSaved()):

- Creates a project and builds it
- Opens sdkconfig, changes partition table offset 0x8000 → 0x4000, saves
- Rebuilds
- Reopens sdkconfig and expects offset 0x4000
- The failure means after save + reopen, the UI still shows the default 0x8000 (or another value), not 0x4000.


**Root cause (Linux GTK timing)**
On Linux/GTK, SWTBot setText() on sdkconfig hex fields can be unreliable:

- The modify listener that records changes in modifiedJsonMap may not fire consistently
- Save can complete before the config server writes to sdkconfig
- The test had no wait after clicking Save
- Hex edits only update modifiedJsonMap locally until save; if the GTK event is missed, nothing is persisted.

This matches recent GTK sdkconfig editor layout fixes (f0c77e00, 8ff7e415) on the Eclipse 2026-03 platform used in CI.

Updated NewEspressifIDFProjectSDKconfigTest.java to be more reliable on Linux:

setPartitionTableOffset() — setFocus() → selectAll() → setText(), with typeText() fallback
waitForPartitionTableOffset() — polls until the UI shows the expected value
waitForOperationsInProgressToFinishSync() after save — ensures sdkconfig is written before rebuild/reopen
assertEquals with actual vs expected — clearer CI failure output

Fixes # https://github.com/espressif/idf-eclipse-plugin/actions/runs/27190770202/job/80270182500?pr=1476

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored SDK Configuration partition table validation tests with new reusable helper methods for improved maintainability.
  * Enhanced test procedures with better wait and assertion mechanisms for offset field verification and configuration persistence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->