### PR TITLE
feat: update lsp4e dependency

### DIFF
--- a/releng/com.espressif.idf.target/com.espressif.idf.target.target
+++ b/releng/com.espressif.idf.target/com.espressif.idf.target.target
@@ -86,7 +86,7 @@
 			<unit id="org.eclipse.swtchart.feature.feature.group" version="1.0.0.202412021530"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.30.5/"/>
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.30.8/"/>
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4j" version="0.0.0"/>


### PR DESCRIPTION
## Description

Bump the target-platform LSP4E p2 repo from 0.30.5 to 0.30.8.



## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Reloaded target platform; Tycho resolves `org.eclipse.lsp4e` / `lsp4j` from 0.30.8
- SWTBot: `IDFProjectLspCdtFunctionalityTest`, `NewEspressifIDFProjectClangFilesTest`
- Manual: new IDF project → build → open `main.c` — clangd start, content assist, hover, diagnostics, format, inlay hints, outline, signature help
- After build / switching build dir, reopen a `.c` file: `--compile-commands-dir=` still applied and clangd restarts

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- `org.eclipse.lsp4e` / `org.eclipse.lsp4e.debug` / `org.eclipse.lsp4j*`
- CDT-LSP / clangd C/C++ editor (`com.espressif.idf.lsp`, `LspService`)

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LSP4E repository source to release 0.30.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->