### PR TITLE
IEP-1792: Align execution environments to java 21

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This document provides AI coding agents with the rules and context needed to wor
   mvn clean verify -Djarsigner.skip=true
   ```
 
-- **Prerequisites:** Java 17+, Maven 3.9+.
+- **Prerequisites:** Java 21+, Maven 3.9+.
 - **Layout:** Plugin source under `bundles/`, tests under `tests/`, release engineering under `releng/`, user documentation under `docs/`.
 
 ### Repository structure
@@ -80,7 +80,7 @@ ALWAYS read these files first to understand the bundle's structure and dependenc
 ### Adding a new plugin (bundle)
 
 1. Create the plugin project under `bundles/` following existing naming (`com.espressif.idf.<name>`).
-2. Configure `META-INF/MANIFEST.MF` — set `Bundle-SymbolicName` (with `singleton:=true` if it has `plugin.xml` extensions), `Bundle-RequiredExecutionEnvironment: JavaSE-17`, and declare dependencies via `Require-Bundle` or `Import-Package`.
+2. Configure `META-INF/MANIFEST.MF` — set `Bundle-SymbolicName` (with `singleton:=true` if it has `plugin.xml` extensions), `Bundle-RequiredExecutionEnvironment: JavaSE-21`, and declare dependencies via `Require-Bundle` or `Import-Package`.
 3. Configure `build.properties` — include `META-INF/`, `.`, `plugin.xml`, and any resource folders in `bin.includes`.
 4. Add the module to [bundles/pom.xml](bundles/pom.xml).
 5. Add the plugin to [features/com.espressif.idf.feature/feature.xml](features/com.espressif.idf.feature/feature.xml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 * Click on `Set as Active Target Platform` and wait for a couple of mins to download and configure your environment with the idf required plugins
   
 ## Setting up an Eclipse Development Manually
-* Install `Java SE`(Java 17 and above) from https://www.oracle.com/technetwork/java/javase/downloads/index.html
+* Install `Java SE`(Java 21 and above) from https://www.oracle.com/technetwork/java/javase/downloads/index.html
 * Install `Eclipse for RCP and RAP Developers` package (Eclipse 2023-03 and above) from https://www.eclipse.org/downloads/packages/
 * Install `Eclipse CDT` plugins in the eclipse https://download.eclipse.org/tools/cdt/releases/latest/ (Choose compatible CDT version based on the Eclipse Release)
 * Install `Eclipse C/C++ OpenOCD Debugging` package from https://download.eclipse.org/embed-cdt/updates/v6/

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Full walkthrough in the [official documentation](https://docs.espressif.com/proj
 
 ## Building from Source
 
-**Prerequisites:** Java 17+ and Maven 3.9+
+**Prerequisites:** Java 21+ and Maven 3.9+
 
 ```bash
 git clone https://github.com/espressif/idf-eclipse-plugin.git

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@ ESP-IDF Eclipse 插件支持 `macOS`、`Windows` 和 `Linux` 操作系统。
 
 IDF Eclipse 插件的运行环境要求如下。
 
-* **Java 17 及以上**：点击<a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">这里</a>下载并安装 Java SE.。
+* **Java 21 及以上**：点击<a href= "https://www.oracle.com/technetwork/java/javase/downloads/index.html">这里</a>下载并安装 Java SE.。
 * **Python 3.6 及以上**：点击<a href="https://www.python.org/downloads/">这里</a>下载并安装 Python。
 * **Eclipse IDE C/C++ 开发工具 2023-03**：点击<a href= "https://www.eclipse.org/downloads/packages/release/2023-03/r/eclipse-ide-cc-developers">这里</a>下载并安装 Eclipse CDT 安装包。
 * **Git**：点击<a href ="https://git-scm.com/downloads">这里</a>获得最新 Git。

--- a/bundles/com.espressif.idf.branding/Espressif-IDE.launch
+++ b/bundles/com.espressif.idf.branding/Espressif-IDE.launch
@@ -39,7 +39,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=11 -Dosgi.instance.area.default=@user.home/eclipse-workspace -XX:+UseG1GC -XX:+UseStringDeduplication --add-modules=ALL-SYSTEM -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM -Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=21 -Dosgi.instance.area.default=@user.home/eclipse-workspace -XX:+UseG1GC -XX:+UseStringDeduplication --add-modules=ALL-SYSTEM -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Dosgi.requiredJavaVersion=21 -Dosgi.dataAreaRequiresExplicitInit=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM -Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="com.espressif.idf.branding.idf"/>
     <setAttribute key="selected_features">

--- a/bundles/com.espressif.idf.branding/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.branding/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: com.espressif.idf.branding;singleton:=true
 Bundle-Version: 4.4.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.core/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.lsp4e;bundle-version="0.18.18",
  org.eclipse.lsp4j;bundle-version="0.24.0",
  com.sun.jna
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.core
 Bundle-ActivationPolicy: lazy
 Export-Package: com.espressif.idf.core,

