### PR TITLE
IEP-1786 Make update site self-contained with includeAllDependencies

### DIFF
--- a/releng/com.espressif.idf.update/category.xml
+++ b/releng/com.espressif.idf.update/category.xml
@@ -6,97 +6,17 @@
    <feature id="com.cthing.cmakeed.feature">
       <category name="com.espressif.idf"/>
    </feature>
-   <feature id="org.eclipse.nebula.widgets.xviewer.feature">
-      <category name="com.espressif.idf"/>
+   
+   <feature id="org.eclipse.rcp">
+      <category name="com.espressif.idf.platform"/>
    </feature>
-   <feature id="org.eclipse.embedcdt">
-      <category name="com.espressif.idf"/>
+   <feature id="org.eclipse.platform">
+      <category name="com.espressif.idf.platform"/>
    </feature>
-   <feature id="org.eclipse.embedcdt.debug.gdbjtag">
-      <category name="com.espressif.idf"/>
+   <feature id="org.eclipse.equinox.p2.user.ui">
+      <category name="com.espressif.idf.platform"/>
    </feature>
-   <feature id="org.eclipse.cdt.lsp.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.epp.mpc">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.tm4e.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.swtchart.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.tm4e.language_pack.feature">
-      <category name="com.espressif.idf"/>
-   </feature>
-   <feature id="org.eclipse.terminal.feature">
-      <category name="com.espressif.idf.dependencies"/>
-   </feature>
-   <feature id="org.eclipse.launchbar">
-      <category name="com.espressif.idf.dependencies"/>
-   </feature>
-   <bundle id="org.eclipse.embedcdt.templates.core">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.embedcdt.packs.core">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4e">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.jcodings">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.joni">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.yaml.snakeyaml">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.gson">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.guava">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="com.google.guava.failureaccess">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4j">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4j.jsonrpc">
-      <category name="com.espressif.idf"/>
-   </bundle>
-   <bundle id="org.apache.httpcomponents.httpclient">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.freemarker.freemarker">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.snakeyaml.engine">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.i18n">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.css">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.constants">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.apache.batik.util">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <bundle id="org.commonmark">
-      <category name="com.espressif.idf.dependencies"/>
-   </bundle>
-   <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin">
-      <description>
-         ESP-IDF Eclipse Plugin for developing ESP32 based IoT applications
-      </description>
-   </category-def>
-   <category-def name="com.espressif.idf.dependencies" label="ESP-IDF Eclipse Plugin - Dependencies"/>
+
+   <category-def name="com.espressif.idf" label="ESP-IDF Eclipse Plugin"/>
+   <category-def name="com.espressif.idf.platform" label="Eclipse Platform Core Updates"/>
 </site>

--- a/releng/com.espressif.idf.update/pom.xml
+++ b/releng/com.espressif.idf.update/pom.xml
@@ -2,6 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
 	<artifactId>com.espressif.idf.update</artifactId>
 	<version>${espressif-ide-release-version}-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
@@ -11,4 +12,17 @@
 		<artifactId>com.espressif.idf.releng</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<includeAllDependencies>true</includeAllDependencies>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
## Description

After deleting the p2 folder and retesting the lightweight online update site, I noticed an issue when updating from older versions that I haven't been able to resolve yet. However, we still need a reliable and robust update site that is easy to maintain and can handle updates from older IDE versions. Therefore, I decided to move the offline update site approach from this PR: https://github.com/espressif/idf-eclipse-plugin/pull/1474 into this one.

Fixes # ([IEP-1786](https://jira.espressif.com:8443/browse/IEP-1786))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

- Update 4.x Espressif-IDE/ plugin with this update site
- Update 3.x Espressif-IDE/plugin with this update site

Note: Use the update option

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Update site

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build configuration to include core platform components and dependencies.
  * Reorganized category definitions to streamline plugin distribution and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->