### PR TITLE
IEP-1787 Mixed / and \ cause incorrect OPENOCD path

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -346,14 +346,10 @@ public class IDFUtil
 	public static String getOpenOCDLocation()
 	{
 		String openOCDScriptPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.OPENOCD_SCRIPTS);
-		if (!StringUtil.isEmpty(openOCDScriptPath))
-		{
-			return openOCDScriptPath
-					.replace(File.separator + "share" + File.separator + "openocd" + File.separator + "scripts", "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-					+ File.separator + "bin"; //$NON-NLS-1$
-		}
-
-		return StringUtil.EMPTY;
+		if (StringUtil.isEmpty(openOCDScriptPath))
+			return StringUtil.EMPTY;
+		// .../openocd-esp32/share/openocd/scripts -> up 3 -> .../openocd-esp32, then /bin
+		return Paths.get(openOCDScriptPath).resolve("../../../bin").normalize().toString(); //$NON-NLS-1$
 	}
 
 	/**

--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/util/IDFUtil.java
@@ -347,9 +347,19 @@ public class IDFUtil
 	{
 		String openOCDScriptPath = new IDFEnvironmentVariables().getEnvValue(IDFEnvironmentVariables.OPENOCD_SCRIPTS);
 		if (StringUtil.isEmpty(openOCDScriptPath))
+		{
 			return StringUtil.EMPTY;
-		// .../openocd-esp32/share/openocd/scripts -> up 3 -> .../openocd-esp32, then /bin
-		return Paths.get(openOCDScriptPath).resolve("../../../bin").normalize().toString(); //$NON-NLS-1$
+		}
+		try
+		{
+			// .../openocd-esp32/share/openocd/scripts -> up 3 -> .../openocd-esp32, then /bin
+			return Paths.get(openOCDScriptPath).resolve("../../../bin").normalize().toString(); //$NON-NLS-1$
+		}
+		catch (InvalidPathException e)
+		{
+			Logger.log(e);
+			return StringUtil.EMPTY;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

Changed approach to getting bin path from the openocd_scripts variable 

Fixes # ([IEP-1787](https://jira.espressif.com:8443/browse/IEP-1787))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved OpenOCD script location handling to prevent incorrect path resolution when script paths are empty or invalid.
  * Ensures the OpenOCD binary directory is derived more reliably from the configured script location.

* **Refactor**
  * Updated the internal logic for determining the OpenOCD location to be more robust and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->