### PR TITLE
feat: adding a link to open ESP-IDF manager in err msg

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/ToolsMissingWizardPage.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/ToolsMissingWizardPage.java
@@ -4,16 +4,21 @@
  *******************************************************************************/
 package com.espressif.idf.ui.wizard;
 
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+
+import com.espressif.idf.core.logging.Logger;
+import com.espressif.idf.ui.tools.ManageEspIdfVersionsHandler;
 
 public class ToolsMissingWizardPage extends WizardPage
 {
-
 
 	protected ToolsMissingWizardPage(String errorMsg)
 	{
@@ -28,15 +33,35 @@ public class ToolsMissingWizardPage extends WizardPage
 		Composite container = new Composite(parent, SWT.NONE);
 		container.setLayout(new GridLayout(1, false));
 
-
-		Label label = new Label(container, SWT.WRAP);
-		label.setText(Messages.ToolsMissingWizardPage_MainText);
+		Link link = new Link(container, SWT.WRAP);
+		link.setText(Messages.ToolsMissingWizardPage_MainText);
+		link.addSelectionListener(new SelectionAdapter()
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e)
+			{
+				openEspIdfManagerAndCloseWizard();
+			}
+		});
 
 		GridData gd = new GridData(SWT.FILL, SWT.CENTER, true, false);
-		label.setLayoutData(gd);
+		link.setLayoutData(gd);
 
 		setControl(container);
 
 		setPageComplete(false);
+	}
+
+	private void openEspIdfManagerAndCloseWizard()
+	{
+		try
+		{
+			new ManageEspIdfVersionsHandler().execute(null);
+		}
+		catch (ExecutionException ex)
+		{
+			Logger.log(ex);
+		}
+		getShell().close();
 	}
 }

--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/messages.properties
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/wizard/messages.properties
@@ -28,6 +28,6 @@ NewComponentWizardPage_CantCreateCompErr=Can not create a component without a pr
 NewComponentWizardPage_ProjectDoesntExistErr=Project doesn't exist
 NewComponentWizardPage_ProjectNameLbl=Project name:
 IdfReconfigureJobName=Running idf.py reconfigure command...
-ToolsMissingWizardPage_MainText=Install or configure the ESP-IDF tools before continuing. Open the ESP-IDF Manager to resolve the issue, then restart this wizard.
+ToolsMissingWizardPage_MainText=Install or configure the ESP-IDF tools before continuing. Open the <a>ESP-IDF Manager</a> to resolve the issue, then restart this wizard.
 ToolsMissingWizardPage_PagaName=ToolsMissingPage
 ToolsMissingWizardPage_Title=ESP-IDF Tools Required


### PR DESCRIPTION
## Description

Added a link to the error message when ESP-IDF is not configured. The link opens the ESP-IDF Manager.
<img width="1402" height="272" alt="image" src="https://github.com/user-attachments/assets/fe9917cf-b5af-4448-ae30-f13c47cee227" />


Fixes # ([IEP-1797](https://jira.espressif.com:8443/browse/IEP-1797))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)


## How has this been tested?

Install Espressif-IDE -> open it and create a new project without configuring esp-idf in the IDE -> see an error -> click on link -> ESP-IDF manager should be opened 

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clickable “ESP-IDF Manager” link to the missing-tools wizard.
  * Selecting the link opens the ESP-IDF Manager flow and closes the wizard afterward.

* **Bug Fixes**
  * Improved handling of failures when launching the ESP-IDF Manager flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->