### PR TITLE
fix: update the url for component manager

### DIFF
--- a/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/installcomponents/handler/InstallIDFComponentsHandler.java
+++ b/bundles/com.espressif.idf.ui/src/com/espressif/idf/ui/installcomponents/handler/InstallIDFComponentsHandler.java
@@ -39,7 +39,7 @@ import com.google.gson.stream.JsonReader;
  */
 public class InstallIDFComponentsHandler extends AbstractHandler
 {
-	private static final String API_URL = "https://api.components.espressif.com/components"; //$NON-NLS-1$
+	private static final String API_URL = "https://components.espressif.com/api/components"; //$NON-NLS-1$
 	private static int TOTAL_RECORDS_TO_FETCH = 100;
 
 	@Override


### PR DESCRIPTION
## Description

Updated the URL for the component manager because the old one is no longer valid

Fixes # ([IEP-XXX](https://jira.espressif.com:8443/browse/IEP-XXX))

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ESP-IDF component service endpoint to ensure component installation requests use the current service path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->