### PR TITLE
fix: make IDE error log visible in generated bug report

### DIFF
--- a/bundles/com.espressif.idf.core/src/com/espressif/idf/core/bug/BugReportGenerator.java
+++ b/bundles/com.espressif.idf.core/src/com/espressif/idf/core/bug/BugReportGenerator.java
@@ -61,6 +61,7 @@ public class BugReportGenerator
 
 	private static final String ECLIPSE_LOG_FILE_NAME = ".log"; //$NON-NLS-1$
 	private static final String ECLIPSE_METADATA_DIRECTORY = ".metadata"; //$NON-NLS-1$
+	private static final String IDE_LOG_REPORT_NAME_PREFIX = "ide_error_log"; //$NON-NLS-1$
 	private static final String UNKNOWN = "Unknown"; //$NON-NLS-1$
 	private static final String BUG_REPORT_DIRECTORY_PREFIX = "bug_report_"; //$NON-NLS-1$
 	private File bugReportDirectory;
@@ -189,6 +190,16 @@ public class BugReportGenerator
 		return logFiles;
 	}
 
+	// Eclipse stores the IDE error log as ".log" (hidden on macOS/Linux); rename so it stays visible in the report.
+	public static String getReportLogFileName(String metadataFileName)
+	{
+		if (metadataFileName.startsWith(".")) //$NON-NLS-1$
+		{
+			return IDE_LOG_REPORT_NAME_PREFIX + metadataFileName;
+		}
+		return metadataFileName;
+	}
+
 	private File createBasicSystemInfoFile() throws IOException
 	{
 		String osName = System.getProperty("os.name", UNKNOWN); //$NON-NLS-1$
@@ -282,7 +293,8 @@ public class BugReportGenerator
 
 			for (File logFile : metadataLogsFile)
 			{
-				FileUtil.copyFile(logFile, new File(ideLogDir.getAbsolutePath() + File.separator + logFile.getName()));
+				FileUtil.copyFile(logFile, new File(
+						ideLogDir.getAbsolutePath() + File.separator + getReportLogFileName(logFile.getName())));
 			}
 			File eimLogPath = getEimLogPath();
 			Logger.log("EIM log path: " + eimLogPath.getAbsolutePath()); //$NON-NLS-1$

--- a/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/bug/test/BugReportGeneratorTest.java
+++ b/tests/com.espressif.idf.core.test/src/com/espressif/idf/core/bug/test/BugReportGeneratorTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD.
+ * All rights reserved. Use is subject to license terms.
+ *******************************************************************************/
+package com.espressif.idf.core.bug.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.espressif.idf.core.bug.BugReportGenerator;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BugReportGeneratorTest
+{
+
+	@ParameterizedTest(name = "''{0}'' is collected as ''{1}''")
+	@CsvSource({ ".log, ide_error_log.log", ".bak_0.log, ide_error_log.bak_0.log",
+			".bak_1.log, ide_error_log.bak_1.log" })
+	void test_hidden_ide_log_gets_a_visible_name(String metadataFileName, String expectedReportFileName)
+	{
+		String reportFileName = BugReportGenerator.getReportLogFileName(metadataFileName);
+
+		Assertions.assertEquals(expectedReportFileName, reportFileName);
+	}
+
+	@ParameterizedTest(name = "''{0}'' is collected unchanged")
+	@CsvSource({ "version.ini", "workspace.log" })
+	void test_already_visible_file_name_is_kept(String metadataFileName)
+	{
+		String reportFileName = BugReportGenerator.getReportLogFileName(metadataFileName);
+
+		Assertions.assertEquals(metadataFileName, reportFileName);
+	}
+
+	@Test
+	void test_no_collected_file_stays_hidden()
+	{
+		Assertions.assertFalse(BugReportGenerator.getReportLogFileName(".log").startsWith("."));
+	}
+}


### PR DESCRIPTION
Rename Eclipse's hidden .log to ide_error_log.log when packaging so Finder and other file managers show it in the report.

## Description

Please include a summary of the change and which issue is fixed.

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IDE log files included in bug reports now retain a visible `.log` filename, making them easier to identify and open.
  * Existing visible filenames remain unchanged.

* **Tests**
  * Added coverage for hidden log-file renaming and filename preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->