--- a/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.debug.gdbjtag.openocd/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.eclipse.cdt.core;bundle-version="6.2.0",
  org.eclipse.embedcdt.debug.gdbjtag.core,
  org.eclipse.embedcdt.ui,
  org.eclipse.ui.console
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %bundle.vendor
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/bundles/com.espressif.idf.help/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.help/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.1.qualifier
 Bundle-Activator: com.espressif.idf.help.HelpActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.help
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.espressif.idf.launch.serial.core;singleton:=true
 Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.launchbar.core;bundle-version="2.2.0",
  org.eclipse.cdt.core;bundle-version="6.4.0",

--- a/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.launch.serial.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.espressif.idf.launch.serial.ui;singleton:=true
 Bundle-Version: 1.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.ui;bundle-version="3.109.0",
  org.eclipse.debug.ui;bundle-version="3.12.50",

--- a/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.lsp/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.cdt.lsp,
  com.espressif.idf.core,
  org.eclipse.cdt.core
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.lsp
 Bundle-ActivationPolicy: lazy
 Bundle-Name: ESP-IDF LSP Plugin

--- a/bundles/com.espressif.idf.sdk.config.core/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.sdk.config.core/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  com.espressif.idf.core,
  org.eclipse.ui.console
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.sdk.config.core
 Bundle-ActivationPolicy: lazy
 Export-Package: com.espressif.idf.sdk.config.core,

--- a/bundles/com.espressif.idf.sdk.config.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.sdk.config.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.editors,
  com.espressif.idf.sdk.config.core,
  org.eclipse.ui.console
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.sdkconfig.ui
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.expressions

--- a/bundles/com.espressif.idf.serial.monitor/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.serial.monitor/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.console;bundle-version="3.9.0",
  org.eclipse.embedcdt.ui,
  org.eclipse.embedcdt.debug.gdbjtag.core
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.serial.monitor
 Bundle-ActivationPolicy: lazy
 Export-Package: com.espressif.idf.serial.monitor,

--- a/bundles/com.espressif.idf.swt.custom/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.swt.custom/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.1.qualifier
 Export-Package: com.espressif.idf.swt.custom
 Bundle-Activator: com.espressif.idf.swt.custom.Activator
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.swt.custom
 Import-Package: org.osgi.framework;version="1.3.0"
 Require-Bundle: org.eclipse.core.variables,

--- a/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.terminal.connector.serial/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.terminal.view.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.terminal.control;bundle-version="[1.0.0,2.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: com.espressif.idf.terminal.connector.serial.activator;x-internal:=true,

--- a/bundles/com.espressif.idf.terminal.connector/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.terminal.connector/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.cdt.core;resolution:=optional,
  org.eclipse.terminal.connector.process;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.terminal.control;bundle-version="[1.0.0,2.0.0)",
  com.google.gson
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: com.espressif.idf.terminal.connector.activator;x-internal:=true,

--- a/bundles/com.espressif.idf.wokwi/META-INF/MANIFEST.MF
+++ b/bundles/com.espressif.idf.wokwi/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.cdt.ui,
  org.eclipse.debug.ui,
  com.espressif.idf.ui
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.espressif.idf.wokwi
 Bundle-ActivationPolicy: lazy

--- a/common/com.espressif.idf.nl.translator/.classpath
+++ b/common/com.espressif.idf.nl.translator/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/common/com.espressif.idf.nl.translator/META-INF/MANIFEST.MF
+++ b/common/com.espressif.idf.nl.translator/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: com.espressif.idf.util;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: ESPRESSIF
 Automatic-Module-Name: com.espressif.idf.util.nls
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: com.espressif.idf.core;bundle-version="1.0.1"

--- a/internal/com.espressif.idf.uploads/.classpath
+++ b/internal/com.espressif.idf.uploads/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/releng/com.espressif.idf.product/META-INF/MANIFEST.MF
+++ b/releng/com.espressif.idf.product/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Espressif-IDE
 Bundle-SymbolicName: com.espressif.idf.product
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/releng/com.espressif.idf.product/idf.product
+++ b/releng/com.espressif.idf.product/idf.product
@@ -44,7 +44,7 @@
    <vm>
       <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</linux>
       <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</macos>
-      <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</solaris>
+      <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</solaris>
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21</windows>
    </vm>
 

--- a/releng/com.espressif.idf.target/.classpath
+++ b/releng/com.espressif.idf.target/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>


### PR DESCRIPTION
## Description

align execution environments to java 21

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, build, and contribution docs to require Java 21+.
  * Refreshed Chinese documentation to match the newer Java requirement.

* **Chores**
  * Raised the minimum Java runtime across project configuration and bundle manifests to Java 21.
  * Updated Eclipse launch and classpath settings to use Java 21 for development and packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->